### PR TITLE
Item holder block.

### DIFF
--- a/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
+++ b/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
@@ -116,6 +116,7 @@ public final class TerraFirmaCraft
         int id = 0;
         // Received on server
         network.registerMessage(new PacketGuiButton.Handler(), PacketGuiButton.class, ++id, Side.SERVER);
+        network.registerMessage(new PacketPlaceBlockFromKeyBind.Handler(), PacketPlaceBlockFromKeyBind.class, ++id, Side.SERVER);
         // Received on client
         network.registerMessage(new PacketAnvilUpdate.Handler(), PacketAnvilUpdate.class, ++id, Side.CLIENT);
         network.registerMessage(new PacketCrucibleUpdate.Handler(), PacketCrucibleUpdate.class, ++id, Side.CLIENT);

--- a/src/main/java/net/dries007/tfc/client/ClientRegisterEvents.java
+++ b/src/main/java/net/dries007/tfc/client/ClientRegisterEvents.java
@@ -197,6 +197,7 @@ public final class ClientRegisterEvents
         ModelLoader.setCustomStateMapper(BlocksTFC.PIT_KILN, blockIn -> ImmutableMap.of(BlocksTFC.PIT_KILN.getDefaultState(), new ModelResourceLocation("tfc:empty")));
         ModelLoader.setCustomStateMapper(BlocksTFC.WORLD_ITEM, blockIn -> ImmutableMap.of(BlocksTFC.WORLD_ITEM.getDefaultState(), new ModelResourceLocation("tfc:empty")));
         ModelLoader.setCustomStateMapper(BlocksTFC.INGOT_PILE, blockIn -> ImmutableMap.of(BlocksTFC.INGOT_PILE.getDefaultState(), new ModelResourceLocation("tfc:empty")));
+        ModelLoader.setCustomStateMapper(BlocksTFC.ITEM_HOLDER, blockIn -> ImmutableMap.of(BlocksTFC.ITEM_HOLDER.getDefaultState(), new ModelResourceLocation("tfc:empty")));
 
         // TESRs //
 
@@ -208,6 +209,7 @@ public final class ClientRegisterEvents
         ClientRegistry.bindTileEntitySpecialRenderer(TEBellows.class, new TESRBellows());
         ClientRegistry.bindTileEntitySpecialRenderer(TEBarrel.class, new TESRBarrel());
         ClientRegistry.bindTileEntitySpecialRenderer(TEAnvilTFC.class, new TESRAnvil());
+        ClientRegistry.bindTileEntitySpecialRenderer(TEItemHolder.class, new TESRItemHolder());
     }
 
     @SubscribeEvent

--- a/src/main/java/net/dries007/tfc/client/TFCKeybindings.java
+++ b/src/main/java/net/dries007/tfc/client/TFCKeybindings.java
@@ -9,6 +9,7 @@ import org.lwjgl.input.Keyboard;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiCrafting;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Mod;
@@ -17,19 +18,25 @@ import net.minecraftforge.fml.common.gameevent.InputEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import net.dries007.tfc.TerraFirmaCraft;
+import net.dries007.tfc.network.PacketPlaceBlockFromKeyBind;
+import net.dries007.tfc.objects.blocks.BlocksTFC;
+
 import static net.dries007.tfc.api.util.TFCConstants.MOD_ID;
 
 @Mod.EventBusSubscriber(value = Side.CLIENT, modid = MOD_ID)
 @SideOnly(Side.CLIENT)
 public class TFCKeybindings
 {
-    // todo: make category for TFC
+    private static final String tfcCatagory = "TerraFirmaCraft";
 
-    public static final KeyBinding OPEN_CRAFTING_TABLE = new KeyBinding("tfc.key.craft", KeyConflictContext.UNIVERSAL, Keyboard.KEY_C, "key.categories.inventory");
+    private static final KeyBinding OPEN_CRAFTING_TABLE = new KeyBinding("tfc.key.craft", KeyConflictContext.UNIVERSAL, Keyboard.KEY_C, tfcCatagory);
+    private static final KeyBinding PLACE_BLOCK = new KeyBinding("tfc.key.placeblock", KeyConflictContext.IN_GAME, Keyboard.KEY_V, tfcCatagory);
 
     public static void init()
     {
         ClientRegistry.registerKeyBinding(OPEN_CRAFTING_TABLE);
+        ClientRegistry.registerKeyBinding(PLACE_BLOCK);
     }
 
 
@@ -41,6 +48,11 @@ public class TFCKeybindings
         if (OPEN_CRAFTING_TABLE.isPressed())
         {
             mc.displayGuiScreen(new GuiCrafting(mc.player.inventory, mc.world));
+        }
+        if (PLACE_BLOCK.isPressed())
+        {
+            TerraFirmaCraft.getNetwork().sendToServer(
+                new PacketPlaceBlockFromKeyBind(mc.player.rayTrace(mc.player.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue(), 1).getBlockPos().up(1), BlocksTFC.ITEM_HOLDER));
         }
     }
 }

