### PR TITLE
Rewrote ore generation

### DIFF
--- a/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
+++ b/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
@@ -5,6 +5,8 @@
 
 package net.dries007.tfc;
 
+import net.dries007.tfc.objects.Ore;
+import net.dries007.tfc.util.OreSpawnData;
 import org.apache.logging.log4j.Logger;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -98,6 +100,9 @@ public class TerraFirmaCraft
         EntitiesTFC.preInit();
         FluidsTFC.preInit();
 
+        OreSpawnData.configDir = event.getModConfigurationDirectory();
+        OreSpawnData.preInit();
+
         if (event.getSide().isClient()) ClientEvents.preInit();
     }
 
@@ -130,6 +135,8 @@ public class TerraFirmaCraft
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event)
     {
+        OreSpawnData.reloadOreGen();
+
         if (!isSignedBuild)
             log.warn("You are not running an official build. Please do not use this and then report bugs or issues.");
     }

--- a/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
+++ b/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
@@ -5,8 +5,6 @@
 
 package net.dries007.tfc;
 
-import net.dries007.tfc.objects.Ore;
-import net.dries007.tfc.util.OreSpawnData;
 import org.apache.logging.log4j.Logger;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -26,6 +24,7 @@ import net.dries007.tfc.objects.entity.EntitiesTFC;
 import net.dries007.tfc.objects.fluids.FluidsTFC;
 import net.dries007.tfc.objects.items.ItemsTFC;
 import net.dries007.tfc.util.OreDictionaryHelper;
+import net.dries007.tfc.util.OreSpawnData;
 import net.dries007.tfc.world.classic.CalenderTFC;
 import net.dries007.tfc.world.classic.WorldTypeTFC;
 import net.dries007.tfc.world.classic.chunkdata.ChunkCapabilityHandler;

--- a/src/main/java/net/dries007/tfc/objects/Ore.java
+++ b/src/main/java/net/dries007/tfc/objects/Ore.java
@@ -43,7 +43,8 @@ public enum Ore
     SYLVITE,
     BORAX,
     OLIVINE,
-    LAPIS_LAZULI;
+    LAPIS_LAZULI,
+    UNKNOWN_ORE;
 
     public final boolean graded;
     public final Metal metal;

--- a/src/main/java/net/dries007/tfc/util/FileUtils.java
+++ b/src/main/java/net/dries007/tfc/util/FileUtils.java
@@ -1,0 +1,26 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
+package net.dries007.tfc.util;
+
+import org.apache.logging.log4j.core.util.Loader;
+
+import java.io.*;
+
+public class FileUtils {
+
+    public static void copyFile(String source, File dest) throws IOException
+    {
+
+        InputStream is = Loader.getResource(source, null).openStream();
+        OutputStream os = new FileOutputStream(dest);
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = is.read(buffer)) > 0)
+        {
+            os.write(buffer, 0, length);
+        }
+    }
+}

--- a/src/main/java/net/dries007/tfc/util/OreSpawnData.java
+++ b/src/main/java/net/dries007/tfc/util/OreSpawnData.java
@@ -5,7 +5,15 @@
 
 package net.dries007.tfc.util;
 
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableList;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -13,15 +21,7 @@ import com.typesafe.config.ConfigValue;
 import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.objects.Ore;
 import net.dries007.tfc.objects.Rock;
-import net.dries007.tfc.objects.Rock.*;
-import net.minecraft.block.Block;
-import net.minecraft.block.state.IBlockState;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.io.File;
-import java.util.List;
-import java.util.Map;
+import net.dries007.tfc.objects.Rock.Category;
 
 // todo: someone look through assets/tfc/config/tfc_ore_spawn_data.json and verify that everything looks good  -Alex (alcatrazEscapee)
 public class OreSpawnData
@@ -66,14 +66,17 @@ public class OreSpawnData
             {
                 throw new Error("Problem creating TFC world gen json: (unspecified error).");
             }
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             TerraFirmaCraft.getLog().fatal("Problem creating TFC world gen json: ", e);
         }
         TerraFirmaCraft.getLog().info("Complete.");
     }
 
     // todo: test that all the exceptions and try statements catch problems with json
