### PR TITLE
Bug fixes and enhancements

### DIFF
--- a/src/main/java/net/dries007/tfc/api/util/ITreeGenerator.java
+++ b/src/main/java/net/dries007/tfc/api/util/ITreeGenerator.java
@@ -7,13 +7,13 @@ package net.dries007.tfc.api.util;
 
 import java.util.Random;
 
-import net.minecraft.block.BlockSapling;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.structure.template.TemplateManager;
 
 import net.dries007.tfc.api.types.Tree;
 import net.dries007.tfc.objects.blocks.BlocksTFC;
+import net.dries007.tfc.objects.blocks.wood.BlockSaplingTFC;
 
 public interface ITreeGenerator
 {
@@ -64,7 +64,7 @@ public interface ITreeGenerator
 
         // Check the position for liquids, etc.
         if (world.getBlockState(pos).getMaterial().isLiquid() || !world.getBlockState(pos).getMaterial().isReplaceable())
-            if (!(world.getBlockState(pos).getBlock() instanceof BlockSapling))
+            if (!(world.getBlockState(pos).getBlock() instanceof BlockSaplingTFC))
                 return false;
 
         // Check if there is sufficient light level

--- a/src/main/java/net/dries007/tfc/client/ClientRegisterEvents.java
+++ b/src/main/java/net/dries007/tfc/client/ClientRegisterEvents.java
@@ -228,6 +228,7 @@ public final class ClientRegisterEvents
         ClientRegistry.bindTileEntitySpecialRenderer(TEBarrel.class, new TESRBarrel());
         ClientRegistry.bindTileEntitySpecialRenderer(TEAnvilTFC.class, new TESRAnvil());
         ClientRegistry.bindTileEntitySpecialRenderer(TELoom.class, new TESRLoom());
+        ClientRegistry.bindTileEntitySpecialRenderer(TECrucible.class, new TESRCrucible());
     }
 
     @SubscribeEvent

--- a/src/main/java/net/dries007/tfc/client/render/TESRCrucible.java
+++ b/src/main/java/net/dries007/tfc/client/render/TESRCrucible.java
@@ -1,0 +1,76 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
+package net.dries007.tfc.client.render;
+
+import org.lwjgl.opengl.GL11;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import net.dries007.tfc.api.types.Metal;
+import net.dries007.tfc.client.FluidSpriteCache;
+import net.dries007.tfc.objects.fluids.FluidsTFC;
+import net.dries007.tfc.objects.te.TECrucible;
+
+/**
+ * Render molten metal inside crucible
+ */
+@SideOnly(Side.CLIENT)
+public class TESRCrucible extends TileEntitySpecialRenderer<TECrucible>
+{
+
+    @Override
+    public void render(TECrucible te, double x, double y, double z, float partialTicks, int destroyStage, float alpha)
+    {
+        int amount = te.getAlloy().getAmount();
+        if (amount < 1) return;
+        Metal metal = te.getAlloyResult();
+        Fluid metalFluid = FluidsTFC.getMetalFluid(metal);
+        FluidStack moltenMetal = new FluidStack(metalFluid, amount);
+
+        GlStateManager.pushMatrix();
+        GlStateManager.translate(x, y, z);
+
+        TextureAtlasSprite sprite = FluidSpriteCache.getSprite(metalFluid);
+
+        GlStateManager.enableAlpha();
+        GlStateManager.enableBlend();
+        GlStateManager.tryBlendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+
+        int color = metalFluid.getColor();
+
+        float r = ((color >> 16) & 0xFF) / 255F;
+        float g = ((color >> 8) & 0xFF) / 255F;
+        float b = (color & 0xFF) / 255F;
+        float a = ((color >> 24) & 0xFF) / 255F;
+
+        GlStateManager.color(r, g, b, a);
+
+        rendererDispatcher.renderEngine.bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+
+        BufferBuilder buffer = Tessellator.getInstance().getBuffer();
+        buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_NORMAL);
+
+        double height = 0.140625D + (0.75D - 0.015625D) * amount / TECrucible.CRUCIBLE_MAX_METAL_FLUID;
+
+        buffer.pos(0.1875D, height, 0.1875D).tex(sprite.getInterpolatedU(3), sprite.getInterpolatedV(3)).normal(0, 0, 1).endVertex();
+        buffer.pos(0.1875D, height, 0.8125D).tex(sprite.getInterpolatedU(3), sprite.getInterpolatedV(13)).normal(0, 0, 1).endVertex();
+        buffer.pos(0.8125D, height, 0.8125D).tex(sprite.getInterpolatedU(13), sprite.getInterpolatedV(13)).normal(0, 0, 1).endVertex();
+        buffer.pos(0.8125D, height, 0.1875D).tex(sprite.getInterpolatedU(13), sprite.getInterpolatedV(3)).normal(0, 0, 1).endVertex();
+
+        Tessellator.getInstance().draw();
+
+        GlStateManager.popMatrix();
+    }
+}

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlockFluidTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlockFluidTFC.java
@@ -6,10 +6,13 @@
 package net.dries007.tfc.objects.blocks;
 
 import java.util.Random;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -18,8 +21,10 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import net.dries007.tfc.Constants;
 import net.dries007.tfc.objects.fluids.FluidsTFC;
 