--- a/src/main/java/net/dries007/tfc/client/render/TESRItemHolder.java
+++ b/src/main/java/net/dries007/tfc/client/render/TESRItemHolder.java
@@ -1,0 +1,63 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
+package net.dries007.tfc.client.render;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.RenderItem;
+import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import net.dries007.tfc.objects.te.TEItemHolder;
+
+@SideOnly(Side.CLIENT)
+public class TESRItemHolder extends TileEntitySpecialRenderer<TEItemHolder>
+{
+    @Override
+    public void render(TEItemHolder te, double x, double y, double z, float partialTicks, int destroyStage, float alpha)
+    {
+        RenderItem renderItem = Minecraft.getMinecraft().getRenderItem();
+        World world = te.getWorld();
+        //noinspection ConstantConditions
+        if (world == null) return;
+
+        GlStateManager.pushMatrix();
+        GlStateManager.pushAttrib();
+        GlStateManager.disableLighting();
+        GlStateManager.translate(x, y, z);
+
+        GlStateManager.pushMatrix();
+        NonNullList<ItemStack> items = te.getItems();
+        float timeD = (float) (360.0 * (System.currentTimeMillis() & 0x3FFFL) / 0x3FFFL);
+        GlStateManager.scale(0.5F, 0.5F, 0.5F);
+        GlStateManager.translate(0.5, 0.5, 0.5);
+        RenderHelper.enableStandardItemLighting();
+        GlStateManager.pushAttrib();
+        for (int i = 0; i < items.size(); i++)
+        {
+            ItemStack stack = items.get(i);
+            if (stack.isEmpty()) continue;
+            GlStateManager.pushMatrix();
+            GlStateManager.translate((i % 2 == 0 ? 1 : 0), 0, (i < 2 ? 1 : 0));
+            GlStateManager.rotate(timeD, 0, 1, 0);
+            renderItem.renderItem(stack, ItemCameraTransforms.TransformType.FIXED);
+            GlStateManager.popMatrix();
+        }
+        RenderHelper.disableStandardItemLighting();
+        GlStateManager.popAttrib();
+        GlStateManager.popMatrix();
+
+
+        GlStateManager.popAttrib();
+        GlStateManager.popMatrix();
+    }
+}

