### PR TITLE
Fluid Rewrite

### DIFF
--- a/src/main/java/net/dries007/tfc/api/recipes/heat/HeatRecipeMetalMelting.java
+++ b/src/main/java/net/dries007/tfc/api/recipes/heat/HeatRecipeMetalMelting.java
@@ -57,7 +57,7 @@ public class HeatRecipeMetalMelting extends HeatRecipe
             Metal metal = metalObject.getMetal(input);
             if (metal != null && metalObject.canMelt(input))
             {
-                return new FluidStack(FluidsTFC.getMetalFluid(metal), metalObject.getSmeltAmount(input));
+                return new FluidStack(FluidsTFC.getFluidFromMetal(metal), metalObject.getSmeltAmount(input));
             }
         }
         return null;

--- a/src/main/java/net/dries007/tfc/client/render/TESRCrucible.java
+++ b/src/main/java/net/dries007/tfc/client/render/TESRCrucible.java
@@ -14,7 +14,6 @@ import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -29,15 +28,13 @@ import net.dries007.tfc.objects.te.TECrucible;
 @SideOnly(Side.CLIENT)
 public class TESRCrucible extends TileEntitySpecialRenderer<TECrucible>
 {
-
     @Override
     public void render(TECrucible te, double x, double y, double z, float partialTicks, int destroyStage, float alpha)
     {
         int amount = te.getAlloy().getAmount();
         if (amount < 1) return;
         Metal metal = te.getAlloyResult();
-        Fluid metalFluid = FluidsTFC.getMetalFluid(metal);
-        FluidStack moltenMetal = new FluidStack(metalFluid, amount);
+        Fluid metalFluid = FluidsTFC.getFluidFromMetal(metal);
 
         GlStateManager.pushMatrix();
         GlStateManager.translate(x, y, z);

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlockFluidTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlockFluidTFC.java
@@ -38,7 +38,7 @@ public class BlockFluidTFC extends BlockFluidClassic
     @Override
     public void randomDisplayTick(IBlockState stateIn, World worldIn, BlockPos pos, Random rand)
     {
-        if (definedFluid == FluidsTFC.HOT_WATER && rand.nextInt(4) == 0)
+        if (definedFluid == FluidsTFC.HOT_WATER.get() && rand.nextInt(4) == 0)
         {
             worldIn.spawnParticle(EnumParticleTypes.WATER_BUBBLE, (double) (pos.getX() + rand.nextFloat()), pos.getY() + 0.50D, (double) (pos.getZ() + rand.nextFloat()), 0.0D, 0.0D, 0.0D, Block.getStateId(stateIn));
         }
@@ -48,7 +48,7 @@ public class BlockFluidTFC extends BlockFluidClassic
     public void onEntityCollision(World worldIn, BlockPos pos, IBlockState state, Entity entityIn)
     {
         super.onEntityCollision(worldIn, pos, state, entityIn);
-        if (definedFluid == FluidsTFC.HOT_WATER && entityIn instanceof EntityLivingBase)
+        if (definedFluid == FluidsTFC.HOT_WATER.get() && entityIn instanceof EntityLivingBase)
         {
             EntityLivingBase entityLiving = (EntityLivingBase) entityIn;
             if (Constants.RNG.nextInt(10) == 0 && entityLiving.getHealth() < entityLiving.getMaxHealth())

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlocksTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlocksTFC.java
@@ -16,7 +16,6 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.BlockFluidBase;
-import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.registry.GameRegistry;
@@ -34,6 +33,7 @@ import net.dries007.tfc.objects.blocks.plants.BlockPlantTFC;
 import net.dries007.tfc.objects.blocks.stone.*;
 import net.dries007.tfc.objects.blocks.wood.*;
 import net.dries007.tfc.objects.fluids.FluidsTFC;
+import net.dries007.tfc.objects.fluids.properties.FluidWrapper;
 import net.dries007.tfc.objects.items.itemblock.*;
 import net.dries007.tfc.objects.te.*;
 import net.dries007.tfc.util.agriculture.BerryBush;
@@ -331,14 +331,34 @@ public final class BlocksTFC
 
         {
             Builder<BlockFluidBase> b = ImmutableList.builder();
-            for (Fluid fluid : FluidsTFC.getAllInfiniteFluids())
-                b.add(register(r, "fluid/" + fluid.getName(), new BlockFluidTFC(fluid, Material.WATER, true)));
-            for (Fluid fluid : FluidsTFC.getAllAlcoholsFluids())
-                b.add(register(r, "fluid/" + fluid.getName(), new BlockFluidTFC(fluid, FluidsTFC.MATERIAL_ALCOHOL, false)));
-            for (Fluid fluid : FluidsTFC.getAllOtherFiniteFluids())
-                b.add(register(r, "fluid/" + fluid.getName(), new BlockFluidTFC(fluid, Material.WATER, false)));
-            for (Fluid fluid : FluidsTFC.getAllMetalFluids())
-                b.add(register(r, "fluid/" + fluid.getName(), new BlockFluidTFC(fluid, Material.LAVA, false)));
+            for (FluidWrapper wrapper : FluidsTFC.getAllInfiniteFluids())
+            {
+                if (wrapper.isDefault())
+                {
+                    b.add(register(r, "fluid/" + wrapper.get().getName(), new BlockFluidTFC(wrapper.get(), Material.WATER, true)));
+                }
+            }
+            for (FluidWrapper wrapper : FluidsTFC.getAllAlcoholsFluids())
+            {
+                if (wrapper.isDefault())
+                {
+                    b.add(register(r, "fluid/" + wrapper.get().getName(), new BlockFluidTFC(wrapper.get(), FluidsTFC.MATERIAL_ALCOHOL, false)));
+                }
+            }
+            for (FluidWrapper wrapper : FluidsTFC.getAllOtherFiniteFluids())
+            {
+                if (wrapper.isDefault())
+                {
+                    b.add(register(r, "fluid/" + wrapper.get().getName(), new BlockFluidTFC(wrapper.get(), Material.WATER, false)));
+                }
+            }
+            for (FluidWrapper wrapper : FluidsTFC.getAllMetalFluids())
+            {
+                if (wrapper.isDefault())
+                {
+                    b.add(register(r, "fluid/" + wrapper.get().getName(), new BlockFluidTFC(wrapper.get(), Material.LAVA, false)));
+                }
+            }
             allFluidBlocks = b.build();
         }
 

--- a/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
@@ -112,13 +112,13 @@ public final class FluidsTFC
     {
         allInfiniteFluids = ImmutableSet.<FluidWrapper>builder()
             .add(
-                HOT_WATER = registerFluid(new Fluid("hot_water", STILL, FLOW, 0xFF345FDA).setTemperature(350), (fluid, isDefault) -> new DrinkableFluidWrapper(fluid, isDefault, player -> {
+                FRESH_WATER = registerFluid(new Fluid("fresh_water", STILL, FLOW, 0xFF1F32DA), (fluid, isDefault) -> new DrinkableFluidWrapper(fluid, isDefault, player -> {
                     if (player.getFoodStats() instanceof FoodStatsTFC)
                     {
                         ((FoodStatsTFC) player.getFoodStats()).addThirst(40);
                     }
                 })),
-                FRESH_WATER = registerFluid(new Fluid("fresh_water", STILL, FLOW, 0xFF1F32DA)),
+                HOT_WATER = registerFluid(new Fluid("hot_water", STILL, FLOW, 0xFF345FDA).setTemperature(350)),
                 registerFluid(new Fluid("salt_water", STILL, FLOW, 0xFF1F5099), (fluid, isDefault) -> new DrinkableFluidWrapper(fluid, isDefault, player -> {
                     if (player.getFoodStats() instanceof FoodStatsTFC)
                     {

--- a/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
@@ -5,147 +5,194 @@
 
 package net.dries007.tfc.objects.fluids;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.material.MaterialLiquid;
+import net.minecraft.init.MobEffects;
 import net.minecraft.item.EnumRarity;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 
+import net.dries007.tfc.Constants;
+import net.dries007.tfc.api.capability.food.FoodStatsTFC;
 import net.dries007.tfc.api.registries.TFCRegistries;
 import net.dries007.tfc.api.types.Metal;
+import net.dries007.tfc.objects.fluids.properties.DrinkableFluidWrapper;
+import net.dries007.tfc.objects.fluids.properties.FluidWrapper;
+import net.dries007.tfc.objects.fluids.properties.MetalFluidWrapper;
 
 import static net.dries007.tfc.api.util.TFCConstants.MOD_ID;
 
-public class FluidsTFC
+public final class FluidsTFC
 {
     public static final Material MATERIAL_ALCOHOL = new MaterialLiquid(MapColor.WATER);
 
     private static final ResourceLocation STILL = new ResourceLocation(MOD_ID, "blocks/fluid_still");
     private static final ResourceLocation FLOW = new ResourceLocation(MOD_ID, "blocks/fluid_flow");
 
+    private static final HashBiMap<Fluid, FluidWrapper> WRAPPERS = HashBiMap.create();
+
     // Water variants
-    public static final Fluid HOT_WATER = new Fluid("hot_water", STILL, FLOW, 0xFF345FDA).setTemperature(350);
-    public static final Fluid FRESH_WATER = new Fluid("fresh_water", STILL, FLOW, 0xFF1F32DA);
-    public static final Fluid SALT_WATER = new Fluid("salt_water", STILL, FLOW, 0xFF1F5099);
+    public static FluidWrapper HOT_WATER;
+    public static FluidWrapper FRESH_WATER;
 
     // Other fluids
-    public static final Fluid LIMEWATER = new Fluid("limewater", STILL, FLOW, 0xFFB4B4B4);
-    public static final Fluid TANNIN = new Fluid("tannin", STILL, FLOW, 0xFF63594E);
-    public static final Fluid VINEGAR = new Fluid("vinegar", STILL, FLOW, 0xFFC7C2AA);
+    public static FluidWrapper LIMEWATER;
+    public static FluidWrapper TANNIN;
+    public static FluidWrapper VINEGAR;
 
     // Alcohols
-    public static final Fluid CIDER = new Fluid("cider", STILL, FLOW, 0xFFB0AE32).setRarity(EnumRarity.UNCOMMON);
-    public static final Fluid VODKA = new Fluid("vodka", STILL, FLOW, 0xFFDCDCDC).setRarity(EnumRarity.UNCOMMON);
-    public static final Fluid SAKE = new Fluid("sake", STILL, FLOW, 0xFFB7D9BC).setRarity(EnumRarity.UNCOMMON);
-    public static final Fluid CORN_WHISKEY = new Fluid("corn_whiskey", STILL, FLOW, 0xFFD9C7B7).setRarity(EnumRarity.UNCOMMON);
-    public static final Fluid RYE_WHISKEY = new Fluid("rye_whiskey", STILL, FLOW, 0xFFC77D51).setRarity(EnumRarity.UNCOMMON);
-    public static final Fluid WHISKEY = new Fluid("whiskey", STILL, FLOW, 0xFF583719).setRarity(EnumRarity.UNCOMMON);
-    public static final Fluid BEER = new Fluid("beer", STILL, FLOW, 0xFFC39E37).setRarity(EnumRarity.UNCOMMON);
-    public static final Fluid RUM = new Fluid("rum", STILL, FLOW, 0xFF6E0123).setRarity(EnumRarity.UNCOMMON);
+    public static FluidWrapper CIDER;
+    public static FluidWrapper VODKA;
+    public static FluidWrapper SAKE;
+    public static FluidWrapper CORN_WHISKEY;
+    public static FluidWrapper RYE_WHISKEY;
+    public static FluidWrapper WHISKEY;
+    public static FluidWrapper BEER;
+    public static FluidWrapper RUM;
 
     private static final ResourceLocation LAVA_STILL = new ResourceLocation(MOD_ID, "blocks/lava_still");
     private static final ResourceLocation LAVA_FLOW = new ResourceLocation(MOD_ID, "blocks/lava_flow");
 
-    private static ImmutableSet<Fluid> allInfiniteFluids;
-    private static ImmutableSet<Fluid> allAlcoholsFluids;
-    private static ImmutableMap<Metal, Fluid> allMetalFluids;
-    private static ImmutableSet<Fluid> allOtherFiniteFluids;
+    private static ImmutableSet<FluidWrapper> allInfiniteFluids;
+    private static ImmutableSet<FluidWrapper> allAlcoholsFluids;
+    private static ImmutableMap<Metal, FluidWrapper> allMetalFluids;
+    private static ImmutableSet<FluidWrapper> allOtherFiniteFluids;
 
-    public static ImmutableSet<Fluid> getAllInfiniteFluids()
+    public static ImmutableSet<FluidWrapper> getAllInfiniteFluids()
     {
         return allInfiniteFluids;
     }
 
-    public static ImmutableSet<Fluid> getAllAlcoholsFluids()
+    public static ImmutableSet<FluidWrapper> getAllAlcoholsFluids()
     {
         return allAlcoholsFluids;
     }
 
-    public static ImmutableSet<Fluid> getAllOtherFiniteFluids()
+    public static ImmutableSet<FluidWrapper> getAllOtherFiniteFluids()
     {
         return allOtherFiniteFluids;
     }
 
-    public static ImmutableCollection<Fluid> getAllMetalFluids()
+    public static ImmutableCollection<FluidWrapper> getAllMetalFluids()
     {
         return allMetalFluids.values();
     }
 
     @Nonnull
-    public static Fluid getMetalFluid(@Nonnull Metal metal)
+    @SuppressWarnings("ConstantConditions")
+    public static FluidWrapper getWrapper(Fluid fluid)
     {
-        return allMetalFluids.get(metal);
+        return WRAPPERS.get(fluid);
+    }
+
+    @Nonnull
+    public static Set<FluidWrapper> getAllWrappers()
+    {
+        return WRAPPERS.values();
+    }
+
+    @Nonnull
+    public static Fluid getFluidFromMetal(@Nonnull Metal metal)
+    {
+        return allMetalFluids.get(metal).get();
     }
 
     public static void preInit()
     {
-        {
-            ImmutableSet.Builder<Fluid> b = ImmutableSet.builder();
+        allInfiniteFluids = ImmutableSet.<FluidWrapper>builder()
+            .add(
+                HOT_WATER = registerFluid(new Fluid("hot_water", STILL, FLOW, 0xFF345FDA).setTemperature(350), (fluid, isDefault) -> new DrinkableFluidWrapper(fluid, isDefault, player -> {
+                    if (player.getFoodStats() instanceof FoodStatsTFC)
+                    {
+                        ((FoodStatsTFC) player.getFoodStats()).addThirst(40);
+                    }
+                })),
+                FRESH_WATER = registerFluid(new Fluid("fresh_water", STILL, FLOW, 0xFF1F32DA)),
+                registerFluid(new Fluid("salt_water", STILL, FLOW, 0xFF1F5099), (fluid, isDefault) -> new DrinkableFluidWrapper(fluid, isDefault, player -> {
+                    if (player.getFoodStats() instanceof FoodStatsTFC)
+                    {
+                        ((FoodStatsTFC) player.getFoodStats()).addThirst(-10);
+                    }
+                }))
+            )
+            .build();
 
-            registerFluid(b, SALT_WATER);
-            registerFluid(b, FRESH_WATER);
-            registerFluid(b, HOT_WATER);
-
-            allInfiniteFluids = b.build();
-        }
-        {
-            ImmutableSet.Builder<Fluid> b = ImmutableSet.builder();
-
-            registerFluid(b, RUM);
-            registerFluid(b, BEER);
-            registerFluid(b, WHISKEY);
-            registerFluid(b, RYE_WHISKEY);
-            registerFluid(b, CORN_WHISKEY);
-            registerFluid(b, SAKE);
-            registerFluid(b, VODKA);
-            registerFluid(b, CIDER);
-
-            allAlcoholsFluids = b.build();
-        }
-        {
-            ImmutableSet.Builder<Fluid> b = ImmutableSet.builder();
-
-            registerFluid(b, VINEGAR);
-            registerFluid(b, new Fluid("brine", STILL, FLOW, 0xFFDCD3C9));
-            registerFluid(b, new Fluid("milk", STILL, FLOW, 0xFFFFFFFF));
-            registerFluid(b, new Fluid("olive_oil", STILL, FLOW, 0xFF6A7537).setRarity(EnumRarity.RARE));
-            registerFluid(b, TANNIN);
-            registerFluid(b, LIMEWATER);
-            registerFluid(b, new Fluid("milk_curdled", STILL, FLOW, 0xFFFFFBE8));
-            registerFluid(b, new Fluid("milk_vinegar", STILL, FLOW, 0xFFFFFBE8));
-
-            allOtherFiniteFluids = b.build();
-        }
-        {
-            ImmutableMap.Builder<Metal, Fluid> b = ImmutableMap.builder();
-
-            for (Metal metal : TFCRegistries.METALS.getValuesCollection())
+        FluidWrapper.Factory alcoholWrapper = (fluid, isDefault) -> new DrinkableFluidWrapper(fluid, isDefault, player -> {
+            if (player.getFoodStats() instanceof FoodStatsTFC)
             {
-                //noinspection ConstantConditions
-                registerFluid(b, metal, new FluidMetal(metal, metal.getRegistryName().getPath(), LAVA_STILL, LAVA_FLOW, metal.getColor()));
+                ((FoodStatsTFC) player.getFoodStats()).addThirst(10);
+                if (Constants.RNG.nextFloat() < 0.25f)
+                {
+                    player.addPotionEffect(new PotionEffect(MobEffects.NAUSEA, 1200, 1));
+                }
             }
-            allMetalFluids = b.build();
+        });
+        allAlcoholsFluids = ImmutableSet.<FluidWrapper>builder()
+            .add(
+                RUM = registerFluid(new Fluid("rum", STILL, FLOW, 0xFF6E0123).setRarity(EnumRarity.UNCOMMON), alcoholWrapper),
+                BEER = registerFluid(new Fluid("beer", STILL, FLOW, 0xFFC39E37).setRarity(EnumRarity.UNCOMMON), alcoholWrapper),
+                WHISKEY = registerFluid(new Fluid("whiskey", STILL, FLOW, 0xFF583719).setRarity(EnumRarity.UNCOMMON), alcoholWrapper),
+                RYE_WHISKEY = registerFluid(new Fluid("rye_whiskey", STILL, FLOW, 0xFFC77D51).setRarity(EnumRarity.UNCOMMON), alcoholWrapper),
+                CORN_WHISKEY = registerFluid(new Fluid("corn_whiskey", STILL, FLOW, 0xFFD9C7B7).setRarity(EnumRarity.UNCOMMON), alcoholWrapper),
+                SAKE = registerFluid(new Fluid("sake", STILL, FLOW, 0xFFB7D9BC).setRarity(EnumRarity.UNCOMMON), alcoholWrapper),
+                VODKA = registerFluid(new Fluid("vodka", STILL, FLOW, 0xFFDCDCDC).setRarity(EnumRarity.UNCOMMON), alcoholWrapper),
+                CIDER = registerFluid(new Fluid("cider", STILL, FLOW, 0xFFB0AE32).setRarity(EnumRarity.UNCOMMON), alcoholWrapper)
+            )
+            .build();
+
+        allOtherFiniteFluids = ImmutableSet.<FluidWrapper>builder()
+            .add(
+                VINEGAR = registerFluid(new Fluid("vinegar", STILL, FLOW, 0xFFC7C2AA)),
+                registerFluid(new Fluid("brine", STILL, FLOW, 0xFFDCD3C9)),
+                registerFluid(new Fluid("milk", STILL, FLOW, 0xFFFFFFFF)),
+                registerFluid(new Fluid("olive_oil", STILL, FLOW, 0xFF6A7537).setRarity(EnumRarity.RARE)),
+                TANNIN = registerFluid(new Fluid("tannin", STILL, FLOW, 0xFF63594E)),
+                LIMEWATER = registerFluid(new Fluid("limewater", STILL, FLOW, 0xFFB4B4B4)),
+                registerFluid(new Fluid("milk_curdled", STILL, FLOW, 0xFFFFFBE8)),
+                registerFluid(new Fluid("milk_vinegar", STILL, FLOW, 0xFFFFFBE8))
+            )
+            .build();
+
+        //noinspection ConstantConditions
+        allMetalFluids = ImmutableMap.<Metal, FluidWrapper>builder()
+            .putAll(
+                TFCRegistries.METALS.getValuesCollection()
+                    .stream()
+                    .collect(Collectors.toMap(
+                        metal -> metal,
+                        metal -> registerFluid(new Fluid(metal.getRegistryName().getPath(), LAVA_STILL, LAVA_FLOW, metal.getColor()), (fluid, isDefault) -> new MetalFluidWrapper(fluid, isDefault, metal))
+                    ))
+            )
+            .build();
+    }
+
+    private static FluidWrapper registerFluid(Fluid fluid)
+    {
+        return registerFluid(fluid, FluidWrapper::new);
+    }
+
+    private static FluidWrapper registerFluid(Fluid newFluid, FluidWrapper.Factory fluidPropertyWrapper)
+    {
+        boolean isDefault = FluidRegistry.registerFluid(newFluid);
+        if (!isDefault)
+        {
+            // Fluid was already registered with this name, default to that fluid
+            newFluid = FluidRegistry.getFluid(newFluid.getName());
         }
-    }
-
-    private static <T extends Fluid> void registerFluid(ImmutableSet.Builder<T> b, T fluid)
-    {
-        FluidRegistry.registerFluid(fluid);
-        FluidRegistry.addBucketForFluid(fluid);
-        b.add(fluid);
-    }
-
-    private static <T extends Fluid, V> void registerFluid(ImmutableMap.Builder<V, T> b, V key, T fluid)
-    {
-        FluidRegistry.registerFluid(fluid);
-        FluidRegistry.addBucketForFluid(fluid);
-        b.put(key, fluid);
+        FluidRegistry.addBucketForFluid(newFluid);
+        FluidWrapper properties = fluidPropertyWrapper.create(newFluid, isDefault);
+        WRAPPERS.put(newFluid, properties);
+        return properties;
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/fluids/properties/DrinkableFluidWrapper.java
+++ b/src/main/java/net/dries007/tfc/objects/fluids/properties/DrinkableFluidWrapper.java
@@ -1,0 +1,28 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
+package net.dries007.tfc.objects.fluids.properties;
+
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraftforge.fluids.Fluid;
+
+public class DrinkableFluidWrapper extends FluidWrapper
+{
+    private final Consumer<EntityPlayer> onDrinkFunction;
+
+    public DrinkableFluidWrapper(@Nonnull Fluid fluid, boolean isDefault, Consumer<EntityPlayer> onDrinkFunction)
+    {
+        super(fluid, isDefault);
+        this.onDrinkFunction = onDrinkFunction;
+    }
+
+    public void onDrink(EntityPlayer entity)
+    {
+        onDrinkFunction.accept(entity);
+    }
+}

--- a/src/main/java/net/dries007/tfc/objects/fluids/properties/FluidWrapper.java
+++ b/src/main/java/net/dries007/tfc/objects/fluids/properties/FluidWrapper.java
@@ -1,0 +1,47 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
+package net.dries007.tfc.objects.fluids.properties;
+
+import javax.annotation.Nonnull;
+
+import net.minecraftforge.fluids.Fluid;
+
+/**
+ * This is a separate class from {@link Fluid} to avoid subclassing.
+ * From LexManos:
+ * > yes thats the point, that if you share a name you use whatever is registered
+ * > you are not special and do not need your special functionality
+ * > IF you do NOT want to work well with others and you have to  be a special special snowflake, namespace your shit.
+ * So in order to keep TFC working well with other mods, we shall use whatever fluids are registered, but we still need to map them to properties
+ */
+public class FluidWrapper
+{
+    private final Fluid fluid;
+    private final boolean isDefault;
+
+    public FluidWrapper(@Nonnull Fluid fluid, boolean isDefault)
+    {
+        this.fluid = fluid;
+        this.isDefault = isDefault;
+    }
+
+    @Nonnull
+    public Fluid get()
+    {
+        return fluid;
+    }
+
+    public boolean isDefault()
+    {
+        return isDefault;
+    }
+
+    public interface Factory
+    {
+        @Nonnull
+        FluidWrapper create(@Nonnull Fluid defaultFluid, boolean isDefault);
+    }
+}

--- a/src/main/java/net/dries007/tfc/objects/fluids/properties/MetalFluidWrapper.java
+++ b/src/main/java/net/dries007/tfc/objects/fluids/properties/MetalFluidWrapper.java
@@ -1,0 +1,29 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
+package net.dries007.tfc.objects.fluids.properties;
+
+import javax.annotation.Nonnull;
+
+import net.minecraftforge.fluids.Fluid;
+
+import net.dries007.tfc.api.types.Metal;
+
+public class MetalFluidWrapper extends FluidWrapper
+{
+    private final Metal metal;
+
+    public MetalFluidWrapper(@Nonnull Fluid fluid, boolean isNewFluid, @Nonnull Metal metal)
+    {
+        super(fluid, isNewFluid);
+        this.metal = metal;
+    }
+
+    @Nonnull
+    public Metal getMetal()
+    {
+        return metal;
+    }
+}

--- a/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
@@ -52,7 +52,7 @@ import net.dries007.tfc.util.calendar.CalendarTFC;
 @ParametersAreNonnullByDefault
 public class ItemSmallVessel extends ItemPottery
 {
-    public final boolean glazed;
+    private final boolean glazed;
 
     public ItemSmallVessel(boolean glazed)
     {
@@ -149,7 +149,7 @@ public class ItemSmallVessel extends ItemPottery
                 }
                 // Fill with the liquid metal
                 cap.setFluidMode(true);
-                cap.fill(new FluidStack(FluidsTFC.getMetalFluid(alloy.getResult()), alloy.getAmount()), true);
+                cap.fill(new FluidStack(FluidsTFC.getFluidFromMetal(alloy.getResult()), alloy.getAmount()), true);
                 cap.setTemperature(1600f);
             }
 

--- a/src/main/java/net/dries007/tfc/objects/te/TECrucible.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TECrucible.java
@@ -159,7 +159,7 @@ public class TECrucible extends TEInventory implements ITickable, ITileFields
                 if (amountToFill > 0)
                 {
                     // Do fill of the mold
-                    Fluid metalFluid = FluidsTFC.getMetalFluid(alloyMetal);
+                    Fluid metalFluid = FluidsTFC.getFluidFromMetal(alloyMetal);
                     FluidStack fluidStack = new FluidStack(metalFluid, amountToFill);
                     int amountFilled = mold.fill(fluidStack, true);
 

--- a/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
+++ b/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
@@ -67,44 +67,44 @@ public final class DefaultRecipes
     {
         event.getRegistry().registerAll(
             // Hide Processing (all three conversions)
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 300), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.SCRAPED, ItemAnimalHide.HideSize.SMALL)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.SMALL)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("small_prepared_hide"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 400), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.SCRAPED, ItemAnimalHide.HideSize.MEDIUM)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.MEDIUM)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("medium_prepared_hide"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.SCRAPED, ItemAnimalHide.HideSize.LARGE)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.LARGE)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("large_prepared_hide"),
-            new BarrelRecipe(IIngredient.of(LIMEWATER, 300), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.RAW, ItemAnimalHide.HideSize.SMALL)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.SOAKED, ItemAnimalHide.HideSize.SMALL)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("small_soaked_hide"),
-            new BarrelRecipe(IIngredient.of(LIMEWATER, 400), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.RAW, ItemAnimalHide.HideSize.MEDIUM)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.SOAKED, ItemAnimalHide.HideSize.MEDIUM)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("medium_soaked_hide"),
-            new BarrelRecipe(IIngredient.of(LIMEWATER, 500), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.RAW, ItemAnimalHide.HideSize.LARGE)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.SOAKED, ItemAnimalHide.HideSize.LARGE)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("large_soaked_hide"),
-            new BarrelRecipe(IIngredient.of(TANNIN, 300), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.SMALL)), null, new ItemStack(Items.LEATHER), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("leather_small_hide"),
-            new BarrelRecipe(IIngredient.of(TANNIN, 400), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.MEDIUM)), null, new ItemStack(Items.LEATHER, 2), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("leather_medium_hide"),
-            new BarrelRecipe(IIngredient.of(TANNIN, 500), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.LARGE)), null, new ItemStack(Items.LEATHER, 3), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("leather_large_hide"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 300), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.SCRAPED, ItemAnimalHide.HideSize.SMALL)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.SMALL)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("small_prepared_hide"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 400), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.SCRAPED, ItemAnimalHide.HideSize.MEDIUM)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.MEDIUM)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("medium_prepared_hide"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.SCRAPED, ItemAnimalHide.HideSize.LARGE)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.LARGE)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("large_prepared_hide"),
+            new BarrelRecipe(IIngredient.of(LIMEWATER.get(), 300), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.RAW, ItemAnimalHide.HideSize.SMALL)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.SOAKED, ItemAnimalHide.HideSize.SMALL)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("small_soaked_hide"),
+            new BarrelRecipe(IIngredient.of(LIMEWATER.get(), 400), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.RAW, ItemAnimalHide.HideSize.MEDIUM)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.SOAKED, ItemAnimalHide.HideSize.MEDIUM)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("medium_soaked_hide"),
+            new BarrelRecipe(IIngredient.of(LIMEWATER.get(), 500), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.RAW, ItemAnimalHide.HideSize.LARGE)), null, new ItemStack(ItemAnimalHide.get(ItemAnimalHide.HideType.SOAKED, ItemAnimalHide.HideSize.LARGE)), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("large_soaked_hide"),
+            new BarrelRecipe(IIngredient.of(TANNIN.get(), 300), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.SMALL)), null, new ItemStack(Items.LEATHER), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("leather_small_hide"),
+            new BarrelRecipe(IIngredient.of(TANNIN.get(), 400), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.MEDIUM)), null, new ItemStack(Items.LEATHER, 2), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("leather_medium_hide"),
+            new BarrelRecipe(IIngredient.of(TANNIN.get(), 500), IIngredient.of(ItemAnimalHide.get(ItemAnimalHide.HideType.PREPARED, ItemAnimalHide.HideSize.LARGE)), null, new ItemStack(Items.LEATHER, 3), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("leather_large_hide"),
             // Misc
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 1000), IIngredient.of("logWoodTannin"), new FluidStack(TANNIN, 10000), ItemStack.EMPTY, 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("tannin"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 200), IIngredient.of(ItemsTFC.JUTE), null, new ItemStack(ItemsTFC.JUTE_FIBER), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("jute_fiber"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 600), IIngredient.of(ItemsTFC.SUGARCANE, 5), null, new ItemStack(Items.SUGAR), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("sugar"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 1000), IIngredient.of("logWoodTannin"), new FluidStack(TANNIN.get(), 10000), ItemStack.EMPTY, 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("tannin"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 200), IIngredient.of(ItemsTFC.JUTE), null, new ItemStack(ItemsTFC.JUTE_FIBER), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("jute_fiber"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 600), IIngredient.of(ItemsTFC.SUGARCANE, 5), null, new ItemStack(Items.SUGAR), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("sugar"),
             // Alcohol
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of(ItemFoodTFC.get(Food.BARLEY_FLOUR)), new FluidStack(FluidsTFC.BEER, 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("beer"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of("apple"), new FluidStack(FluidsTFC.CIDER, 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("cider"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of("sugar"), new FluidStack(FluidsTFC.RUM, 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("rum"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of(ItemFoodTFC.get(Food.RICE_FLOUR)), new FluidStack(FluidsTFC.SAKE, 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("sake"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of(ItemFoodTFC.get(Food.POTATO)), new FluidStack(FluidsTFC.VODKA, 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("vodka"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of(ItemFoodTFC.get(Food.WHEAT_FLOUR)), new FluidStack(FluidsTFC.WHISKEY, 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("whiskey"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of(ItemFoodTFC.get(Food.CORNMEAL_FLOUR)), new FluidStack(FluidsTFC.CORN_WHISKEY, 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("corn_whiskey"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of(ItemFoodTFC.get(Food.RYE_FLOUR)), new FluidStack(FluidsTFC.RYE_WHISKEY, 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("rye_whiskey"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.BARLEY_FLOUR)), new FluidStack(FluidsTFC.BEER.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("beer"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of("apple"), new FluidStack(FluidsTFC.CIDER.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("cider"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of("sugar"), new FluidStack(FluidsTFC.RUM.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("rum"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.RICE_FLOUR)), new FluidStack(FluidsTFC.SAKE.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("sake"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.POTATO)), new FluidStack(FluidsTFC.VODKA.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("vodka"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.WHEAT_FLOUR)), new FluidStack(FluidsTFC.WHISKEY.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("whiskey"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.CORNMEAL_FLOUR)), new FluidStack(FluidsTFC.CORN_WHISKEY.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("corn_whiskey"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.RYE_FLOUR)), new FluidStack(FluidsTFC.RYE_WHISKEY.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("rye_whiskey"),
             // Vinegar
-            new BarrelRecipe(IIngredient.of(200, FluidsTFC.BEER, FluidsTFC.CIDER, FluidsTFC.RUM, FluidsTFC.SAKE, FluidsTFC.VODKA, FluidsTFC.WHISKEY, FluidsTFC.CORN_WHISKEY, FluidsTFC.RYE_WHISKEY), IIngredient.of("fruit"), new FluidStack(FluidsTFC.VINEGAR, 200), ItemStack.EMPTY, 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("vinegar"),
+            new BarrelRecipe(IIngredient.of(200, FluidsTFC.BEER.get(), FluidsTFC.CIDER.get(), FluidsTFC.RUM.get(), FluidsTFC.SAKE.get(), FluidsTFC.VODKA.get(), FluidsTFC.WHISKEY.get(), FluidsTFC.CORN_WHISKEY.get(), FluidsTFC.RYE_WHISKEY.get()), IIngredient.of("fruit"), new FluidStack(FluidsTFC.VINEGAR.get(), 200), ItemStack.EMPTY, 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("vinegar"),
             // Food preservation
-            new BarrelRecipeFoodTraits(IIngredient.of(VINEGAR, 125), IIngredient.of("fruit"), CapabilityFood.PICKLED, 4 * ICalendar.TICKS_IN_HOUR).setRegistryName("pickling_fruit"),
-            new BarrelRecipeFoodTraits(IIngredient.of(VINEGAR, 125), IIngredient.of("meat"), CapabilityFood.PICKLED, 4 * ICalendar.TICKS_IN_HOUR).setRegistryName("pickling_meat"),
-            new BarrelRecipeFoodTraits(IIngredient.of(VINEGAR, 125), IIngredient.of("vegetable"), CapabilityFood.PICKLED, 4 * ICalendar.TICKS_IN_HOUR).setRegistryName("pickling_vegetable"),
+            new BarrelRecipeFoodTraits(IIngredient.of(VINEGAR.get(), 125), IIngredient.of("fruit"), CapabilityFood.PICKLED, 4 * ICalendar.TICKS_IN_HOUR).setRegistryName("pickling_fruit"),
+            new BarrelRecipeFoodTraits(IIngredient.of(VINEGAR.get(), 125), IIngredient.of("meat"), CapabilityFood.PICKLED, 4 * ICalendar.TICKS_IN_HOUR).setRegistryName("pickling_meat"),
+            new BarrelRecipeFoodTraits(IIngredient.of(VINEGAR.get(), 125), IIngredient.of("vegetable"), CapabilityFood.PICKLED, 4 * ICalendar.TICKS_IN_HOUR).setRegistryName("pickling_vegetable"),
             // todo: brined food
             // todo: mortar
             // todo: curdled milk -> cheese (use an empty IIngredient for the item)
 
             // Instant recipes: set the duration to 0
             // todo: brine
-            new BarrelRecipe(IIngredient.of(FRESH_WATER, 500), IIngredient.of("dustFlux"), new FluidStack(LIMEWATER, 500), ItemStack.EMPTY, 0).setRegistryName("limewater"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of("dustFlux"), new FluidStack(LIMEWATER.get(), 500), ItemStack.EMPTY, 0).setRegistryName("limewater"),
             // todo: curdled milk (make it a simpler calculation)
 
-            new BarrelRecipeTemperature(IIngredient.of(FRESH_WATER, 1), 50).setRegistryName("fresh_water_cooling")
+            new BarrelRecipeTemperature(IIngredient.of(FRESH_WATER.get(), 1), 50).setRegistryName("fresh_water_cooling")
         );
     }
 

--- a/src/main/java/net/dries007/tfc/util/OreDictionaryHelper.java
+++ b/src/main/java/net/dries007/tfc/util/OreDictionaryHelper.java
@@ -5,7 +5,6 @@
 
 package net.dries007.tfc.util;
 
-import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 
 import com.google.common.base.CaseFormat;
@@ -14,9 +13,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
-import org.apache.commons.lang3.ArrayUtils;
 import net.minecraft.block.Block;
-import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
@@ -87,11 +84,6 @@ public class OreDictionaryHelper
         MAP.clear(); // No need to keep this stuff around
     }
 
-    public static Predicate<EntityItem> createPredicateItemEntity(String... names)
-    {
-        return input -> input.isEntityAlive() && createPredicateStack(names).test(input.getItem());
-    }
-
     /**
      * Checks if an ItemStack has an OreDictionary entry that matches 'name'.
      */
@@ -109,40 +101,6 @@ public class OreDictionaryHelper
             if (id == needle) return true;
         }
         return false;
-    }
-
-    /**
-     * Checks is an ItemStack has ore names, which have a certain prefix
-     * used to search for all 'ingots' / all 'plates' etc.
-     */
-    public static boolean doesStackMatchOrePrefix(@Nonnull ItemStack stack, String prefix)
-    {
-        if (stack.isEmpty()) return false;
-        int[] ids = OreDictionary.getOreIDs(stack);
-        for (int id : ids)
-        {
-            String oreName = OreDictionary.getOreName(id);
-            if (oreName.length() >= prefix.length())
-            {
-                if (oreName.substring(0, prefix.length()).equals(prefix))
-                {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private static Predicate<ItemStack> createPredicateStack(String... names)
-    {
-        return input -> {
-            if (input.isEmpty()) return false;
-            int[] ids = OreDictionary.getOreIDs(input);
-            for (String name : names)
-                if (ArrayUtils.contains(ids, OreDictionary.getOreID(name)))
-                    return true;
-            return false;
-        };
     }
 
     private static void register(Thing thing, Object... parts)


### PR DESCRIPTION
 - All TFC fluids now are stored as wrappers, which hold the fluid instance (either the TFC created one, or a default one), and records if it is default or not
 - Blocks are registered for non-default fluids, using the wrapper.
 - Moved Drinkables and Metal fluids into their own wrapper classes