+@ParametersAreNonnullByDefault
 public class BlockFluidTFC extends BlockFluidClassic
 {
     public BlockFluidTFC(Fluid fluid, Material material, boolean canCreateSources)
@@ -35,6 +40,21 @@ public class BlockFluidTFC extends BlockFluidClassic
         if (definedFluid == FluidsTFC.HOT_WATER && rand.nextInt(4) == 0)
         {
             worldIn.spawnParticle(EnumParticleTypes.WATER_BUBBLE, (double) (pos.getX() + rand.nextFloat()), pos.getY() + 0.50D, (double) (pos.getZ() + rand.nextFloat()), 0.0D, 0.0D, 0.0D, Block.getStateId(stateIn));
+        }
+    }
+
+    @Override
+    public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn)
+    {
+        super.onEntityCollision(worldIn, pos, state, entityIn);
+        if (definedFluid == FluidsTFC.HOT_WATER && entityIn instanceof EntityLivingBase)
+        {
+            EntityLivingBase e = ((EntityLivingBase) entityIn);
+            if (Constants.RNG.nextInt(25) == 0 && e.getHealth() < e.getMaxHealth())
+            {
+                float healing = (e.getMaxHealth() - e.getHealth()) * 0.01f;
+                e.heal(Math.max(healing, 0.05f));
+            }
         }
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlockPlacedItem.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlockPlacedItem.java
@@ -131,7 +131,7 @@ public class BlockPlacedItem extends Block
             // Check for pit kiln conversion
             if (!playerIn.isSneaking() && (OreDictionaryHelper.doesStackMatchOre(stack, "straw") || OreDictionaryHelper.doesStackMatchOre(stack, "blockStraw")))
             {
-                TEPitKiln.convertPlacedItemToPitKiln(worldIn, pos, stack);
+                TEPitKiln.convertPlacedItemToPitKiln(worldIn, pos, stack.splitStack(1));
                 return true;
             }
             return te.onRightClick(playerIn, playerIn.getHeldItem(hand), hitX < 0.5, hitZ < 0.5);

--- a/src/main/java/net/dries007/tfc/objects/entity/animal/EntityAnimalTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/entity/animal/EntityAnimalTFC.java
@@ -252,6 +252,13 @@ public abstract class EntityAnimalTFC extends EntityAnimal
         return this.getAge() == Age.CHILD;
     }
 