--- a/src/main/java/net/dries007/tfc/network/PacketPlaceBlockFromKeyBind.java
+++ b/src/main/java/net/dries007/tfc/network/PacketPlaceBlockFromKeyBind.java
@@ -1,0 +1,90 @@
+package net.dries007.tfc.network;
+
+import java.util.Objects;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.common.network.ByteBufUtils;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
+import io.netty.buffer.ByteBuf;
+import net.dries007.tfc.TerraFirmaCraft;
+
+/**
+ * Packet to handle key press -> block place at location of the cursor.
+ *
+ * @author Claycorp
+ */
+
+public class PacketPlaceBlockFromKeyBind implements IMessage
+{
+    private BlockPos blockPos;
+    private String block;
+
+    @SuppressWarnings("unused")
+    public PacketPlaceBlockFromKeyBind()
+    {
+    }
+
+    /**
+     * Packet to handle key press -> block place at location of the cursor.
+     *
+     * @param blockposin Blockpos the block will be placed at.
+     *                   NOTE: All spacial transformations need to be done at the source as this is a direct pass through.
+     *                   It also checks for air below, if the block is within real player limits and if the spot where the
+     *                   block will be placed is replaceable.
+     * @param blockin    the block to be placed as a Block Object.
+     */
+    public PacketPlaceBlockFromKeyBind(BlockPos blockposin, Block blockin)
+    {
+        this.blockPos = blockposin;
+        this.block = Objects.requireNonNull(blockin.getRegistryName()).toString();
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf)
+    {
+        blockPos = BlockPos.fromLong(buf.readLong());
+        block = ByteBufUtils.readUTF8String(buf);
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf)
+    {
+        buf.writeLong(blockPos.toLong());
+        ByteBufUtils.writeUTF8String(buf, block);
+    }
+
+    public static class Handler implements IMessageHandler<PacketPlaceBlockFromKeyBind, IMessage>
+    {
+        @Override
+        public IMessage onMessage(PacketPlaceBlockFromKeyBind message, MessageContext ctx)
+        {
+            EntityPlayer player = TerraFirmaCraft.getProxy().getPlayer(ctx);
+            World world = player.getEntityWorld();
+            BlockPos blockPos = message.blockPos;
+            Block block = Block.getBlockFromName(message.block);
+
+            TerraFirmaCraft.getProxy().getThreadListener(ctx).addScheduledTask(() -> {
+                //sanity checks on block to stop the stupid.
+                if (block != null)
+                {
+                    //more sanity checks to stop people from placing beyond what they should be, placing in thin air and make sure they don't outright replace something that shouldn't be.
+                    if (player.getDistanceSq(blockPos) <= player.getEntityAttribute(EntityPlayer.REACH_DISTANCE).getAttributeValue() &&
+                        world.getBlockState(blockPos.down(1)) != Blocks.AIR.getDefaultState() && world.getBlockState(blockPos).getBlock().isReplaceable(world, blockPos))
+                    {
+                        //Place block.
+                        world.setBlockState(blockPos, block.getDefaultState());
+                    }
+                }
+            });
+            return null;
+        }
+    }
+}
+

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlockItemHolder.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlockItemHolder.java
@@ -1,0 +1,108 @@
+package net.dries007.tfc.objects.blocks;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumBlockRenderType;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+
+import net.dries007.tfc.objects.te.TEItemHolder;
+import net.dries007.tfc.util.Helpers;
+
+public class BlockItemHolder extends Block
+{
+    protected static final AxisAlignedBB AABB = new AxisAlignedBB(0, 0, 0, 1, 1D / 16D, 1);
+
+    public BlockItemHolder()
+    {
+        super(Material.CIRCUITS);
+        setHardness(0.5f);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isTopSolid(IBlockState state)
+    {
+        return false;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isFullCube(IBlockState state)
+    {
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public EnumBlockRenderType getRenderType(IBlockState state)
+    {
+        return EnumBlockRenderType.ENTITYBLOCK_ANIMATED;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos)
+    {
+        return AABB;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face)
+    {
+        return BlockFaceShape.UNDEFINED;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public boolean isOpaqueCube(IBlockState state)
+    {
+        return false;
+    }
+
+    @Override
+    public void breakBlock(World worldIn, BlockPos pos, IBlockState state)
+    {
+        TEItemHolder te = Helpers.getTE(worldIn, pos, TEItemHolder.class);
+        if (te != null)
+        {
+            te.onBreakBlock();
+        }
+        super.breakBlock(worldIn, pos, state);
+    }
+
+    @Override
+    public boolean onBlockActivated(World worldIn, BlockPos pos, IBlockState state, EntityPlayer playerIn, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ)
+    {
+        TEItemHolder te = Helpers.getTE(worldIn, pos, TEItemHolder.class);
+        if (te != null)
+        {
+            return te.onRightClick(playerIn, playerIn.getHeldItem(hand), hitX < 0.5, hitZ < 0.5);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean hasTileEntity(IBlockState state)
+    {
+        return true;
+    }
+
+    @Nullable
+    @Override
+    public TileEntity createTileEntity(World world, IBlockState state)
+    {
+        return new TEItemHolder();
+    }
+}

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlocksTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlocksTFC.java
@@ -104,6 +104,7 @@ public final class BlocksTFC
     public static final BlockTorchTFC TORCH = getNull();
     public static final BlockCharcoalForge CHARCOAL_FORGE = getNull();
     public static final BlockCrucible CRUCIBLE = getNull();
+    public static final BlockItemHolder ITEM_HOLDER = getNull();
 
     // All these are for use in model registration. Do not use for block lookups.
     // Use the static get methods in the classes instead.
@@ -466,6 +467,7 @@ public final class BlocksTFC
         register(r, "ingot_pile", new BlockIngotPile());
         register(r, "log_pile", new BlockLogPile());
         register(r, "pit_kiln", new BlockPitKiln());
+        register(r, "item_holder", new BlockItemHolder());
 
         // todo: pumpkin/melon ?
         // todo: fruit tree stuff (leaves, saplings, logs)
@@ -511,6 +513,7 @@ public final class BlocksTFC
         register(TECharcoalForge.class, "charcoal_forge");
         register(TEAnvilTFC.class, "anvil");
         register(TECrucible.class, "crucible");
+        register(TEItemHolder.class, "item_holder");
     }
 
     public static boolean isWater(IBlockState current)

--- a/src/main/java/net/dries007/tfc/objects/te/TEItemHolder.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEItemHolder.java
@@ -1,0 +1,122 @@
+package net.dries007.tfc.objects.te;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.InventoryHelper;
+import net.minecraft.inventory.ItemStackHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.play.server.SPacketUpdateTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+public class TEItemHolder extends TileEntity
+{
+    private final NonNullList<ItemStack> items = NonNullList.withSize(4, ItemStack.EMPTY);
+
+    @Override
+    public void readFromNBT(NBTTagCompound compound)
+    {
+        super.readFromNBT(compound);
+        ItemStackHelper.loadAllItems(compound.getCompoundTag("items"), items);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound compound)
+    {
+        super.writeToNBT(compound);
+        compound.setTag("items", ItemStackHelper.saveAllItems(new NBTTagCompound(), items));
+        return compound;
+    }
+
+    @Nullable
+    @Override
+    public SPacketUpdateTileEntity getUpdatePacket()
+    {
+        return new SPacketUpdateTileEntity(pos, 127, getUpdateTag());
+    }
+
+    @Override
+    public NBTTagCompound getUpdateTag()
+    {
+        return writeToNBT(new NBTTagCompound());
+    }
+
+    @Override
+    public void onDataPacket(NetworkManager net, SPacketUpdateTileEntity pkt)
+    {
+        readFromNBT(pkt.getNbtCompound());
+        updateBlock();
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public AxisAlignedBB getRenderBoundingBox()
+    {
+        return new AxisAlignedBB(getPos(), getPos().add(1, 1, 1));
+    }
+
+    /**
+     * @return true if an action was taken (passed back through onItemRightClick
+     */
+    public boolean onRightClick(EntityPlayer player, ItemStack stack, boolean x, boolean z)
+    {
+        final int slot = (x ? 1 : 0) + (z ? 2 : 0);
+
+        // Try and extract an item
+        if (stack.isEmpty())
+        {
+
+            // Try and grab the item
+            ItemStack current = items.get(slot);
+            if (current.isEmpty())
+            {
+                return false;
+            }
+            player.addItemStackToInventory(current.splitStack(1));
+            items.set(slot, ItemStack.EMPTY);
+            updateBlock();
+            if (items.stream().filter(ItemStack::isEmpty).count() == 4)
+            {
+                world.setBlockToAir(pos);
+            }
+            return true;
+        }
+        else
+        {
+            // Insert an item
+
+            if (items.get(slot).isEmpty())
+            {
+                items.set(slot, stack.splitStack(1));
+                updateBlock();
+                return true;
+            }
+
+        }
+        return false;
+    }
+
+    public void onBreakBlock()
+    {
+        items.forEach(i -> InventoryHelper.spawnItemStack(world, pos.getX(), pos.getY(), pos.getZ(), i));
+    }
+
+    public NonNullList<ItemStack> getItems()
+    {
+        return items;
+    }
+
+    private void updateBlock()
+    {
+        IBlockState state = world.getBlockState(pos);
+        world.notifyBlockUpdate(pos, state, state, 3); // sync TE
+        markDirty(); // make sure everything saves to disk
+    }
+}

--- a/src/main/resources/assets/tfc/lang/en_us.lang
+++ b/src/main/resources/assets/tfc/lang/en_us.lang
@@ -33,6 +33,7 @@ tfc.tooltip.time_command_disabled=This command has been disabled by TFC. Use /ti
 
 ## Keybindings
 tfc.key.craft=Crafting GUI
+tfc.key.placeblock=Place Item Holder Block
 
 ## Gui.World
 createWorld.customize.custom.spawnfuzz=Spawn Fuzzing Radius

--- a/src/main/resources/assets/tfc/models/block/empty.json
+++ b/src/main/resources/assets/tfc/models/block/empty.json
@@ -1,6 +1,7 @@
 {
   "textures": {
-      "texture": "tfc:blocks/empty"
+    "texture": "tfc:blocks/empty",
+    "particle": "tfc:blocks/empty"
   },
   "elements": [
     {


### PR DESCRIPTION
Added Item holder block that works like the pit kiln 'display'.
Placed by keybinding. Packet sent from client to server is sanity checked and shouldn't allow exploits of arbitrary block placement.
Also includes misc fixes like, adding a TFC key category and fixing breaking particles on technical blocks to be nothing instead of missing texture.

See it in action!
![https://i.imgur.com/VEXSJJs.png](https://i.imgur.com/VEXSJJs.png)