### PR TITLE
Fallable blocks should check horizontal blocks before falling trough …

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockVariantFallable.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockVariantFallable.java
@@ -86,7 +86,7 @@ public class BlockRockVariantFallable extends BlockRockVariant implements IFalli
 
             // Check if it can fall
             faces = Arrays.stream(EnumFacing.HORIZONTALS)
-                .filter(x -> shouldFall(world, pos.offset(x)))
+                .filter(x -> shouldFall(world, pos.offset(x)) && canFallThrough(world.getBlockState(pos.offset(x))))
                 .toArray(EnumFacing[]::new);
 
             if (faces.length >= 1)


### PR DESCRIPTION
…them.

Placing blocks on top of the emerald block would earlier delete the gold.

![image](https://user-images.githubusercontent.com/42100910/57570194-d04be400-73ff-11e9-9dce-57f187b2e078.png)

Also checking if I managed to get what Alcatraz mentioned in discord working.