+    @Override
+    public void setScaleForAge(boolean child)
+    {
+        float ageScale = 1 / (2.0F - getPercentToAdulthood());
+        this.setScale(ageScale);
+    }
+
     /**
      * Used by models renderer to scale the size of the animal
      *

--- a/src/main/java/net/dries007/tfc/objects/entity/animal/EntityDeerTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/entity/animal/EntityDeerTFC.java
@@ -49,7 +49,7 @@ public class EntityDeerTFC extends EntityAnimalMammal implements IAnimalTFC
     public EntityDeerTFC(World worldIn, Gender gender, int birthDay)
     {
         super(worldIn, gender, birthDay);
-        this.setSize(0.9F, 1.3F);
+        this.setSize(1.3F, 1.9F);
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
@@ -130,6 +130,11 @@ public class ItemSmallVessel extends ItemFiredPottery
             Alloy alloy = new Alloy().add(cap);
             if (alloy.isValid())
             {
+                //Empty contents
+                for (int i = 0; i < cap.getSlots(); i++)
+                {
+                    cap.extractItem(i, cap.getStackInSlot(i).getCount(), false);
+                }
                 // Fill with the liquid metal
                 cap.setFluidMode(true);
                 cap.fill(new FluidStack(FluidsTFC.getMetalFluid(alloy.getResult()), alloy.getAmount()), true);

--- a/src/main/java/net/dries007/tfc/objects/te/TECharcoalForge.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TECharcoalForge.java
@@ -21,6 +21,8 @@ import net.dries007.tfc.ConfigTFC;
 import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.api.capability.heat.CapabilityItemHeat;
 import net.dries007.tfc.api.capability.heat.IItemHeat;
+import net.dries007.tfc.api.recipes.PitKilnRecipe;
+import net.dries007.tfc.api.types.Metal;
 import net.dries007.tfc.api.util.IHeatConsumerBlock;
 import net.dries007.tfc.objects.recipes.heat.HeatRecipe;
 import net.dries007.tfc.objects.recipes.heat.HeatRecipeManager;
@@ -145,7 +147,7 @@ public class TECharcoalForge extends TEInventory implements ITickable, ITileFiel
 
             // Update items in slots
             // Loop through input + 2 output slots
-            for (int i = SLOT_INPUT_MIN; i <= SLOT_EXTRA_MAX; i++)
+            for (int i = SLOT_INPUT_MIN; i <= SLOT_INPUT_MAX; i++)
             {
                 ItemStack stack = inventory.getStackInSlot(i);
                 IItemHeat cap = stack.getCapability(CapabilityItemHeat.ITEM_HEAT_CAPABILITY, null);
@@ -158,9 +160,16 @@ public class TECharcoalForge extends TEInventory implements ITickable, ITileFiel
                         CapabilityItemHeat.addTemp(cap);
                     }
 
-                    // This will melt + consume the input stack
-                    // Output stacks are assumed to not melt (see the case of ceramic molds in the output)
-                    if (cap.isMolten() && i <= SLOT_INPUT_MAX)
+                    PitKilnRecipe recipe = PitKilnRecipe.get(stack);
+                    if (recipe != null)
+                    {
+                        //Found a pit kiln recipe for this, let's use it
+                        if (itemTemp >= 1599f) //Brilliant white
+                        {
+                            inventory.setStackInSlot(i, recipe.getOutput(stack, Metal.Tier.TIER_I));
+                        }
+                    }
+                    else if (cap.isMolten())
                     {
                         handleInputMelting(stack, i);
                     }

--- a/src/main/java/net/dries007/tfc/objects/te/TEFirePit.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEFirePit.java
@@ -20,6 +20,8 @@ import net.dries007.tfc.ConfigTFC;
 import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.api.capability.heat.CapabilityItemHeat;
 import net.dries007.tfc.api.capability.heat.IItemHeat;
+import net.dries007.tfc.api.recipes.PitKilnRecipe;
+import net.dries007.tfc.api.types.Metal;
 import net.dries007.tfc.objects.recipes.heat.HeatRecipe;
 import net.dries007.tfc.objects.recipes.heat.HeatRecipeManager;
 import net.dries007.tfc.util.fuel.Fuel;
@@ -126,9 +128,16 @@ public class TEFirePit extends TEInventory implements ITickable, ITileFields
                         CapabilityItemHeat.addTemp(cap);
                     }
 
-                    // This will melt + consume the input stack
-                    // Output stacks are assumed to not melt (see the case of ceramic molds in the output)
-                    if (cap.isMolten() && i == SLOT_ITEM_INPUT)
+                    PitKilnRecipe recipe = PitKilnRecipe.get(stack);
+                    if (recipe != null)
+                    {
+                        //Found a pit kiln recipe for this, let's use it
+                        if (itemTemp >= 1599f) //Brilliant white
+                        {
+                            inventory.setStackInSlot(i, recipe.getOutput(stack, Metal.Tier.TIER_I));
+                        }
+                    }
+                    else if (cap.isMolten() && i == SLOT_ITEM_INPUT)
                     {
                         handleInputMelting(stack);
                     }
@@ -182,7 +191,7 @@ public class TEFirePit extends TEInventory implements ITickable, ITileFields
         switch (slot)
         {
             case SLOT_FUEL_INPUT: // Valid fuel if it is registered correctly
-                return FuelManager.isItemFuel(stack);
+                return FuelManager.isItemFuel(stack) && !FuelManager.isItemForgeFuel(stack);
             case SLOT_ITEM_INPUT: // Valid input as long as it can be heated
                 return stack.hasCapability(CapabilityItemHeat.ITEM_HEAT_CAPABILITY, null);
             case SLOT_OUTPUT_1:

--- a/src/main/java/net/dries007/tfc/world/classic/BiomeProviderTFC.java
+++ b/src/main/java/net/dries007/tfc/world/classic/BiomeProviderTFC.java
@@ -5,20 +5,26 @@
 
 package net.dries007.tfc.world.classic;
 
-import java.util.Collections;
 import java.util.List;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+import com.google.common.collect.Lists;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldType;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeProvider;
 import net.minecraft.world.gen.layer.GenLayer;
 
+import mcp.MethodsReturnNonnullByDefault;
 import net.dries007.tfc.world.classic.biomes.BiomesTFC;
 import net.dries007.tfc.world.classic.genlayers.GenLayerTFC;
 
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
 public class BiomeProviderTFC extends BiomeProvider
 {
+    private List<Biome> biomesToSpawnIn;
+
     public BiomeProviderTFC(World world)
     {
         super(world.getWorldInfo());
@@ -26,15 +32,19 @@ public class BiomeProviderTFC extends BiomeProvider
         if (!(world.getWorldType() instanceof WorldTypeTFC))
             throw new RuntimeException("Terrible things have gone wrong here.");
 
-        List<Biome> biomesToSpawnIn = getBiomesToSpawnIn();
-        biomesToSpawnIn.clear();
-        Collections.addAll(biomesToSpawnIn, BiomesTFC.getPlayerSpawnBiomes());
+        biomesToSpawnIn = Lists.newArrayList(BiomesTFC.getPlayerSpawnBiomes());
     }
 
     @Override
     public float getTemperatureAtHeight(float p_76939_1_, int p_76939_2_)
     {
         return super.getTemperatureAtHeight(p_76939_1_, p_76939_2_);
+    }
+
+    @Override
+    public List<Biome> getBiomesToSpawnIn()
+    {
+        return biomesToSpawnIn;
     }
 
     /**

--- a/src/main/java/net/dries007/tfc/world/classic/biomes/BiomeTFC.java
+++ b/src/main/java/net/dries007/tfc/world/classic/biomes/BiomeTFC.java
@@ -16,6 +16,7 @@ public class BiomeTFC extends Biome
 {
     public final int waterPlantsPerChunk;
     public final int lilyPadPerChunk;
+    private boolean canBeSpawn;
 
     public BiomeTFC(BiomeProperties properties)
     {
@@ -39,6 +40,7 @@ public class BiomeTFC extends Biome
         this.spawnableCreatureList.add(new Biome.SpawnListEntry(EntityDeerTFC.class, 14, 2, 4));
         this.spawnableCreatureList.add(new Biome.SpawnListEntry(EntityPheasantTFC.class, 14, 2, 4));
         this.spawnableCreatureList.add(new Biome.SpawnListEntry(EntityBearTFC.class, 4, 1, 2));
+        canBeSpawn = false;
     }
 
     @Override
@@ -53,5 +55,17 @@ public class BiomeTFC extends Biome
     {
         // todo: Forge event wrap this
         return new BiomeDecoratorTFC(lilyPadPerChunk, waterPlantsPerChunk);
+    }
+
+    public Biome setCanBeSpawn()
+    {
+        this.canBeSpawn = true;
+        return this;
+    }
+
+    @Override
+    public boolean ignorePlayerSpawnSuitability()
+    {
+        return canBeSpawn;
     }
 }

--- a/src/main/java/net/dries007/tfc/world/classic/biomes/BiomesTFC.java
+++ b/src/main/java/net/dries007/tfc/world/classic/biomes/BiomesTFC.java
@@ -50,13 +50,13 @@ public final class BiomesTFC
         register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Beach").setBaseHeight(-2.69f).setHeightVariation(-2.68f), 0, 16), BiomeDictionary.Type.BEACH);
         register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Gravel Beach").setBaseHeight(-2.69f).setHeightVariation(-2.68f).setBaseBiome("tfc:beach"), 0, 16), BiomeDictionary.Type.BEACH);
         register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills").setBaseHeight(-1.9000001f).setHeightVariation(-1.1f), 0, 8), BiomeDictionary.Type.HILLS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Plains").setBaseHeight(-2.6000001f).setHeightVariation(-2.54f), 1, 16), BiomeDictionary.Type.PLAINS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Swampland").setBaseHeight(-2.8f).setHeightVariation(-2.6000001f), 64, 64), BiomeDictionary.Type.SWAMP);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Plains").setBaseHeight(-2.6000001f).setHeightVariation(-2.54f), 1, 16).setCanBeSpawn(), BiomeDictionary.Type.PLAINS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Swampland").setBaseHeight(-2.8f).setHeightVariation(-2.6000001f), 64, 64).setCanBeSpawn(), BiomeDictionary.Type.SWAMP);
         register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills Edge").setBaseHeight(-2.5f).setHeightVariation(-2.3f).setBaseBiome("tfc:high_hills"), 0, 8), BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Rolling Hills").setBaseHeight(-2.6000001f).setHeightVariation(-2.3f), 1, 16), BiomeDictionary.Type.HILLS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains").setBaseHeight(-1.9000001f).setHeightVariation(-1.1f)), BiomeDictionary.Type.MOUNTAIN);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Rolling Hills").setBaseHeight(-2.6000001f).setHeightVariation(-2.3f), 1, 16).setCanBeSpawn(), BiomeDictionary.Type.HILLS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains").setBaseHeight(-1.9000001f).setHeightVariation(-1.1f)).setCanBeSpawn(), BiomeDictionary.Type.MOUNTAIN);
         register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains Edge").setBaseHeight(-2.3f).setHeightVariation(-1.9000001f).setBaseBiome("tfc:mountains"), 0, 4), BiomeDictionary.Type.MOUNTAIN);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Plains").setBaseHeight(-2.3f).setHeightVariation(-2.27f), 1, 16), BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Plains").setBaseHeight(-2.3f).setHeightVariation(-2.27f), 1, 16).setCanBeSpawn(), BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
         register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Deep Ocean").setBaseHeight(-3.5f).setHeightVariation(-2.69999f).setBaseBiome("tfc:ocean"), 1, 16), BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
         register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Lake").setBaseHeight(-3.2f).setHeightVariation(-2.6990001f).setBaseBiome("tfc:ocean"), 1, 16), BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
 

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenLooseRocks.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenLooseRocks.java
@@ -39,6 +39,9 @@ public class WorldGenLooseRocks implements IWorldGenerator
         // Check dimension is overworld
         if (world.provider.getDimension() != 0) return;
 
+        // Set constant values here
+        int xoff = chunkX * 16 + 8;
+        int zoff = chunkZ * 16 + 8;
         // Get the proper list of veins
         List<Vein> veins = WorldGenOreVeins.getNearbyVeins(chunkX, chunkZ, world.getSeed(), 1);
         if (!veins.isEmpty())
@@ -48,14 +51,13 @@ public class WorldGenLooseRocks implements IWorldGenerator
 
                 int minScanY = (WorldTypeTFC.ROCKLAYER2 + WorldTypeTFC.ROCKLAYER3) / 2;
                 int maxScanY = WorldTypeTFC.SEALEVEL + chunkData.getSeaLevelOffset(v.pos);
-                return v.pos.getY() <= minScanY || v.pos.getY() >= maxScanY || !v.type.baseRocks.contains(chunkData.getRock1(0, 0));
-
+                for (BlockPos.MutableBlockPos pos : BlockPos.getAllInBoxMutable(xoff, minScanY, zoff, xoff + 15, maxScanY, zoff))
+                {
+                    if (v.type.isOreBlock(world.getBlockState(pos))) return false;
+                }
+                return true;
             });
         }
-
-        // Set constant values here
-        int xoff = chunkX * 16 + 8;
-        int zoff = chunkZ * 16 + 8;
 
         for (int i = 0; i < 12; i++)
         {

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenLooseRocks.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenLooseRocks.java
@@ -51,7 +51,7 @@ public class WorldGenLooseRocks implements IWorldGenerator
 
                 int minScanY = (WorldTypeTFC.ROCKLAYER2 + WorldTypeTFC.ROCKLAYER3) / 2;
                 int maxScanY = WorldTypeTFC.SEALEVEL + chunkData.getSeaLevelOffset(v.pos);
-                for (BlockPos.MutableBlockPos pos : BlockPos.getAllInBoxMutable(xoff, minScanY, zoff, xoff + 15, maxScanY, zoff))
+                for (BlockPos.MutableBlockPos pos : BlockPos.getAllInBoxMutable(xoff, minScanY, zoff, xoff + 15, maxScanY, zoff + 15))
                 {
                     if (v.type.isOreBlock(world.getBlockState(pos))) return false;
                 }

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenLooseRocks.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenLooseRocks.java
@@ -10,7 +10,6 @@ import java.util.Random;
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.IChunkProvider;
@@ -74,7 +73,7 @@ public class WorldGenLooseRocks implements IWorldGenerator
     {
         // Use air, so it doesn't replace other replaceable world gen
         // This matches the check in BlockPlacedItemFlat for if the block can stay
-        if (world.isAirBlock(pos) && world.getBlockState(pos.down()).isSideSolid(world, pos.down(), EnumFacing.UP))
+        if (world.isAirBlock(pos) && world.getBlockState(pos.down()).isFullBlock())
         {
             world.setBlockState(pos, BlocksTFC.PLACED_ITEM_FLAT.getDefaultState(), 2);
             TEPlacedItemFlat tile = Helpers.getTE(world, pos, TEPlacedItemFlat.class);

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/fissure/WorldGenFissure.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/fissure/WorldGenFissure.java
@@ -11,6 +11,7 @@ import java.util.Random;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
@@ -80,8 +81,7 @@ public class WorldGenFissure implements IWorldGenerator
         if (checkStability && stable)
             return;
 
-        int creviceDepth = 1;
-        if (rng.nextInt(100) < 50) creviceDepth += 2 + rng.nextInt(8);
+        int creviceDepth = 3 + rng.nextInt(5);
 
         int poolDepth = 1 + rng.nextInt(Math.max(creviceDepth - 1, 1));
 
@@ -93,7 +93,7 @@ public class WorldGenFissure implements IWorldGenerator
         final IBlockState rock = BlockRockVariant.get(getRock3(world, start), Rock.Type.RAW).getDefaultState();
         final IBlockState localFillBlock = (!stable && BlocksTFC.isWater(fillBlock)) ? ChunkGenTFC.HOT_WATER : fillBlock;
 
-        List<BlockPos> list = getCollapseMap(world, start.add(0, -creviceDepth, 0), fillBlock, poolDepth);
+        List<BlockPos> list = getCollapseMap(world, start, fillBlock, poolDepth);
 
         for (BlockPos pos : list)
         {
@@ -217,22 +217,12 @@ public class WorldGenFissure implements IWorldGenerator
 
     private void fill(World world, BlockPos pos, IBlockState rock, IBlockState fillBlock)
     {
-        // todo: check if this should even update the blocks (flags = 3 means update) I think this only causes lag. (if not also replace `setBlockToAir`)
-        world.setBlockState(pos, fillBlock, 2);
-        BlockPos p = pos.add(-1, 0, 0);
-        if (world.isAirBlock(p)) world.setBlockState(p, rock, 3);
-        p = pos.add(-1, 0, 0);
-        if (world.isAirBlock(p)) world.setBlockState(p, rock, 3);
-        p = pos.add(1, 0, 0);
-        if (world.isAirBlock(p)) world.setBlockState(p, rock, 3);
-        p = pos.add(0, 0, -1);
-        if (world.isAirBlock(p)) world.setBlockState(p, rock, 3);
-        p = pos.add(0, 0, 1);
-        if (world.isAirBlock(p)) world.setBlockState(p, rock, 3);
-        p = pos.add(0, -1, 0);
-        if (world.isAirBlock(p)) world.setBlockState(p, rock, 3);
-        p = pos.add(0, 1, 0);
-        if (world.isAirBlock(p)) world.setBlockState(p, rock, 3);
+        world.setBlockState(pos, fillBlock);
+        for (EnumFacing facing : EnumFacing.VALUES)
+        {
+            if (facing == EnumFacing.UP || world.getBlockState(pos.offset(facing)) == fillBlock) continue;
+            world.setBlockState(pos.offset(facing), rock);
+        }
     }
 
 

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenAcacia.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenAcacia.java
@@ -25,6 +25,7 @@ import net.dries007.tfc.api.types.Tree;
 import net.dries007.tfc.api.util.ITreeGenerator;
 import net.dries007.tfc.objects.blocks.wood.BlockLeavesTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockLogTFC;
+import net.dries007.tfc.objects.blocks.wood.BlockSaplingTFC;
 import net.dries007.tfc.world.classic.StructureHelper;
 
 import static net.dries007.tfc.objects.blocks.wood.BlockLogTFC.PLACED;
@@ -100,7 +101,7 @@ public class TreeGenAcacia implements ITreeGenerator
 
     private void placeLog(World world, BlockPos pos, boolean useBark)
     {
-        if (world.getBlockState(pos).getMaterial().isReplaceable() || world.getBlockState(pos).getBlock() instanceof BlockLeavesTFC)
+        if (world.getBlockState(pos).getMaterial().isReplaceable() || world.getBlockState(pos).getBlock() instanceof BlockSaplingTFC || world.getBlockState(pos).getBlock() instanceof BlockLeavesTFC)
             world.setBlockState(pos, useBark ? bark : trunk);
     }
 }

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenBushes.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenBushes.java
@@ -8,7 +8,6 @@ package net.dries007.tfc.world.classic.worldgen.trees;
 import java.util.Random;
 
 import net.minecraft.block.BlockLog;
-import net.minecraft.block.BlockSapling;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
@@ -20,6 +19,7 @@ import net.dries007.tfc.api.util.ITreeGenerator;
 import net.dries007.tfc.objects.blocks.BlocksTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockLeavesTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockLogTFC;
+import net.dries007.tfc.objects.blocks.wood.BlockSaplingTFC;
 
 import static net.dries007.tfc.objects.blocks.wood.BlockLogTFC.PLACED;
 import static net.minecraft.block.BlockLeaves.DECAYABLE;
@@ -61,7 +61,7 @@ public class TreeGenBushes implements ITreeGenerator
 
         // Check the position for liquids, etc.
         if (world.getBlockState(pos).getMaterial().isLiquid() || !world.getBlockState(pos).getMaterial().isReplaceable())
-            if (!(world.getBlockState(pos) instanceof BlockSapling))
+            if (!(world.getBlockState(pos) instanceof BlockSaplingTFC))
                 return false;
 
         // Check if there is sufficient light level

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenKapok.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenKapok.java
@@ -24,6 +24,7 @@ import net.dries007.tfc.api.util.ITreeGenerator;
 import net.dries007.tfc.objects.blocks.BlocksTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockLeavesTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockLogTFC;
+import net.dries007.tfc.objects.blocks.wood.BlockSaplingTFC;
 import net.dries007.tfc.world.classic.StructureHelper;
 
 import static net.dries007.tfc.objects.blocks.wood.BlockLogTFC.PLACED;
@@ -126,7 +127,7 @@ public class TreeGenKapok implements ITreeGenerator
 
     private void checkAndPlace(World world, BlockPos pos, boolean useBark)
     {
-        if (world.getBlockState(pos).getMaterial().isReplaceable() || world.getBlockState(pos).getBlock() instanceof BlockLeavesTFC)
+        if (world.getBlockState(pos).getMaterial().isReplaceable() || world.getBlockState(pos).getBlock() instanceof BlockSaplingTFC || world.getBlockState(pos).getBlock() instanceof BlockLeavesTFC)
             world.setBlockState(pos, useBark ? bark : trunk);
     }
 

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenSequoia.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenSequoia.java
@@ -21,6 +21,7 @@ import net.dries007.tfc.api.util.ITreeGenerator;
 import net.dries007.tfc.objects.blocks.BlocksTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockLeavesTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockLogTFC;
+import net.dries007.tfc.objects.blocks.wood.BlockSaplingTFC;
 import net.dries007.tfc.world.classic.StructureHelper;
 
 import static net.dries007.tfc.objects.blocks.wood.BlockLogTFC.PLACED;
@@ -69,7 +70,7 @@ public class TreeGenSequoia implements ITreeGenerator
     {
         for (BlockPos p1 : OFFSETS)
         {
-            if (!BlocksTFC.isSoil(world.getBlockState(pos.add(p1))))
+            if (!BlocksTFC.isSoil(world.getBlockState(pos.add(p1).down())))
             {
                 if (world.getBlockState(pos.add(p1)).getMaterial().isReplaceable())
                 {
@@ -112,7 +113,7 @@ public class TreeGenSequoia implements ITreeGenerator
 
     private void checkAndPlace(World world, BlockPos pos)
     {
-        if (world.getBlockState(pos).getMaterial().isReplaceable() || world.getBlockState(pos).getBlock() instanceof BlockLeavesTFC)
+        if (world.getBlockState(pos).getMaterial().isReplaceable() || world.getBlockState(pos).getBlock() instanceof BlockSaplingTFC || world.getBlockState(pos).getBlock() instanceof BlockLeavesTFC)
         {
             world.setBlockState(pos, trunk);
         }

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenWillow.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/trees/TreeGenWillow.java
@@ -21,6 +21,7 @@ import net.dries007.tfc.api.util.ITreeGenerator;
 import net.dries007.tfc.api.util.TFCConstants;
 import net.dries007.tfc.objects.blocks.wood.BlockLeavesTFC;
 import net.dries007.tfc.objects.blocks.wood.BlockLogTFC;
+import net.dries007.tfc.objects.blocks.wood.BlockSaplingTFC;
 import net.dries007.tfc.world.classic.StructureHelper;
 
 import static net.dries007.tfc.objects.blocks.wood.BlockLogTFC.PLACED;
@@ -100,7 +101,7 @@ public class TreeGenWillow implements ITreeGenerator
 
     private void tryPlaceLog(World world, BlockPos pos, Tree tree, BlockLog.EnumAxis axis)
     {
-        if (world.getBlockState(pos).getMaterial().isReplaceable() || world.getBlockState(pos).getBlock() instanceof BlockLeavesTFC)
+        if (world.getBlockState(pos).getMaterial().isReplaceable() || world.getBlockState(pos).getBlock() instanceof BlockSaplingTFC || world.getBlockState(pos).getBlock() instanceof BlockLeavesTFC)
             world.setBlockState(pos, BlockLogTFC.get(tree).getDefaultState().withProperty(LOG_AXIS, axis).withProperty(PLACED, false));
     }
 }


### PR DESCRIPTION
Some bug fixes and enhancements

Enhancements:
Crucible now shows molten metal, like Barrel shows liquid.
Fissures now fill up properly
Fire pits and charcoal forge can work on pit kiln recipes if the temp rises to Brilliant White.

Closes #46 fixed by overriding `ignorePlayerSpawnSuitability()` in spawnable biomes
Closes #97 fixed by checking for full blocks below placed item
Closes #175 now checks if at least one ore block has generated in chunk
Closes #187 found a way to properly handle child hitboxes
Closes #196 added missing feature
Closes #202 fixed by using correct instanceof reference. Also, fixed missing log placement on the sapling itself when tree grows
Closes #203 
Closes #206 