-    public static void reloadOreGen(){
+    public static void reloadOreGen()
+    {
         Config genData = ConfigFactory.parseFile(genFile);
         ImmutableList.Builder<OreEntry> builder = new ImmutableList.Builder<>();
 
@@ -89,7 +92,8 @@ public class OreSpawnData
             final int maxY;
             final int density;
             List<String> baseStrings;
-            try {
+            try
+            {
                 entryData = genData.getConfig(genEntry.getKey());
 
                 //ore = Ore.valueOf(entryData.getString("ore").toUpperCase());
@@ -97,46 +101,62 @@ public class OreSpawnData
                 shape = SpawnType.valueOf(entryData.getString("shape").toUpperCase());
 
                 rarity = entryData.getInt("rarity");
-                minY = entryData.getInt("minimum-height");
-                maxY = entryData.getInt("maximum-height");
+                minY = entryData.getInt("minimum_height");
+                maxY = entryData.getInt("maximum_height");
                 density = entryData.getInt("density");
 
-                baseStrings = entryData.getStringList("base-rocks");
+                baseStrings = entryData.getStringList("base_rocks");
 
-            } catch (Exception e) {
-                TerraFirmaCraft.getLog().warn("Problem parsing data for ore generation entry with key: \""+genEntry.getKey()+"\" Skipping.");
+            }
+            catch (Exception e)
+            {
+                TerraFirmaCraft.getLog().warn("Problem parsing data for ore generation entry with key: \"" + genEntry.getKey() + "\" Skipping.");
                 continue;
             }
 
-            try{
+            try
+            {
                 ore = Ore.valueOf(entryData.getString("ore").toUpperCase());
+                if (ore == Ore.UNKNOWN_ORE)
+                    throw new Exception("Can't assign to unknown ore");
                 state = null;
-            } catch (Exception e1) {
-                try {
+            }
+            catch (Exception e1)
+            {
+                try
+                {
                     String blockName = entryData.getString("ore");
                     Block block = Block.getBlockFromName(blockName);
-                    if(block != null)
+                    if (block != null)
                     {
                         state = block.getDefaultState();
                         ore = Ore.UNKNOWN_ORE;
-                    }else{
+                    }
+                    else
+                    {
                         TerraFirmaCraft.getLog().warn("Problem parsing IBlockState: block doesn't exist for ore generation entry with key: \\\"\"+genEntry.getKey()+\"\\\" Skipping.\"");
                         continue;
                     }
-                } catch (Exception e2){
+                }
+                catch (Exception e2)
+                {
                     TerraFirmaCraft.getLog().warn("Problem parsing Ore / IBlockState for ore generation entry with key: \\\"\"+genEntry.getKey()+\"\\\" Skipping.\"");
                     continue;
                 }
             }
 
             ImmutableList.Builder<Rock> b = new ImmutableList.Builder<>();
-            for(String s : baseStrings)
+            for (String s : baseStrings)
             {
-                try {
+                try
+                {
                     Rock rock = Rock.valueOf(s.toUpperCase());
                     b.add(rock);
-                } catch(IllegalArgumentException e1){
-                    try{
+                }
+                catch (IllegalArgumentException e1)
+                {
+                    try
+                    {
                         Category category = Category.valueOf(s.toUpperCase());
                         for (Rock rock : Rock.values())
                         {
@@ -145,63 +165,20 @@ public class OreSpawnData
                                 b.add(rock);
                             }
                         }
-                    } catch(IllegalArgumentException e2){
-                        TerraFirmaCraft.getLog().warn("Problem parsing base rock \""+s+"\" for ore generation entry with key+\""+genEntry.getKey()+"\" Skipping");
+                    }
+                    catch (IllegalArgumentException e2)
+                    {
+                        TerraFirmaCraft.getLog().warn("Problem parsing base rock \"" + s + "\" for ore generation entry with key+\"" + genEntry.getKey() + "\" Skipping");
                     }
                 }
             }
 
             builder.add(new OreEntry(ore, state, size, shape, b.build(), rarity, minY, maxY, density));
             TOTAL_WEIGHT += 1.0D / (double) rarity;
-            TerraFirmaCraft.getLog().debug("Added ore generation entry for "+genEntry.getKey());
+            TerraFirmaCraft.getLog().debug("Added ore generation entry for " + genEntry.getKey());
         }
 
         ORE_SPAWN_DATA = builder.build();
-    }
-
-    public static final class OreEntry
-    {
-        public final Ore ore;
-        public final IBlockState state;
-        public final SpawnType type;
-        public final SpawnSize size;
-        public final int rarity;
-        public final ImmutableList<Rock> baseRocks;
-        public final int minY;
-        public final int maxY;
-        public final double weight;
-        public final double density;
-
-        private OreEntry(@Nonnull Ore ore, @Nullable IBlockState state, SpawnSize size, SpawnType type, ImmutableList<Rock> baseRocks, int rarity, int minY, int maxY, int density)
-        {
-            this.ore = ore;
-            this.state = state;
-            this.size = size;
-            this.type = type;
-            this.baseRocks = baseRocks;
-
-            this.rarity = rarity;
-            this.weight = 1.0D / (double) rarity;
-            this.minY = minY;
-            this.maxY = maxY;
-            this.density= 0.01D * (double)density; // For debug purposes, removing the 0.01D will lead to ore veins being full size, easy to see shapes
-
-            if(ore == Ore.UNKNOWN_ORE && state == null) throw new IllegalStateException("Ore Entry has neither a IBlockState or a Ore type");
-        }
-
-        @Override
-        public String toString() {
-            return "OreSpawnData{" +
-                "ore=" + ore +
-                ", type=" + type +
-                ", size=" + size +
-                ", rarity=" + rarity +
-                ", baseRocks=" + baseRocks +
-                ", minY=" + minY +
-                ", maxY=" + maxY +
-                ", density=" + density +
-                '}';
-        }
     }
 
     public enum SpawnType
@@ -232,6 +209,53 @@ public class OreSpawnData
         {
             this.radius = radius;
             this.densityModifier = densityModifier;
+        }
+    }
+
+    public static final class OreEntry
+    {
+        public final Ore ore;
+        public final IBlockState state;
+        public final SpawnType type;
+        public final SpawnSize size;
+        public final int rarity;
+        public final ImmutableList<Rock> baseRocks;
+        public final int minY;
+        public final int maxY;
+        public final double weight;
+        public final double density;
+
+        private OreEntry(@Nonnull Ore ore, @Nullable IBlockState state, SpawnSize size, SpawnType type, ImmutableList<Rock> baseRocks, int rarity, int minY, int maxY, int density)
+        {
+            this.ore = ore;
+            this.state = state;
+            this.size = size;
+            this.type = type;
+            this.baseRocks = baseRocks;
+
+            this.rarity = rarity;
+            this.weight = 1.0D / (double) rarity;
+            this.minY = minY;
+            this.maxY = maxY;
+            this.density = 0.01D * (double) density; // For debug purposes, removing the 0.01D will lead to ore veins being full size, easy to see shapes
+
+            if (ore == Ore.UNKNOWN_ORE && state == null)
+                throw new IllegalStateException("Ore Entry has neither a IBlockState or a Ore type");
+        }
+
+        @Override
+        public String toString()
+        {
+            return "OreSpawnData{" +
+                "ore=" + ore +
+                ", type=" + type +
+                ", size=" + size +
+                ", rarity=" + rarity +
+                ", baseRocks=" + baseRocks +
+                ", minY=" + minY +
+                ", maxY=" + maxY +
+                ", density=" + density +
+                '}';
         }
     }
 }

--- a/src/main/java/net/dries007/tfc/util/OreSpawnData.java
+++ b/src/main/java/net/dries007/tfc/util/OreSpawnData.java
@@ -7,150 +7,191 @@ package net.dries007.tfc.util;
 
 import com.google.common.collect.ImmutableList;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValue;
+import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.objects.Ore;
 import net.dries007.tfc.objects.Rock;
 import net.dries007.tfc.objects.Rock.*;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 
-import static net.dries007.tfc.objects.Ore.*;
-import static net.dries007.tfc.objects.Rock.Category.*;
-import static net.dries007.tfc.objects.Rock.*;
-import static net.dries007.tfc.util.OreSpawnData.SpawnSize.*;
-import static net.dries007.tfc.util.OreSpawnData.SpawnType.DEFAULT;
-import static net.dries007.tfc.util.OreSpawnData.SpawnType.VEINS;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
 
-/**
- * todo: make this configurable
- * todo: have this checked by someone
- */
-public final class OreSpawnData
+// todo: someone look through assets/tfc/config/tfc_ore_spawn_data.json and verify that everything looks good  -Alex (alcatrazEscapee)
+public class OreSpawnData
 {
-    public static final ImmutableList<OreSpawnData> ORE_SPAWN_DATA;
-    public static final double TOTAL_WEIGHT;
+    public static ImmutableList<OreEntry> ORE_SPAWN_DATA;
+    public static double TOTAL_WEIGHT = 0.0;
 
-    static
+    public static File configDir;
+    private static File genFile;
+
+
+    public static void preInit()
     {
-        ImmutableList.Builder<OreSpawnData> b = new ImmutableList.Builder<>();
+        TerraFirmaCraft.getLog().info("Loading or creating ore generation config file");
 
-        // Metals
-        b.add(new OreSpawnData(NATIVE_COPPER, VEINS, LARGE, 120, IGNEOUS_EXTRUSIVE, 5, 128, 80, 60));
-        b.add(new OreSpawnData(NATIVE_GOLD, VEINS, LARGE, 120, new Category[] {IGNEOUS_EXTRUSIVE, IGNEOUS_INTRUSIVE}, 5, 128, 80, 60));
-        b.add(new OreSpawnData(NATIVE_PLATINUM, VEINS, SMALL, 150, SEDIMENTARY, 5, 128, 40, 80));
-        b.add(new OreSpawnData(HEMATITE, VEINS, MEDIUM, 125, IGNEOUS_EXTRUSIVE, 5, 128, 80, 60));
-        b.add(new OreSpawnData(NATIVE_SILVER, VEINS, MEDIUM, 100, new Rock[] {GRANITE, GNEISS}, 5, 128, 80, 60));
-        b.add(new OreSpawnData(CASSITERITE, VEINS, MEDIUM, 100, IGNEOUS_INTRUSIVE, 5, 128, 80, 60));
-        b.add(new OreSpawnData(GALENA, VEINS, MEDIUM, 100, new Rock[] {GRANITE, LIMESTONE}, new Category[] {IGNEOUS_EXTRUSIVE, METAMORPHIC}, 5, 128, 80, 60));
-        b.add(new OreSpawnData(BISMUTHINITE, VEINS, MEDIUM, 100, new Category[] {IGNEOUS_EXTRUSIVE, SEDIMENTARY}, 5, 128, 80, 60));
-        b.add(new OreSpawnData(GARNIERITE, VEINS, MEDIUM, 150, GABBRO, 5, 128, 80, 60));
-        b.add(new OreSpawnData(MALACHITE, VEINS, LARGE, 100, new Rock[] {LIMESTONE, MARBLE}, 5, 128, 80, 60));
-        b.add(new OreSpawnData(MAGNETITE, VEINS, MEDIUM, 150, SEDIMENTARY, 5, 128, 80, 60));
-        b.add(new OreSpawnData(LIMONITE, VEINS, MEDIUM, 150, SEDIMENTARY, 5, 128, 80, 60));
-        b.add(new OreSpawnData(SPHALERITE, VEINS, MEDIUM, 100, METAMORPHIC, 5, 128, 80, 60));
-        b.add(new OreSpawnData(TETRAHEDRITE, VEINS, MEDIUM, 120, METAMORPHIC, 5, 128, 80, 60));
-        b.add(new OreSpawnData(BITUMINOUS_COAL, DEFAULT, LARGE, 100, SEDIMENTARY, 5, 128, 90, 40));
-        b.add(new OreSpawnData(LIGNITE, DEFAULT, MEDIUM, 100, SEDIMENTARY, 5, 128, 90, 40));
+        File tfcDir = new File(configDir, "/tfc/");
 
-        // Minerals
-        b.add(new OreSpawnData(KAOLINITE, DEFAULT, MEDIUM, 90, SEDIMENTARY, 5, 128, 80, 60));
-        b.add(new OreSpawnData(GYPSUM, VEINS, LARGE, 120, SEDIMENTARY, 5, 128, 80, 60));
-        //b.add(new OreSpawnData(SATINSPAR, VEINS, SMALL, 150, SEDIMENTARY, 5, 128, 40, 60));
-        //b.add(new OreSpawnData(SELENITE, VEINS, MEDIUM, 125, IGNEOUS_EXTRUSIVE, 5, 128, 60, 60));
-        b.add(new OreSpawnData(GRAPHITE, VEINS, MEDIUM, 100, new Rock[] {MARBLE, GNEISS, QUARTZITE, SCHIST}, 5, 128, 80, 60));
-        b.add(new OreSpawnData(KIMBERLITE, VEINS, MEDIUM, 200, new Rock[] {GABBRO}, 5, 128, 30, 80));
-        //b.add(new OreSpawnData(PETRIFIED_WOOD, VEINS, MEDIUM, 100, new Rock[]{GRANITE, LIMESTONE}, new Category[]{IGNEOUS_EXTRUSIVE, METAMORPHIC}, 5, 128, 60, 80));
-        //b.add(new OreSpawnData(SULFUR, VEINS, MEDIUM, 100, new Category[]{IGNEOUS_EXTRUSIVE, SEDIMENTARY}, 5, 128, 60, 60));
-        b.add(new OreSpawnData(JET, VEINS, LARGE, 110, new Category[] {SEDIMENTARY}, 5, 128, 80, 60));
-        //b.add(new OreSpawnData(MICROCLINE, VEINS, LARGE, 100, new Rock[]{LIMESTONE, MARBLE}, 5, 128, 60, 60));
-        b.add(new OreSpawnData(PITCHBLENDE, VEINS, SMALL, 150, new Rock[] {GRANITE}, 5, 128, 80, 60));
-        b.add(new OreSpawnData(CINNABAR, VEINS, SMALL, 150, new Rock[] {SHALE, QUARTZITE}, new Category[] {IGNEOUS_EXTRUSIVE}, 5, 128, 30, 80));
-        b.add(new OreSpawnData(CRYOLITE, VEINS, SMALL, 100, GRANITE, 5, 128, 80, 60));
-        b.add(new OreSpawnData(SALTPETER, VEINS, MEDIUM, 120, SEDIMENTARY, 5, 128, 80, 60));
-        //b.add(new OreSpawnData(SERPENTINE, VEINS, LARGE, 100, SEDIMENTARY, 5, 128, 90, 40));
-        b.add(new OreSpawnData(SYLVITE, VEINS, MEDIUM, 100, ROCKSALT, 5, 128, 90, 40));
-        b.add(new OreSpawnData(BORAX, VEINS, LARGE, 120, ROCKSALT, 5, 128, 80, 60));
-        b.add(new OreSpawnData(LAPIS_LAZULI, VEINS, LARGE, 120, MARBLE, 5, 128, 80, 60));
-        //b.add(new OreSpawnData(OLIVINE, VEINS, SMALL, 150, MARBLE, 5, 128, 40, 80));
-
-        // Surface ores
-        b.add(new OreSpawnData(NATIVE_COPPER, VEINS, SMALL, 35, IGNEOUS_EXTRUSIVE, 128, 240, 40, 40));
-        b.add(new OreSpawnData(CASSITERITE, VEINS, SMALL, 35, GRANITE, 128, 240, 40, 40));
-        b.add(new OreSpawnData(BISMUTHINITE, VEINS, SMALL, 35, new Category[] {IGNEOUS_EXTRUSIVE, SEDIMENTARY}, 128, 240, 40, 40));
-        b.add(new OreSpawnData(SPHALERITE, VEINS, SMALL, 35, METAMORPHIC, 128, 240, 40, 40));
-        b.add(new OreSpawnData(TETRAHEDRITE, VEINS, SMALL, 35, METAMORPHIC, 128, 240, 40, 40));
-
-        ORE_SPAWN_DATA = b.build();
-
-        double totalWeight = 0;
-        for(OreSpawnData data : ORE_SPAWN_DATA){
-            totalWeight += data.weight;
+        if (!tfcDir.exists())
+        {
+            try
+            {
+                if (!tfcDir.mkdir())
+                {
+                    throw new Error("Problem creating TFC World gen directory: (unknown error)");
+                }
+            }
+            catch (Exception e)
+            {
+                TerraFirmaCraft.getLog().fatal("Problem creating TFC World gen directory:", e);
+                return;
+            }
         }
-        TOTAL_WEIGHT = totalWeight;
-        System.out.println("TOTAL WEIGHT: "+totalWeight);
+        genFile = new File(tfcDir, "tfc_ore_spawn_data.json");
+        try
+        {
+            if (genFile.createNewFile())
+            {
+                FileUtils.copyFile("assets/tfc/config/tfc_ore_spawn_data.json", genFile);
+                TerraFirmaCraft.getLog().info("Created standard generation json.");
+            }
+            else if (!genFile.exists())
+            {
+                throw new Error("Problem creating TFC world gen json: (unspecified error).");
+            }
+        } catch (Exception e) {
+            TerraFirmaCraft.getLog().fatal("Problem creating TFC world gen json: ", e);
+        }
+        TerraFirmaCraft.getLog().info("Complete.");
     }
 
-    public final Ore ore;
-    public final SpawnType type;
-    public final SpawnSize size;
-    public final int rarity;
-    public final ImmutableList<Rock> baseRocks;
-    public final int minY;
-    public final int maxY;
-    public final float densityVertical;
-    public final float densityHorizontal;
-    public final float densityModifier;
-    public final int maxClusters;
+    // todo: test that all the exceptions and try statements catch problems with json
+    public static void reloadOreGen(){
+        Config genData = ConfigFactory.parseFile(genFile);
+        ImmutableList.Builder<OreEntry> builder = new ImmutableList.Builder<>();
 
-    // NEW
-    public final double weight;
+        for (Map.Entry<String, ConfigValue> genEntry : genData.root().entrySet())
+        {
+            Config entryData;
+            Ore ore;
+            IBlockState state;
+            final SpawnSize size;
+            final SpawnType shape;
+            final int rarity;
+            final int minY;
+            final int maxY;
+            final int density;
+            List<String> baseStrings;
+            try {
+                entryData = genData.getConfig(genEntry.getKey());
 
-    private OreSpawnData(Ore ore, SpawnType type, SpawnSize size, int rarity, Category[] baseRocksCategories, int minY, int maxY, int densityVertical, int densityHorizontal)
-    {
-        this(ore, type, size, rarity, null, baseRocksCategories, minY, maxY, densityVertical, densityHorizontal);
+                //ore = Ore.valueOf(entryData.getString("ore").toUpperCase());
+                size = SpawnSize.valueOf(entryData.getString("size").toUpperCase());
+                shape = SpawnType.valueOf(entryData.getString("shape").toUpperCase());
+
+                rarity = entryData.getInt("rarity");
+                minY = entryData.getInt("minimum-height");
+                maxY = entryData.getInt("maximum-height");
+                density = entryData.getInt("density");
+
+                baseStrings = entryData.getStringList("base-rocks");
+
+            } catch (Exception e) {
+                TerraFirmaCraft.getLog().warn("Problem parsing data for ore generation entry with key: \""+genEntry.getKey()+"\" Skipping.");
+                continue;
+            }
+
+            try{
+                ore = Ore.valueOf(entryData.getString("ore").toUpperCase());
+                state = null;
+            } catch (Exception e1) {
+                try {
+                    String blockName = entryData.getString("ore");
+                    Block block = Block.getBlockFromName(blockName);
+                    if(block != null)
+                    {
+                        state = block.getDefaultState();
+                        ore = Ore.UNKNOWN_ORE;
+                    }else{
+                        TerraFirmaCraft.getLog().warn("Problem parsing IBlockState: block doesn't exist for ore generation entry with key: \\\"\"+genEntry.getKey()+\"\\\" Skipping.\"");
+                        continue;
+                    }
+                } catch (Exception e2){
+                    TerraFirmaCraft.getLog().warn("Problem parsing Ore / IBlockState for ore generation entry with key: \\\"\"+genEntry.getKey()+\"\\\" Skipping.\"");
+                    continue;
+                }
+            }
+
+            ImmutableList.Builder<Rock> b = new ImmutableList.Builder<>();
+            for(String s : baseStrings)
+            {
+                try {
+                    Rock rock = Rock.valueOf(s.toUpperCase());
+                    b.add(rock);
+                } catch(IllegalArgumentException e1){
+                    try{
+                        Category category = Category.valueOf(s.toUpperCase());
+                        for (Rock rock : Rock.values())
+                        {
+                            if (rock.category == category)
+                            {
+                                b.add(rock);
+                            }
+                        }
+                    } catch(IllegalArgumentException e2){
+                        TerraFirmaCraft.getLog().warn("Problem parsing base rock \""+s+"\" for ore generation entry with key+\""+genEntry.getKey()+"\" Skipping");
+                    }
+                }
+            }
+
+            builder.add(new OreEntry(ore, state, size, shape, b.build(), rarity, minY, maxY, density));
+            TOTAL_WEIGHT += 1.0D / (double) rarity;
+            TerraFirmaCraft.getLog().debug("Added ore generation entry for "+genEntry.getKey());
+        }
+
+        ORE_SPAWN_DATA = builder.build();
     }
 
-    private OreSpawnData(Ore ore, SpawnType type, SpawnSize size, int rarity, Rock[] baseRocks, int minY, int maxY, int densityVertical, int densityHorizontal)
+    public static final class OreEntry
     {
-        this(ore, type, size, rarity, baseRocks, null, minY, maxY, densityVertical, densityHorizontal);
-    }
+        public final Ore ore;
+        public final IBlockState state;
+        public final SpawnType type;
+        public final SpawnSize size;
+        public final int rarity;
+        public final ImmutableList<Rock> baseRocks;
+        public final int minY;
+        public final int maxY;
+        public final double weight;
+        public final double density;
 
-    private OreSpawnData(Ore ore, SpawnType type, SpawnSize size, int rarity, Category baseRocksCategorie, int minY, int maxY, int densityVertical, int densityHorizontal)
-    {
-        this(ore, type, size, rarity, null, new Category[] {baseRocksCategorie}, minY, maxY, densityVertical, densityHorizontal);
-    }
+        private OreEntry(@Nonnull Ore ore, @Nullable IBlockState state, SpawnSize size, SpawnType type, ImmutableList<Rock> baseRocks, int rarity, int minY, int maxY, int density)
+        {
+            this.ore = ore;
+            this.state = state;
+            this.size = size;
+            this.type = type;
+            this.baseRocks = baseRocks;
 
-    private OreSpawnData(Ore ore, SpawnType type, SpawnSize size, int rarity, Rock baseRock, int minY, int maxY, int densityVertical, int densityHorizontal)
-    {
-        this(ore, type, size, rarity, new Rock[] {baseRock}, null, minY, maxY, densityVertical, densityHorizontal);
-    }
+            this.rarity = rarity;
+            this.weight = 1.0D / (double) rarity;
+            this.minY = minY;
+            this.maxY = maxY;
+            this.density= 0.01D * (double)density; // For debug purposes, removing the 0.01D will lead to ore veins being full size, easy to see shapes
 
-    private OreSpawnData(Ore ore, SpawnType type, SpawnSize size, int rarity, Rock[] baseRocks, Category[] baseRocksCategories, int minY, int maxY, int densityVertical, int densityHorizontal)
-    {
-        this.ore = ore;
-        this.type = type;
-        this.size = size;
-        this.rarity = rarity;
-        this.weight = 1.0D / (double)rarity;
-        this.maxClusters = 5;
+            if(ore == Ore.UNKNOWN_ORE && state == null) throw new IllegalStateException("Ore Entry has neither a IBlockState or a Ore type");
+        }
 
-        ImmutableList.Builder<Rock> b = new ImmutableList.Builder<>();
-        if (baseRocks != null) b.add(baseRocks);
-        if (baseRocksCategories != null)
-            for (Category baseRocksCategory : baseRocksCategories)
-                for (Rock rock : Rock.values())
-                    if (rock.category == baseRocksCategory)
-                        b.add(rock);
-        this.baseRocks = b.build();
-
-        this.minY = minY;
-        this.maxY = maxY;
-        this.densityVertical = densityVertical * 0.01f;
-        this.densityHorizontal = densityHorizontal * 0.01f;
-        this.densityModifier = this.densityHorizontal + this.densityVertical / 2.0f;
-    }
-
-    @Override
-    public String toString()
-    {
-        return "OreSpawnData{" +
+        @Override
+        public String toString() {
+            return "OreSpawnData{" +
                 "ore=" + ore +
                 ", type=" + type +
                 ", size=" + size +
@@ -158,14 +199,24 @@ public final class OreSpawnData
                 ", baseRocks=" + baseRocks +
                 ", minY=" + minY +
                 ", maxY=" + maxY +
-                ", densityVertical=" + densityVertical +
-                ", densityHorizontal=" + densityHorizontal +
+                ", density=" + density +
                 '}';
+        }
     }
 
     public enum SpawnType
     {
-        DEFAULT, VEINS
+        SCATTERED_CLUSTER(2, 5), // This is the default. It creates scattered spheriods
+        SINGLE_CLUSTER(1, 1); // This is to create a single spheriod
+
+        public final int minClusters;
+        public final int maxClusters;
+
+        SpawnType(int minClusters, int maxClusters)
+        {
+            this.minClusters = minClusters;
+            this.maxClusters = maxClusters;
+        }
     }
 
     public enum SpawnSize
@@ -181,16 +232,6 @@ public final class OreSpawnData
         {
             this.radius = radius;
             this.densityModifier = densityModifier;
-        }
-
-        public float getDensityModifier()
-        {
-            return densityModifier;
-        }
-
-        public float getRadius()
-        {
-            return radius;
         }
     }
 }

--- a/src/main/java/net/dries007/tfc/util/OreSpawnData.java
+++ b/src/main/java/net/dries007/tfc/util/OreSpawnData.java
@@ -25,6 +25,7 @@ import static net.dries007.tfc.util.OreSpawnData.SpawnType.VEINS;
 public final class OreSpawnData
 {
     public static final ImmutableList<OreSpawnData> ORE_SPAWN_DATA;
+    public static final double TOTAL_WEIGHT;
 
     static
     {
@@ -77,6 +78,13 @@ public final class OreSpawnData
         b.add(new OreSpawnData(TETRAHEDRITE, VEINS, SMALL, 35, METAMORPHIC, 128, 240, 40, 40));
 
         ORE_SPAWN_DATA = b.build();
+
+        double totalWeight = 0;
+        for(OreSpawnData data : ORE_SPAWN_DATA){
+            totalWeight += data.weight;
+        }
+        TOTAL_WEIGHT = totalWeight;
+        System.out.println("TOTAL WEIGHT: "+totalWeight);
     }
 
     public final Ore ore;
@@ -88,6 +96,11 @@ public final class OreSpawnData
     public final int maxY;
     public final float densityVertical;
     public final float densityHorizontal;
+    public final float densityModifier;
+    public final int maxClusters;
+
+    // NEW
+    public final double weight;
 
     private OreSpawnData(Ore ore, SpawnType type, SpawnSize size, int rarity, Category[] baseRocksCategories, int minY, int maxY, int densityVertical, int densityHorizontal)
     {
@@ -115,6 +128,8 @@ public final class OreSpawnData
         this.type = type;
         this.size = size;
         this.rarity = rarity;
+        this.weight = 1.0D / (double)rarity;
+        this.maxClusters = 5;
 
         ImmutableList.Builder<Rock> b = new ImmutableList.Builder<>();
         if (baseRocks != null) b.add(baseRocks);
@@ -129,6 +144,7 @@ public final class OreSpawnData
         this.maxY = maxY;
         this.densityVertical = densityVertical * 0.01f;
         this.densityHorizontal = densityHorizontal * 0.01f;
+        this.densityModifier = this.densityHorizontal + this.densityVertical / 2.0f;
     }
 
     @Override
@@ -154,6 +170,27 @@ public final class OreSpawnData
 
     public enum SpawnSize
     {
-        SMALL, MEDIUM, LARGE
+        SMALL(8.0F, 0.7F),
+        MEDIUM(12.0F, 0.6F),
+        LARGE(16.0F, 0.5F);
+
+        public final float radius;
+        public final float densityModifier;
+
+        SpawnSize(float radius, float densityModifier)
+        {
+            this.radius = radius;
+            this.densityModifier = densityModifier;
+        }
+
+        public float getDensityModifier()
+        {
+            return densityModifier;
+        }
+
+        public float getRadius()
+        {
+            return radius;
+        }
     }
 }

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenOre.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenOre.java
@@ -5,12 +5,14 @@
 
 package net.dries007.tfc.world.classic.worldgen;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
-import com.google.common.collect.ImmutableList;
+import net.dries007.tfc.world.classic.worldgen.vein.VeinType;
+import net.dries007.tfc.world.classic.worldgen.vein.VeinTypeCluster;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.IChunkGenerator;
@@ -24,296 +26,128 @@ import net.dries007.tfc.util.OreSpawnData;
 import net.dries007.tfc.world.classic.ChunkGenTFC;
 import net.dries007.tfc.world.classic.chunkdata.ChunkDataTFC;
 
+import javax.annotation.Nullable;
+
+import static net.dries007.tfc.util.OreSpawnData.TOTAL_WEIGHT;
+
 /**
  * todo: maybe fix cascading worldgen issues? idk if it's worth it though.
  */
-public class WorldGenOre implements IWorldGenerator
-{
+public class WorldGenOre implements IWorldGenerator {
+
+    private static final int CHUNK_RADIUS = 2;
+
+    public static final int VEIN_MAX_RADIUS = 16 * CHUNK_RADIUS;
+    public static final int VEIN_MAX_RADIUS_SQUARED = VEIN_MAX_RADIUS * VEIN_MAX_RADIUS;
+
     @Override
-    public void generate(Random rng, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider)
-    {
+    public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider) {
         if (!(chunkGenerator instanceof ChunkGenTFC)) return;
         final BlockPos chunkBlockPos = new BlockPos(chunkX << 4, 0, chunkZ << 4);
         ChunkDataTFC chunkData = ChunkDataTFC.get(world, chunkBlockPos);
         if (!chunkData.isInitialized()) return;
 
-        for (OreSpawnData spawnData : OreSpawnData.ORE_SPAWN_DATA)
-        {
-            int veinSize;
-            int veinAmount;
-            int height;
-            int diameter;
-            switch (spawnData.size)
-            {
-                /* Bioxx numbers, unajusted for changes in worldgen
-                case SMALL:
-                    veinSize = 20;
-                    veinAmount = 30;
-                    height = 5;
-                    diameter = 40;
-                    break;
-                case MEDIUM:
-                    veinSize = 30;
-                    veinAmount = 40;
-                    height = 10;
-                    diameter = 60;
-                    break;
-                case LARGE:
-                    veinSize = 60;
-                    veinAmount = 45;
-                    height = 20;
-                    diameter = 80;
-                    break;
-                */
-                case SMALL:
-                    veinSize = 20;
-                    veinAmount = 30;
-                    height = 5;
-                    diameter = 20;
-                    break;
-                case MEDIUM:
-                    veinSize = 30;
-                    veinAmount = 80;
-                    height = 10;
-                    diameter = 30;
-                    break;
-                case LARGE:
-                    veinSize = 60;
-                    veinAmount = 80;
-                    height = 20;
-                    diameter = 40;
-                    break;
-                default:
-                    throw new RuntimeException("Enum constants not constant");
-            }
+        // Check dimension is overworld
+        if (world.provider.getDimension() != 0) return;
 
-            if (!spawnData.baseRocks.contains(chunkData.getRock1(0, 0).rock) &&
-                    !spawnData.baseRocks.contains(chunkData.getRock2(0, 0).rock) &&
-                    !spawnData.baseRocks.contains(chunkData.getRock2(0, 0).rock))
+        List<VeinType> veins = getNearbyVeins(chunkX, chunkZ, world.getSeed(), chunkData);
+        if (veins.isEmpty()) return;
+
+        // Set constant values here
+        int xoff = chunkX * 16 + 8;
+        int zoff = chunkZ * 16 + 8;
+
+        for (VeinType vein : veins) {
+            // Do checks here that are specific to each vein
+            if (!vein.oreSpawnData.baseRocks.contains(chunkData.getRock1(0, 0).rock) &&
+                !vein.oreSpawnData.baseRocks.contains(chunkData.getRock2(0, 0).rock) &&
+                !vein.oreSpawnData.baseRocks.contains(chunkData.getRock2(0, 0).rock))
                 continue;
 
+
+            for (int x = 0; x < 16; x++) {
+                for (int z = 0; z < 16; z++) {
+                    // Do checks here that are specific to the the horizontal position, not the vertical one
+                    if (!vein.inRange(new BlockPos(xoff + x, 0, zoff + z))) continue;
+
+                    for (int y = vein.getLowestY(); y <= vein.getHighestY(); y++) {
+
+                        final BlockPos posAt = new BlockPos(xoff + x, y, z + zoff);
+                        final IBlockState stateAt = world.getBlockState(posAt);
+                        // Do checks specific to the individual block pos that is getting replaced
+
+                        if (random.nextDouble() > vein.getChanceToGenerate(posAt)) continue;
+                        if (!(stateAt.getBlock() instanceof BlockRockVariant)) continue;
+
+                        final BlockRockVariant blockAt = (BlockRockVariant) stateAt.getBlock();
+                        if (blockAt.type != Rock.Type.RAW || !vein.oreSpawnData.baseRocks.contains(blockAt.rock))
+                            continue;
+
+                        world.setBlockState(posAt, BlockOreTFC.get(vein.oreSpawnData.ore, blockAt.rock, vein.grade), 2);
+                    }
+                }
+            }
+        }
+
+        // Chunk Data (It needs to be a bit different now, as it is harder to get the exact number of blocks spawned)
+        // TODO: remove the "blocks spawned" count from ore vein chunk data
+        VeinType veinAtChunk = getVeinAtChunk(chunkX, chunkZ, world.getSeed(), chunkData);
+        if (veinAtChunk != null) {
+            chunkData.addSpawnedOre(veinAtChunk.oreSpawnData.ore, veinAtChunk.oreSpawnData.size, veinAtChunk.grade, veinAtChunk.pos, 0);
+        }
+    }
+
+    // Used to generate chunk
+    private List<VeinType> getNearbyVeins(int chunkX, int chunkZ, long worldSeed, ChunkDataTFC chunkData) {
+        List<VeinType> veins = new ArrayList<>();
+
+        for (int x = -CHUNK_RADIUS; x <= CHUNK_RADIUS; x++) {
+            for (int z = -CHUNK_RADIUS; z <= CHUNK_RADIUS; z++) {
+                VeinType vein = getVeinAtChunk(chunkX + x, chunkZ + z, worldSeed, chunkData);
+                if (vein != null) veins.add(vein);
+            }
+        }
+
+        return veins;
+    }
+
+    // Gets veins at a single chunk. Deterministic for a specific chunk x/z and world seed
+    @Nullable
+    private VeinType getVeinAtChunk(int chunkX, int chunkZ, Long worldSeed, ChunkDataTFC chunkData) {
+        Random rand = new Random(worldSeed + chunkX * 341873128712L + chunkZ * 132897987541L);
+
+        if (rand.nextFloat() < TOTAL_WEIGHT) {
+            OreSpawnData oreType = getWeightedOreType(rand);
+
+            BlockPos startPos = new BlockPos(
+                chunkX * 16 + rand.nextInt(16),
+                oreType.minY + rand.nextInt(oreType.maxY - oreType.minY),
+                chunkZ * 16 + rand.nextInt(16)
+            );
+
+            if (!oreType.baseRocks.contains(chunkData.getRockHeight(startPos.getX(), startPos.getY(), startPos.getZ()).rock))
+                return null;
+
             Ore.Grade grade = Ore.Grade.NORMAL;
-            if (spawnData.ore.graded)
-            {
-                int gradeInt = rng.nextInt(100);
+            if (oreType.ore.graded) {
+                int gradeInt = rand.nextInt(100);
                 if (gradeInt < 20) grade = Ore.Grade.RICH;
                 else if (gradeInt < 50) grade = Ore.Grade.POOR;
             }
-
-            if (rng.nextInt(spawnData.rarity) != 0) continue;
-            final BlockPos start = chunkBlockPos.add(0, spawnData.minY + rng.nextInt(spawnData.maxY - spawnData.minY), 0);
-            int blocksSpawned = 0;
-            float avgDensity = (spawnData.densityHorizontal + spawnData.densityVertical) / 2f;
-            for (int i = 0; i < veinAmount; i++)
-            {
-                final BlockPos pos = start.add((1f - spawnData.densityHorizontal) * (rng.nextInt(diameter) - diameter / 2), (1f - spawnData.densityVertical) * (rng.nextInt(height) - height / 2), (1f - spawnData.densityHorizontal) * (rng.nextInt(diameter) - diameter / 2));
-//                final BlockPos pos = start.add(calculateDensity(rng, diameter, spawnData.densityHorizontal), calculateDensity(rng, height, spawnData.densityVertical), calculateDensity(rng, diameter, spawnData.densityHorizontal));
-                // todo: use density
-                switch (spawnData.type)
-                {
-                    case DEFAULT:
-                        blocksSpawned += generateDefault(spawnData.ore, grade, world, rng, pos, veinSize, spawnData.baseRocks, avgDensity);
-                        break;
-                    case VEINS:
-                        blocksSpawned += generateVein(spawnData.ore, grade, world, rng, pos, veinSize, spawnData.baseRocks);
-                        break;
-                }
-            }
-            if (blocksSpawned != 0) chunkData.addSpawnedOre(spawnData.ore, spawnData.size, grade, start, blocksSpawned);
+            return new VeinTypeCluster(startPos, oreType, grade, rand);
         }
+        return null;
     }
 
-    private int generateDefault(Ore ore, Ore.Grade grade, World world, Random rng, BlockPos start, int size, ImmutableList<Rock> baseRocks, float density)
-    {
-        int blocksSpawned = 0;
-        final float angle = rng.nextFloat() * (float) Math.PI;
-        final double minX = start.getX() + 8 + MathHelper.sin(angle) * size / 8.0F;
-        final double maxX = start.getX() + 8 - MathHelper.sin(angle) * size / 8.0F;
-        final double minZ = start.getZ() + 8 + MathHelper.cos(angle) * size / 8.0F;
-        final double maxZ = start.getZ() + 8 - MathHelper.cos(angle) * size / 8.0F;
-        final double minY = start.getY() + rng.nextInt(3) - 2;
-        final double maxY = start.getY() + rng.nextInt(3) - 2;
-
-        for (int i = 0; i <= size; ++i)
-        {
-            final double centerX = minX + (maxX - minX) * i / size;
-            final double centerY = minY + (maxY - minY) * i / size;
-            final double centerZ = minZ + (maxZ - minZ) * i / size;
-            final double scale = rng.nextDouble() * size / 16.0D;
-            final double radius = (MathHelper.sin(i * (float) Math.PI / size) + 1.0F) * scale + 1.0D;
-            final int startX = MathHelper.floor(centerX - radius / 2.0D);
-            final int startY = MathHelper.floor(centerY - radius / 2.0D);
-            final int startZ = MathHelper.floor(centerZ - radius / 2.0D);
-            final int endX = MathHelper.floor(centerX + radius / 2.0D);
-            final int endY = MathHelper.floor(centerY + radius / 2.0D);
-            final int endZ = MathHelper.floor(centerZ + radius / 2.0D);
-
-            for (int posX = startX; posX <= endX; ++posX)
-            {
-                double rx = (posX + 0.5D - centerX) / (radius / 2.0D);
-                if (rx * rx >= 1.0D) continue;
-
-                for (int posY = startY; posY <= endY; ++posY)
-                {
-                    double ry = (posY + 0.5D - centerY) / (radius / 2.0D);
-                    if (rx * rx + ry * ry >= 1.0D) continue;
-
-                    for (int posZ = startZ; posZ <= endZ; ++posZ)
-                    {
-                        double rz = (posZ + 0.5D - centerZ) / (radius / 2.0D);
-                        if (rx * rx + ry * ry + rz * rz >= 1.0D) continue;
-
-                        if (density < rng.nextFloat()) continue;
-
-                        BlockPos pos = new BlockPos(posX, posY, posZ);
-                        pos = pos.add(0, ChunkDataTFC.getSeaLevelOffset(world, pos), 0);
-                        final IBlockState current = world.getBlockState(pos);
-
-                        if (!(current.getBlock() instanceof BlockRockVariant)) continue;
-
-                        final BlockRockVariant currentBlock = (BlockRockVariant) current.getBlock();
-
-                        if (currentBlock.type != Rock.Type.RAW || !baseRocks.contains(currentBlock.rock)) continue;
-
-                        world.setBlockState(pos, BlockOreTFC.get(ore, currentBlock.rock, grade), 2);
-                        blocksSpawned++;
-                    }
-                }
-            }
+    private OreSpawnData getWeightedOreType(Random rand) {
+        double r = rand.nextDouble() * TOTAL_WEIGHT;
+        double countWeight = 0.0;
+        for (OreSpawnData ore : OreSpawnData.ORE_SPAWN_DATA) {
+            countWeight += ore.weight;
+            if (countWeight >= r)
+                return ore;
         }
-        return blocksSpawned;
+        throw new RuntimeException("Problem choosing random ore weights. Should never be shown");
     }
 
-    private int generateVein(Ore ore, Ore.Grade grade, World world, Random rng, BlockPos start, int size, ImmutableList<Rock> baseRocks)
-    {
-        int blocksSpawned = 0;
-
-        int posX2 = 0;
-        int posY2 = 0;
-        int posZ2 = 0;
-        int directionX;
-        int directionY;
-        int directionZ;
-        int directionX2;
-        int directionY2;
-        int directionZ2;
-        int directionChange;
-        int directionChange2;
-        int blocksToUse2;
-
-        for (int blocksMade = 0; blocksMade <= size; ) // make veins
-        {
-            int posX = start.getX();
-            int posY = start.getY();
-            int posZ = start.getZ();
-
-            blocksToUse2 = 1 + (size / 30);
-            directionChange = rng.nextInt(6);
-            directionX = rng.nextInt(2);
-            directionY = rng.nextInt(2);
-            directionZ = rng.nextInt(2);
-
-            for (int blocksMade1 = 0; blocksMade1 <= blocksToUse2; ) // make branch
-            {
-                if (directionX == 0 && directionChange != 1)
-                    posX = posX + rng.nextInt(2);
-                if (directionX == 1 && directionChange != 1)
-                    posX = posX - rng.nextInt(2);
-                if (directionY == 0 && directionChange != 2)
-                    posY = posY + rng.nextInt(2);
-                if (directionY == 1 && directionChange != 2)
-                    posY = posY - rng.nextInt(2);
-                if (directionZ == 0 && directionChange != 3)
-                    posZ = posZ + rng.nextInt(2);
-                if (directionZ == 1 && directionChange != 3)
-                    posZ = posZ - rng.nextInt(2);
-                if (rng.nextInt(4) == 0)
-                {
-                    posX2 = posX2 + rng.nextInt(2);
-                    posY2 = posY2 + rng.nextInt(2);
-                    posZ2 = posZ2 + rng.nextInt(2);
-                    posX2 = posX2 - rng.nextInt(2);
-                    posY2 = posY2 - rng.nextInt(2);
-                    posZ2 = posZ2 - rng.nextInt(2);
-                }
-                if (rng.nextInt(3) == 0) // make sub-branch
-                {
-                    posX2 = posX;
-                    posY2 = posY;
-                    posZ2 = posZ;
-                    directionX2 = rng.nextInt(2);
-                    directionY2 = rng.nextInt(2);
-                    directionZ2 = rng.nextInt(2);
-                    directionChange2 = rng.nextInt(6);
-                    if (directionX2 == 0 && directionChange2 != 0)
-                        posX2 = posX2 + rng.nextInt(2);
-                    if (directionY2 == 0 && directionChange2 != 1)
-                        posY2 = posY2 + rng.nextInt(2);
-                    if (directionZ2 == 0 && directionChange2 != 2)
-                        posZ2 = posZ2 + rng.nextInt(2);
-                    if (directionX2 == 1 && directionChange2 != 0)
-                        posX2 = posX2 - rng.nextInt(2);
-                    if (directionY2 == 1 && directionChange2 != 1)
-                        posY2 = posY2 - rng.nextInt(2);
-                    if (directionZ2 == 1 && directionChange2 != 2)
-                        posZ2 = posZ2 - rng.nextInt(2);
-
-                    for (int blocksMade2 = 0; blocksMade2 <= (1 + (blocksToUse2 / 5)); )
-                    {
-                        if (directionX2 == 0 && directionChange2 != 0)
-                            posX2 = posX2 + rng.nextInt(2);
-                        if (directionY2 == 0 && directionChange2 != 1)
-                            posY2 = posY2 + rng.nextInt(2);
-                        if (directionZ2 == 0 && directionChange2 != 2)
-                            posZ2 = posZ2 + rng.nextInt(2);
-                        if (directionX2 == 1 && directionChange2 != 0)
-                            posX2 = posX2 - rng.nextInt(2);
-                        if (directionY2 == 1 && directionChange2 != 1)
-                            posY2 = posY2 - rng.nextInt(2);
-                        if (directionZ2 == 1 && directionChange2 != 2)
-                            posZ2 = posZ2 - rng.nextInt(2);
-
-                        blocksMade++;
-                        blocksMade1++;
-                        blocksMade2++;
-
-                        BlockPos pos = new BlockPos(posX, posY, posZ);
-                        pos = pos.add(0, ChunkDataTFC.getSeaLevelOffset(world, pos), 0);
-                        final IBlockState current = world.getBlockState(pos);
-
-                        if (!(current.getBlock() instanceof BlockRockVariant)) continue;
-
-                        final BlockRockVariant currentBlock = (BlockRockVariant) current.getBlock();
-
-                        if (currentBlock.type != Rock.Type.RAW || !baseRocks.contains(currentBlock.rock)) continue;
-
-                        world.setBlockState(pos, BlockOreTFC.get(ore, currentBlock.rock, grade), 2);
-
-                        blocksSpawned++;
-                    }
-                }
-
-                blocksMade++;
-                blocksMade1++;
-
-                BlockPos pos = new BlockPos(posX, posY, posZ);
-                pos = pos.add(0, ChunkDataTFC.getSeaLevelOffset(world, pos), 0);
-                final IBlockState current = world.getBlockState(pos);
-
-                if (!(current.getBlock() instanceof BlockRockVariant)) continue;
-
-                final BlockRockVariant currentBlock = (BlockRockVariant) current.getBlock();
-
-                if (currentBlock.type != Rock.Type.RAW || !baseRocks.contains(currentBlock.rock)) continue;
-
-                world.setBlockState(pos, BlockOreTFC.get(ore, currentBlock.rock, grade), 2);
-
-                blocksSpawned++;
-            }
-
-            start = start.add(rng.nextInt(3) - 1, rng.nextInt(3) - 1, rng.nextInt(3) - 1);
-        }
-
-        return blocksSpawned;
-    }
 }

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenOre.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenOre.java
@@ -8,9 +8,8 @@ package net.dries007.tfc.world.classic.worldgen;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import javax.annotation.Nullable;
 
-import net.dries007.tfc.world.classic.worldgen.vein.VeinType;
-import net.dries007.tfc.world.classic.worldgen.vein.VeinTypeCluster;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -25,8 +24,8 @@ import net.dries007.tfc.objects.blocks.stone.BlockRockVariant;
 import net.dries007.tfc.util.OreSpawnData;
 import net.dries007.tfc.world.classic.ChunkGenTFC;
 import net.dries007.tfc.world.classic.chunkdata.ChunkDataTFC;
-
-import javax.annotation.Nullable;
+import net.dries007.tfc.world.classic.worldgen.vein.VeinType;
+import net.dries007.tfc.world.classic.worldgen.vein.VeinTypeCluster;
 
 import static net.dries007.tfc.util.OreSpawnData.TOTAL_WEIGHT;
 
@@ -34,7 +33,6 @@ public class WorldGenOre implements IWorldGenerator
 {
 
     private static final int CHUNK_RADIUS = 2;
-
     public static final int VEIN_MAX_RADIUS = 16 * CHUNK_RADIUS;
     public static final int VEIN_MAX_RADIUS_SQUARED = VEIN_MAX_RADIUS * VEIN_MAX_RADIUS;
 
@@ -86,7 +84,7 @@ public class WorldGenOre implements IWorldGenerator
                         if (blockAt.type != Rock.Type.RAW || !vein.oreSpawnData.baseRocks.contains(blockAt.rock))
                             continue;
 
-                        if(vein.oreSpawnData.ore == Ore.UNKNOWN_ORE && vein.oreSpawnData.state != null)
+                        if (vein.oreSpawnData.ore == Ore.UNKNOWN_ORE && vein.oreSpawnData.state != null)
                         {
                             world.setBlockState(posAt, vein.oreSpawnData.state, 2);
                         }
@@ -108,7 +106,8 @@ public class WorldGenOre implements IWorldGenerator
     }
 
     // Used to generate chunk
-    private List<VeinType> getNearbyVeins(int chunkX, int chunkZ, long worldSeed, ChunkDataTFC chunkData) {
+    private List<VeinType> getNearbyVeins(int chunkX, int chunkZ, long worldSeed, ChunkDataTFC chunkData)
+    {
         List<VeinType> veins = new ArrayList<>();
 
         for (int x = -CHUNK_RADIUS; x <= CHUNK_RADIUS; x++)

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinType.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinType.java
@@ -1,3 +1,8 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
 package net.dries007.tfc.world.classic.worldgen.vein;
 
 import net.dries007.tfc.objects.Ore;
@@ -8,10 +13,10 @@ import net.minecraft.util.math.BlockPos;
 public abstract class VeinType
 {
     public final BlockPos pos;
-    public final OreSpawnData oreSpawnData;
+    public final OreSpawnData.OreEntry oreSpawnData;
     public final Ore.Grade grade;
 
-    VeinType(BlockPos pos, OreSpawnData oreSpawnData, Ore.Grade grade)
+    VeinType(BlockPos pos, OreSpawnData.OreEntry oreSpawnData, Ore.Grade grade)
     {
         this.pos = pos;
         this.oreSpawnData = oreSpawnData;

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinType.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinType.java
@@ -5,10 +5,11 @@
 
 package net.dries007.tfc.world.classic.worldgen.vein;
 
+import net.minecraft.util.math.BlockPos;
+
 import net.dries007.tfc.objects.Ore;
 import net.dries007.tfc.util.OreSpawnData;
 import net.dries007.tfc.world.classic.worldgen.WorldGenOre;
-import net.minecraft.util.math.BlockPos;
 
 public abstract class VeinType
 {
@@ -25,12 +26,14 @@ public abstract class VeinType
 
     public final boolean inRange(BlockPos pos1)
     {
-        return Math.pow(pos1.getX() - this.pos.getX(),2) + Math.pow(pos1.getZ() - this.pos.getZ(),2) <= WorldGenOre.VEIN_MAX_RADIUS_SQUARED;
+        return Math.pow(pos1.getX() - this.pos.getX(), 2) + Math.pow(pos1.getZ() - this.pos.getZ(), 2) <= WorldGenOre.VEIN_MAX_RADIUS_SQUARED;
     }
+
     public int getLowestY()
     {
         return Math.max(pos.getY() - WorldGenOre.VEIN_MAX_RADIUS / 2, oreSpawnData.minY);
     }
+
     public int getHighestY()
     {
         return Math.min(pos.getY() + WorldGenOre.VEIN_MAX_RADIUS / 2, oreSpawnData.maxY);

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinType.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinType.java
@@ -1,0 +1,35 @@
+package net.dries007.tfc.world.classic.worldgen.vein;
+
+import net.dries007.tfc.objects.Ore;
+import net.dries007.tfc.util.OreSpawnData;
+import net.dries007.tfc.world.classic.worldgen.WorldGenOre;
+import net.minecraft.util.math.BlockPos;
+
+public abstract class VeinType
+{
+    public final BlockPos pos;
+    public final OreSpawnData oreSpawnData;
+    public final Ore.Grade grade;
+
+    VeinType(BlockPos pos, OreSpawnData oreSpawnData, Ore.Grade grade)
+    {
+        this.pos = pos;
+        this.oreSpawnData = oreSpawnData;
+        this.grade = grade;
+    }
+
+    public final boolean inRange(BlockPos pos1)
+    {
+        return Math.pow(pos1.getX() - this.pos.getX(),2) + Math.pow(pos1.getZ() - this.pos.getZ(),2) <= WorldGenOre.VEIN_MAX_RADIUS_SQUARED;
+    }
+    public int getLowestY()
+    {
+        return Math.max(pos.getY() - WorldGenOre.VEIN_MAX_RADIUS / 2, oreSpawnData.minY);
+    }
+    public int getHighestY()
+    {
+        return Math.min(pos.getY() + WorldGenOre.VEIN_MAX_RADIUS / 2, oreSpawnData.maxY);
+    }
+
+    public abstract double getChanceToGenerate(BlockPos pos1);
+}

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinTypeCluster.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinTypeCluster.java
@@ -5,11 +5,12 @@
 
 package net.dries007.tfc.world.classic.worldgen.vein;
 
-import net.dries007.tfc.objects.Ore;
-import net.dries007.tfc.util.OreSpawnData;
+import java.util.Random;
+
 import net.minecraft.util.math.BlockPos;
 
-import java.util.Random;
+import net.dries007.tfc.objects.Ore;
+import net.dries007.tfc.util.OreSpawnData;
 
 public class VeinTypeCluster extends VeinType
 {
@@ -27,13 +28,13 @@ public class VeinTypeCluster extends VeinType
         this.verticalModifier = (1.5 - rand.nextDouble()) * data.size.radius;
 
         int clusters = data.type.minClusters;
-        if(data.type.maxClusters > clusters)
+        if (data.type.maxClusters > clusters)
         {
             clusters += rand.nextInt(data.type.maxClusters - data.type.minClusters);
         }
         spawnPoints = new Cluster[clusters];
-        spawnPoints[0] = new Cluster(pos,0.6 + 0.5 * rand.nextDouble());
-        for(int i = 1; i < clusters; i++)
+        spawnPoints[0] = new Cluster(pos, 0.6 + 0.5 * rand.nextDouble());
+        for (int i = 1; i < clusters; i++)
         {
             final BlockPos clusterPos = pos.add(
                 1.5 * horizontalModifier * (0.5 - rand.nextDouble()),
@@ -49,15 +50,15 @@ public class VeinTypeCluster extends VeinType
     {
         double shortestRadius = -1;
 
-        for(Cluster c : spawnPoints)
+        for (Cluster c : spawnPoints)
         {
             final double dx = Math.pow(c.pos.getX() - pos1.getX(), 2);
             final double dy = Math.pow(c.pos.getY() - pos1.getY(), 2);
             final double dz = Math.pow(c.pos.getZ() - pos1.getZ(), 2);
 
-            final double radius = (dx + dz) / Math.pow(c.size*horizontalModifier, 2) + dy / Math.pow(c.size*verticalModifier, 2);
+            final double radius = (dx + dz) / Math.pow(c.size * horizontalModifier, 2) + dy / Math.pow(c.size * verticalModifier, 2);
 
-            if(shortestRadius == -1 || radius < shortestRadius) shortestRadius = radius;
+            if (shortestRadius == -1 || radius < shortestRadius) shortestRadius = radius;
         }
         return oreSpawnData.density * oreSpawnData.size.densityModifier * (1.0 - shortestRadius);
     }

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinTypeCluster.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinTypeCluster.java
@@ -1,0 +1,67 @@
+package net.dries007.tfc.world.classic.worldgen.vein;
+
+import net.dries007.tfc.objects.Ore;
+import net.dries007.tfc.util.OreSpawnData;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.Random;
+
+public class VeinTypeCluster extends VeinType
+{
+
+    private final double verticalModifier;
+    private final double horizontalModifier;
+
+    private final Cluster[] spawnPoints;
+
+    public VeinTypeCluster(BlockPos pos, OreSpawnData data, Ore.Grade grade, Random rand)
+    {
+        super(pos, data, grade);
+
+        this.horizontalModifier = (1.5 - rand.nextDouble()) * data.size.getRadius();
+        this.verticalModifier = (1.5 - rand.nextDouble()) * data.size.getRadius();
+
+        int clusters = 1 + rand.nextInt(data.maxClusters);
+        spawnPoints = new Cluster[clusters];
+        spawnPoints[0] = new Cluster(pos,0.6 + 0.5 * rand.nextDouble());
+        for(int i = 1; i < clusters; i++)
+        {
+            final BlockPos clusterPos = pos.add(
+                1.5 * horizontalModifier * (0.5 - rand.nextDouble()),
+                1.5 * verticalModifier * (0.5 - rand.nextDouble()),
+                1.5 * horizontalModifier * (0.5 - rand.nextDouble())
+            );
+            spawnPoints[i] = new Cluster(clusterPos, 0.3 + 0.5 * rand.nextDouble());
+        }
+    }
+
+    @Override
+    public double getChanceToGenerate(BlockPos pos1){
+        double shortestRadius = -1;
+
+        for(Cluster c : spawnPoints)
+        {
+            final double dx = Math.pow(c.pos.getX() - pos1.getX(), 2);
+            final double dy = Math.pow(c.pos.getY() - pos1.getY(), 2);
+            final double dz = Math.pow(c.pos.getZ() - pos1.getZ(), 2);
+
+            final double radius = (dx + dz) / Math.pow(c.size*horizontalModifier, 2) + dy / Math.pow(c.size*verticalModifier, 2);
+
+            if(shortestRadius == -1 || radius < shortestRadius) shortestRadius = radius;
+        }
+        return (double)oreSpawnData.densityModifier * oreSpawnData.size.getDensityModifier() * (1.0 - shortestRadius);
+    }
+
+    final class Cluster
+    {
+        final BlockPos pos;
+        final double size;
+
+        Cluster(BlockPos pos, double size)
+        {
+            this.pos = pos;
+            this.size = size;
+        }
+
+    }
+}

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinTypeCluster.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/vein/VeinTypeCluster.java
@@ -1,3 +1,8 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
 package net.dries007.tfc.world.classic.worldgen.vein;
 
 import net.dries007.tfc.objects.Ore;
@@ -14,14 +19,18 @@ public class VeinTypeCluster extends VeinType
 
     private final Cluster[] spawnPoints;
 
-    public VeinTypeCluster(BlockPos pos, OreSpawnData data, Ore.Grade grade, Random rand)
+    public VeinTypeCluster(BlockPos pos, OreSpawnData.OreEntry data, Ore.Grade grade, Random rand)
     {
         super(pos, data, grade);
 
-        this.horizontalModifier = (1.5 - rand.nextDouble()) * data.size.getRadius();
-        this.verticalModifier = (1.5 - rand.nextDouble()) * data.size.getRadius();
+        this.horizontalModifier = (1.5 - rand.nextDouble()) * data.size.radius;
+        this.verticalModifier = (1.5 - rand.nextDouble()) * data.size.radius;
 
-        int clusters = 1 + rand.nextInt(data.maxClusters);
+        int clusters = data.type.minClusters;
+        if(data.type.maxClusters > clusters)
+        {
+            clusters += rand.nextInt(data.type.maxClusters - data.type.minClusters);
+        }
         spawnPoints = new Cluster[clusters];
         spawnPoints[0] = new Cluster(pos,0.6 + 0.5 * rand.nextDouble());
         for(int i = 1; i < clusters; i++)
@@ -36,7 +45,8 @@ public class VeinTypeCluster extends VeinType
     }
 
     @Override
-    public double getChanceToGenerate(BlockPos pos1){
+    public double getChanceToGenerate(BlockPos pos1)
+    {
         double shortestRadius = -1;
 
         for(Cluster c : spawnPoints)
@@ -49,7 +59,7 @@ public class VeinTypeCluster extends VeinType
 
             if(shortestRadius == -1 || radius < shortestRadius) shortestRadius = radius;
         }
-        return (double)oreSpawnData.densityModifier * oreSpawnData.size.getDensityModifier() * (1.0 - shortestRadius);
+        return oreSpawnData.density * oreSpawnData.size.densityModifier * (1.0 - shortestRadius);
     }
 
     final class Cluster

--- a/src/main/resources/assets/tfc/config/tfc_ore_spawn_data.json
+++ b/src/main/resources/assets/tfc/config/tfc_ore_spawn_data.json
@@ -4,10 +4,10 @@
 		"size": "large",
 		"shape": "scattered_cluster",
 		"rarity": 120,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_extrusive"
 		]
 
@@ -17,10 +17,10 @@
 		"size": "large",
 		"shape": "scattered_cluster",
 		"rarity": 120,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_extrusive",
 			"igneous_intrusive"
 		]
@@ -31,10 +31,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 150,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 60,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -44,10 +44,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"gabbro",
 			"gneiss"
 		]
@@ -58,10 +58,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 125,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_extrusive"
 		]
 
@@ -71,10 +71,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_intrusive"
 		]
 
@@ -84,10 +84,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_extrusive",
 			"metamorphic",
 			"granite",
@@ -100,10 +100,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_extrusive",
 			"sedimentary"
 		]
@@ -114,10 +114,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 150,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"gabbro"
 		]
 
@@ -127,10 +127,10 @@
 		"size": "large",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"limestone",
 			"marble"
 		]
@@ -141,10 +141,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 150,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -154,10 +154,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 150,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -167,10 +167,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"metamorphic"
 		]
 
@@ -180,10 +180,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"metamorphic"
 		]
 
@@ -193,10 +193,10 @@
 		"size": "large",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 60,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -206,10 +206,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 60,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -219,10 +219,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 90,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -232,10 +232,10 @@
 		"size": "large",
 		"shape": "scattered_cluster",
 		"rarity": 120,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -245,10 +245,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"marble",
 			"gneiss",
 			"quartzite",
@@ -261,10 +261,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 200,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 50,
-		"base-rocks": [
+    "base_rocks": [
 			"gabbro"
 		]
 
@@ -274,10 +274,10 @@
 		"size": "large",
 		"shape": "scattered_cluster",
 		"rarity": 110,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -287,10 +287,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 150,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"granite"
 		]
 
@@ -300,10 +300,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 150,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 60,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_extrusive",
 			"shale",
 			"quartzite"
@@ -315,10 +315,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"granite"
 		]
 
@@ -328,10 +328,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 120,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"sedimentary"
 		]
 
@@ -341,10 +341,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 100,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 60,
-		"base-rocks": [
+    "base_rocks": [
 			"rocksalt"
 		]
 
@@ -354,10 +354,10 @@
 		"size": "medium",
 		"shape": "scattered_cluster",
 		"rarity": 120,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"rocksalt"
 		]
 
@@ -367,10 +367,10 @@
 		"size": "large",
 		"shape": "scattered_cluster",
 		"rarity": 120,
-		"minimum-height": 5,
-		"maximum-height": 128,
+    "minimum_height": 5,
+    "maximum_height": 128,
 		"density": 70,
-		"base-rocks": [
+    "base_rocks": [
 			"marble"
 		]
 
@@ -380,10 +380,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 35,
-		"minimum-height": 128,
-		"maximum-height": 240,
+    "minimum_height": 128,
+    "maximum_height": 240,
 		"density": 40,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_extrusive"
 		]
 
@@ -393,10 +393,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 35,
-		"minimum-height": 128,
-		"maximum-height": 240,
+    "minimum_height": 128,
+    "maximum_height": 240,
 		"density": 40,
-		"base-rocks": [
+    "base_rocks": [
 			"granite"
 		]
 
@@ -406,10 +406,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 35,
-		"minimum-height": 128,
-		"maximum-height": 240,
+    "minimum_height": 128,
+    "maximum_height": 240,
 		"density": 40,
-		"base-rocks": [
+    "base_rocks": [
 			"igneous_extrusive",
 			"sedimentary"
 		]
@@ -420,10 +420,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 35,
-		"minimum-height": 128,
-		"maximum-height": 240,
+    "minimum_height": 128,
+    "maximum_height": 240,
 		"density": 40,
-		"base-rocks": [
+    "base_rocks": [
 			"metamorphic"
 		]
 
@@ -433,10 +433,10 @@
 		"size": "small",
 		"shape": "scattered_cluster",
 		"rarity": 35,
-		"minimum-height": 128,
-		"maximum-height": 240,
+    "minimum_height": 128,
+    "maximum_height": 240,
 		"density": 40,
-		"base-rocks": [
+    "base_rocks": [
 			"metamorphic"
 		]
 

--- a/src/main/resources/assets/tfc/config/tfc_ore_spawn_data.json
+++ b/src/main/resources/assets/tfc/config/tfc_ore_spawn_data.json
@@ -1,0 +1,444 @@
+{
+	"native_copper": {
+		"ore": "native_copper",
+		"size": "large",
+		"shape": "scattered_cluster",
+		"rarity": 120,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"igneous_extrusive"
+		]
+
+	},
+	"native_gold": {
+		"ore": "native_gold",
+		"size": "large",
+		"shape": "scattered_cluster",
+		"rarity": 120,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"igneous_extrusive",
+			"igneous_intrusive"
+		]
+
+	},
+	"native_platinum": {
+		"ore": "native_platinum",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 150,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 60,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"native_silver": {
+		"ore": "native_silver",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"gabbro",
+			"gneiss"
+		]
+
+	},
+	"hematite": {
+		"ore": "hematite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 125,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"igneous_extrusive"
+		]
+
+	},
+	"cassiterite": {
+		"ore": "cassiterite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"igneous_intrusive"
+		]
+
+	},
+	"galena": {
+		"ore": "galena",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"igneous_extrusive",
+			"metamorphic",
+			"granite",
+			"limestone"
+		]
+
+	},
+	"bismuthinite": {
+		"ore": "bismuthinite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"igneous_extrusive",
+			"sedimentary"
+		]
+
+	},
+	"garnierite": {
+		"ore": "garnierite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 150,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"gabbro"
+		]
+
+	},
+	"malachite": {
+		"ore": "malachite",
+		"size": "large",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"limestone",
+			"marble"
+		]
+
+	},
+	"magnetite": {
+		"ore": "magnetite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 150,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"limonite": {
+		"ore": "limonite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 150,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"sphalerite": {
+		"ore": "sphalerite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"metamorphic"
+		]
+
+	},
+	"tetrahedrite": {
+		"ore": "tetrahedrite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"metamorphic"
+		]
+
+	},
+	"bithminous_coal": {
+		"ore": "bituminous_coal",
+		"size": "large",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 60,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"lignite": {
+		"ore": "lignite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 60,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"kaolinite": {
+		"ore": "kaolinite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 90,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"gypsum": {
+		"ore": "gypsum",
+		"size": "large",
+		"shape": "scattered_cluster",
+		"rarity": 120,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"graphite": {
+		"ore": "graphite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"marble",
+			"gneiss",
+			"quartzite",
+			"schist"
+		]
+
+	},
+	"kimberlite": {
+		"ore": "kimberlite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 200,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 50,
+		"base-rocks": [
+			"gabbro"
+		]
+
+	},
+	"jet": {
+		"ore": "jet",
+		"size": "large",
+		"shape": "scattered_cluster",
+		"rarity": 110,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"pitchblende": {
+		"ore": "pitchblende",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 150,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"granite"
+		]
+
+	},
+	"cinnabar": {
+		"ore": "cinnabar",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 150,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 60,
+		"base-rocks": [
+			"igneous_extrusive",
+			"shale",
+			"quartzite"
+		]
+
+	},
+	"cryolite": {
+		"ore": "cryolite",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"granite"
+		]
+
+	},
+	"saltpeter": {
+		"ore": "saltpeter",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 120,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"sedimentary"
+		]
+
+	},
+	"sylvite": {
+		"ore": "sylvite",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 100,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 60,
+		"base-rocks": [
+			"rocksalt"
+		]
+
+	},
+	"borax": {
+		"ore": "borax",
+		"size": "medium",
+		"shape": "scattered_cluster",
+		"rarity": 120,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"rocksalt"
+		]
+
+	},
+	"lapis_lazuli": {
+		"ore": "lapis_lazuli",
+		"size": "large",
+		"shape": "scattered_cluster",
+		"rarity": 120,
+		"minimum-height": 5,
+		"maximum-height": 128,
+		"density": 70,
+		"base-rocks": [
+			"marble"
+		]
+
+	},
+	"surface_native_copper": {
+		"ore": "native_copper",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 35,
+		"minimum-height": 128,
+		"maximum-height": 240,
+		"density": 40,
+		"base-rocks": [
+			"igneous_extrusive"
+		]
+
+	},
+	"surface_cassiterite": {
+		"ore": "cassiterite",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 35,
+		"minimum-height": 128,
+		"maximum-height": 240,
+		"density": 40,
+		"base-rocks": [
+			"granite"
+		]
+
+	},
+	"surface_bismuthinite": {
+		"ore": "bismuthinite",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 35,
+		"minimum-height": 128,
+		"maximum-height": 240,
+		"density": 40,
+		"base-rocks": [
+			"igneous_extrusive",
+			"sedimentary"
+		]
+
+	},
+	"surface_sphalerite": {
+		"ore": "sphalerite",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 35,
+		"minimum-height": 128,
+		"maximum-height": 240,
+		"density": 40,
+		"base-rocks": [
+			"metamorphic"
+		]
+
+	},
+	"surface_tetrahedrite": {
+		"ore": "tetrahedrite",
+		"size": "small",
+		"shape": "scattered_cluster",
+		"rarity": 35,
+		"minimum-height": 128,
+		"maximum-height": 240,
+		"density": 40,
+		"base-rocks": [
+			"metamorphic"
+		]
+
+	}
+}


### PR DESCRIPTION
Some data on cascading lag. I did ten trials for each generation type in which I loaded a new world and counted the number of chunks that were generated via cascading lag. This is the results:

OLD ORES: mean = 32.8, standard dev. = 12.8
NO ORES: mean = 8.1, standard dev. = 6.5
NEW ORES: mean = 8.5, standard dev = 4.6

I think it is fair to say that this eliminates cascading lag that is caused by ore generation.

Other changes:
 - Ore generation is now controlled via a json file
 - Default file is at assets/tfc/config, which will be copied into .minecraft/config/tfc at first load
 - Can support non-tfc blocks, by putting a block name in the ore field (i.e. "ore": "minecraft:gold_ore" instead of "ore": "native_gold")
 - Size, type, etc. are all controlled via enums. Can add and change as necessary.