### PR TITLE
Fixes plant inventory tinting

### DIFF
--- a/src/main/java/net/dries007/tfc/client/ClientRegisterEvents.java
+++ b/src/main/java/net/dries007/tfc/client/ClientRegisterEvents.java
@@ -301,10 +301,6 @@ public final class ClientRegisterEvents
 
         itemColors.registerItemColorHandler((stack, tintIndex) ->
                 event.getBlockColors().colorMultiplier(((ItemBlock) stack.getItem()).getBlock().getStateFromMeta(stack.getMetadata()), null, null, tintIndex),
-            BlocksTFC.getAllPlantBlocks().toArray(new BlockPlantTFC[0]));
-
-        itemColors.registerItemColorHandler((stack, tintIndex) ->
-                event.getBlockColors().colorMultiplier(((ItemBlock) stack.getItem()).getBlock().getStateFromMeta(stack.getMetadata()), null, null, tintIndex),
             BlocksTFC.getAllGrassBlocks().toArray(new BlockPlantTFC[0]));
     }
 


### PR DESCRIPTION
Should stop plant items from getting recolored in the inventory. Removed "
        itemColors.registerItemColorHandler((stack, tintIndex) ->
                event.getBlockColors().colorMultiplier(((ItemBlock) stack.getItem()).getBlock().getStateFromMeta(stack.getMetadata()), null, null, tintIndex),
            BlocksTFC.getAllPlantBlocks().toArray(new BlockPlantTFC[0]));
" at the recommendation of Konlii.