### PR TITLE
Misc. worldgen fixes

### DIFF
--- a/src/main/java/net/dries007/tfc/world/classic/ChunkGenTFC.java
+++ b/src/main/java/net/dries007/tfc/world/classic/ChunkGenTFC.java
@@ -148,6 +148,9 @@ public class ChunkGenTFC implements IChunkGenerator
     private final MapGenBase ravineGen;
     private final MapGenBase riverRavineGen;
 
+    private final int seaLevel = 32;
+    private final int yOffset = 112;
+
     private int[] rockLayer1 = new int[256];
     private int[] rockLayer2 = new int[256];
     private int[] rockLayer3 = new int[256];
@@ -407,7 +410,7 @@ public class ChunkGenTFC implements IChunkGenerator
                             {
                                 if ((var47 += var49) > 0.0D)
                                     primer.setBlockState(x * 4 + xx, y * 8 + yy, z * 4 + zz, STONE);
-                                else if (y * 8 + yy < 16)
+                                else if (y * 8 + yy < seaLevel)
                                     primer.setBlockState(x * 4 + xx, y * 8 + yy, z * 4 + zz, SALT_WATER);
                                 else primer.setBlockState(x * 4 + xx, y * 8 + yy, z * 4 + zz, AIR);
                             }
@@ -527,8 +530,9 @@ public class ChunkGenTFC implements IChunkGenerator
 
     private void replaceBlocksForBiomeHigh(int chunkX, int chunkZ, ChunkPrimer inp, CustomChunkPrimer outp)
     {
-        final int seaLevel = 16;
-        final int yOffset = 128;
+        //System.out.println(Arrays.deepToString(chunkHeightMap));
+
+
         double var6 = 0.03125D;
         noiseGen4.generateNoiseOctaves(noise4, chunkX * 16, chunkZ * 16, 0, 16, 16, 1, var6 * 4.0D, var6, var6 * 4.0D);
         boolean[] cliffMap = new boolean[256];
@@ -560,19 +564,37 @@ public class ChunkGenTFC implements IChunkGenerator
                     if (!BiomesTFC.isBeachBiome(getBiomeOffset(x, z))) cliffMap[colIndex] = true;
                 }
 
-                int h = 0;
-                for (int y = 127; y >= 0; y--)
+
+
+                //Used to make better rivers
+                int nonRiverTiles = 0;
+                for (int a = x - 1; a <= x + 1; a++) {
+                    for (int b = z - 1; b <= z + 1; b++) {
+                        if (!BiomesTFC.isRiverBiome(getBiomeOffset(a, b)))
+                            nonRiverTiles++;
+                    }
+                }
+
+
+                //Smooth out cliffs near beaches
+                int nonBeachTiles = 0;
+                for (int a = x - 1; a <= x + 1; a++) {
+                    for (int b = z - 1; b <= z + 1; b++) {
+                        if (!BiomesTFC.isBeachBiome(getBiomeOffset(a, b)) && !BiomesTFC.isOceanicBiome(getBiomeOffset(a, b)) && getBiomeOffset(a, b) != BiomesTFC.DEEP_OCEAN && getBiomeOffset(a, b) != BiomesTFC.OCEAN)
+                            nonBeachTiles++;
+                    }
+                }
+
+
+                int highestStone = 0;
+
+                for (int y = 255 - yOffset; y >= 0; y--)
                 {
                     /*
                      * HIGH PART (yOffset is used)
                      */
 
                     float temp = averageTemp - ClimateHelper.heightFactor(y + yOffset);
-                    if (BiomesTFC.isBeachBiome(biome) && y + yOffset > seaLevel + h && inp.getBlockState(x, y + yOffset, z) == STONE)
-                    {
-                        inp.setBlockState(x, y + yOffset, z, AIR);
-                        if (h == 0) h = (y + yOffset - 16) / 4;
-                    }
 
                     if (outp.isEmpty(x, y + yOffset, z))
                     {
@@ -584,6 +606,42 @@ public class ChunkGenTFC implements IChunkGenerator
                                 outp.setBlockState(x, y + yOffset + upCount, z, AIR);
                             }
                         }
+                    }
+
+
+                    if (outp.getBlockState(x, y + yOffset, z) == STONE) {
+                        highestStone = Math.max(highestStone, y);
+                    }
+
+                    int highestBeachTheoretical = (highestStone- seaLevel) / 4 + seaLevel;
+                    int beachCliffHeight = nonBeachTiles > 0 ? (int) ((highestStone - highestBeachTheoretical) * (nonBeachTiles) / 6.0 + highestBeachTheoretical) : highestBeachTheoretical;
+
+                    //Redo cliffs
+                    if(BiomesTFC.isBeachBiome(biome) && y > seaLevel && outp.getBlockState(x, y + yOffset, z) != AIR && y >= beachCliffHeight) {
+
+                        inp.setBlockState(x, y, z, y >= seaLevel ? AIR : SALT_WATER);
+                        outp.setBlockState(x, y + yOffset, z, y >= seaLevel ? AIR : SALT_WATER);
+                    }
+                    //Ensure rivers can't get blocked
+                    if(BiomesTFC.isRiverBiome(biome) && y >= seaLevel - 2 && outp.getBlockState(x, y + yOffset, z) != AIR) {
+
+                        if(nonRiverTiles > 0) {
+                            if(y >= seaLevel - 1) {
+                                inp.setBlockState(x, y, z, y >= seaLevel ? AIR : SALT_WATER);
+                                outp.setBlockState(x, y + yOffset, z, y >= seaLevel ? AIR : SALT_WATER);
+                            }
+                        } else  {
+                            inp.setBlockState(x, y, z, y >= seaLevel ? AIR : SALT_WATER);
+                            outp.setBlockState(x, y + yOffset, z, y >= seaLevel ? AIR : SALT_WATER);
+                        }
+
+
+
+
+                        //outp.setBlockState(x, y + yOffset, z, y >= seaLevel ? AIR : SALT_WATER);
+                    } else if(!BiomesTFC.isRiverBiome(biome) && nonRiverTiles < 9 && outp.getBlockState(x, y + yOffset, z) == STONE && ((y >= ((highestStone - seaLevel) / (10 - nonRiverTiles) + seaLevel)) || (nonRiverTiles <= 5 && y >= seaLevel))) {
+                        inp.setBlockState(x, y, z, y >= seaLevel ? AIR : SALT_WATER);
+                        outp.setBlockState(x, y + yOffset, z, y >= seaLevel ? AIR : SALT_WATER);
                     }
 
                     if (outp.getBlockState(x, y + yOffset, z) == STONE)
@@ -653,15 +711,15 @@ public class ChunkGenTFC implements IChunkGenerator
                             }
 
                             // Determine the soil depth based on world y
-                            int dirtH = Math.max(8 - ((y + 96 - WorldTypeTFC.SEALEVEL) / 16), 0);
+                            int dirtH = Math.max(8 - ((y + yOffset - 24 - WorldTypeTFC.SEALEVEL) / 16), 0);
 
                             if (smooth > 0)
                             {
-                                if (y >= seaLevel - 1 && y + 1 < yOffset && inp.getBlockState(x, y + 1, z) != SALT_WATER && dirtH > 0)
+                                if (y >= seaLevel - 1 && y + 1 < yOffset && inp.getBlockState(x, y + 1, z) != SALT_WATER && dirtH > 0 && !(BiomesTFC.isBeachBiome(biome) && y > highestBeachTheoretical + 2))
                                 {
                                     outp.setBlockState(x, y + yOffset, z, surfaceBlock);
 
-                                    boolean mountains = BiomesTFC.isMountainBiome(biome) || biome == BiomesTFC.HIGH_HILLS || biome == BiomesTFC.HIGH_HILLS_EDGE;
+                                    boolean mountains = BiomesTFC.isMountainBiome(biome) || biome == BiomesTFC.HIGH_HILLS || biome == BiomesTFC.HIGH_HILLS_EDGE || biome == BiomesTFC.MOUNTAINS  || biome == BiomesTFC.MOUNTAINS_EDGE ;
                                     for (int c = 1; c < dirtH && !mountains && !cliffMap[colIndex]; c++)
                                     {
                                         outp.setBlockState(x, y - c + yOffset, z, subSurfaceBlock);
@@ -694,7 +752,7 @@ public class ChunkGenTFC implements IChunkGenerator
                     }
                 }
 
-                for (int y = 127; y >= 0; y--) // This cannot be optimized with the prev for loop, because the sealeveloffset won't be ready yet.
+                for (int y = yOffset - 1; y >= 0; y--) // This cannot be optimized with the prev for loop, because the sealeveloffset won't be ready yet.
                 {
                     /*
                      * LOW PART (yOffset is NOT used)

--- a/src/main/java/net/dries007/tfc/world/classic/biomes/BiomesTFC.java
+++ b/src/main/java/net/dries007/tfc/world/classic/biomes/BiomesTFC.java
@@ -49,20 +49,20 @@ public final class BiomesTFC
     {
         IForgeRegistry<Biome> r = event.getRegistry();
 
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Ocean").setBaseHeight(1-3.6f).setHeightVariation(-2.69999f)), false, true, BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " River").setBaseHeight(0.9f-3.2f).setHeightVariation(-3f)), false, false, BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Beach").setBaseHeight(1-2.69f).setHeightVariation(-2.68f)), false, false, BiomeDictionary.Type.BEACH);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Gravel Beach").setBaseHeight(1-2.69f).setHeightVariation(-2.68f).setBaseBiome("tfc:beach")), false, false, BiomeDictionary.Type.BEACH);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills").setBaseHeight(1-1.9000001f).setHeightVariation(-1.1f)), false, true, BiomeDictionary.Type.HILLS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Plains").setBaseHeight(1-2.6000001f).setHeightVariation(-2.54f)).setSpawnBiome(), true, true, BiomeDictionary.Type.PLAINS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Swampland").setBaseHeight(1-2.8f).setHeightVariation(-2.6000001f), 16, 45).setSpawnBiome(), true, true, BiomeDictionary.Type.SWAMP);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills Edge").setBaseHeight(1-2.5f).setHeightVariation(-2.3f).setBaseBiome("tfc:high_hills")), false, false, BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Rolling Hills").setBaseHeight(1-2.6000001f).setHeightVariation(-2.3f)).setSpawnBiome(), true, true, BiomeDictionary.Type.HILLS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains").setBaseHeight(1-1.9000001f).setHeightVariation(-1.1f)).setSpawnBiome(), true, true, BiomeDictionary.Type.MOUNTAIN);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains Edge").setBaseHeight(1-2.3f).setHeightVariation(-1.9000001f).setBaseBiome("tfc:mountains")), true, false, BiomeDictionary.Type.MOUNTAIN);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Plains").setBaseHeight(1-2.3f).setHeightVariation(-2.27f)).setSpawnBiome(), true, true, BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Deep Ocean").setBaseHeight(1-4.2f).setHeightVariation(0.2f-2.69999f).setBaseBiome("tfc:ocean")), false, false, BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Lake").setBaseHeight(0.8f-3.2f).setHeightVariation(0.1f-2.6990001f).setBaseBiome("tfc:ocean"), 4, 5), false, false, BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Ocean").setBaseHeight(-2.6f).setHeightVariation(-2.69999f)), false, true, BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " River").setBaseHeight(-2.3f).setHeightVariation(-3f)), false, false, BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Beach").setBaseHeight(-1.69f).setHeightVariation(-2.68f)), false, false, BiomeDictionary.Type.BEACH);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Gravel Beach").setBaseHeight(-1.69f).setHeightVariation(-2.68f).setBaseBiome("tfc:beach")), false, false, BiomeDictionary.Type.BEACH);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills").setBaseHeight(-0.9000001f).setHeightVariation(-1.1f)), false, true, BiomeDictionary.Type.HILLS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Plains").setBaseHeight(-1.6000001f).setHeightVariation(-2.54f)).setSpawnBiome(), true, true, BiomeDictionary.Type.PLAINS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Swampland").setBaseHeight(-1.8f).setHeightVariation(-2.6000001f), 16, 45).setSpawnBiome(), true, true, BiomeDictionary.Type.SWAMP);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills Edge").setBaseHeight(-1.5f).setHeightVariation(-2.3f).setBaseBiome("tfc:high_hills")), false, false, BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Rolling Hills").setBaseHeight(-1.6000001f).setHeightVariation(-2.3f)).setSpawnBiome(), true, true, BiomeDictionary.Type.HILLS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains").setBaseHeight(-0.9000001f).setHeightVariation(-1.1f)).setSpawnBiome(), true, true, BiomeDictionary.Type.MOUNTAIN);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains Edge").setBaseHeight(-1.3f).setHeightVariation(-1.9000001f).setBaseBiome("tfc:mountains")), true, false, BiomeDictionary.Type.MOUNTAIN);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Plains").setBaseHeight(-1.3f).setHeightVariation(-2.27f)).setSpawnBiome(), true, true, BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Deep Ocean").setBaseHeight(-3.2f).setHeightVariation(-2.49999f).setBaseBiome("tfc:ocean")), false, false, BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Lake").setBaseHeight(-2.4f).setHeightVariation(-2.5990001f).setBaseBiome("tfc:ocean"), 4, 5), false, false, BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
 
     }
 

--- a/src/main/java/net/dries007/tfc/world/classic/biomes/BiomesTFC.java
+++ b/src/main/java/net/dries007/tfc/world/classic/biomes/BiomesTFC.java
@@ -40,6 +40,7 @@ public final class BiomesTFC
     public static final BiomeTFC DEEP_OCEAN = Helpers.getNull();
     public static final BiomeTFC LAKE = Helpers.getNull();
 
+
     private static final List<Biome> SPAWN_BIOMES = new ArrayList<>();
     private static final List<Biome> WORLD_GEN_BIOMES = new ArrayList<>();
 
@@ -48,20 +49,21 @@ public final class BiomesTFC
     {
         IForgeRegistry<Biome> r = event.getRegistry();
 
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Ocean").setBaseHeight(-3.6f).setHeightVariation(-2.69999f)), false, true, BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " River").setBaseHeight(-3.2f).setHeightVariation(-3f)), false, false, BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Beach").setBaseHeight(-2.69f).setHeightVariation(-2.68f)), false, false, BiomeDictionary.Type.BEACH);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Gravel Beach").setBaseHeight(-2.69f).setHeightVariation(-2.68f).setBaseBiome("tfc:beach")), false, false, BiomeDictionary.Type.BEACH);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills").setBaseHeight(-1.9000001f).setHeightVariation(-1.1f)), false, true, BiomeDictionary.Type.HILLS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Plains").setBaseHeight(-2.6000001f).setHeightVariation(-2.54f)).setSpawnBiome(), true, true, BiomeDictionary.Type.PLAINS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Swampland").setBaseHeight(-2.8f).setHeightVariation(-2.6000001f), 16, 45).setSpawnBiome(), true, true, BiomeDictionary.Type.SWAMP);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills Edge").setBaseHeight(-2.5f).setHeightVariation(-2.3f).setBaseBiome("tfc:high_hills")), false, false, BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Rolling Hills").setBaseHeight(-2.6000001f).setHeightVariation(-2.3f)).setSpawnBiome(), true, true, BiomeDictionary.Type.HILLS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains").setBaseHeight(-1.9000001f).setHeightVariation(-1.1f)).setSpawnBiome(), true, true, BiomeDictionary.Type.MOUNTAIN);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains Edge").setBaseHeight(-2.3f).setHeightVariation(-1.9000001f).setBaseBiome("tfc:mountains")), false, false, BiomeDictionary.Type.MOUNTAIN);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Plains").setBaseHeight(-2.3f).setHeightVariation(-2.27f)).setSpawnBiome(), true, true, BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Deep Ocean").setBaseHeight(-4.2f).setHeightVariation(-2.69999f).setBaseBiome("tfc:ocean")), false, false, BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
-        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Lake").setBaseHeight(-3.2f).setHeightVariation(-2.6990001f).setBaseBiome("tfc:ocean"), 4, 5), false, false, BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Ocean").setBaseHeight(1-3.6f).setHeightVariation(-2.69999f)), false, true, BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " River").setBaseHeight(0.9f-3.2f).setHeightVariation(-3f)), false, false, BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Beach").setBaseHeight(1-2.69f).setHeightVariation(-2.68f)), false, false, BiomeDictionary.Type.BEACH);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Gravel Beach").setBaseHeight(1-2.69f).setHeightVariation(-2.68f).setBaseBiome("tfc:beach")), false, false, BiomeDictionary.Type.BEACH);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills").setBaseHeight(1-1.9000001f).setHeightVariation(-1.1f)), false, true, BiomeDictionary.Type.HILLS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Plains").setBaseHeight(1-2.6000001f).setHeightVariation(-2.54f)).setSpawnBiome(), true, true, BiomeDictionary.Type.PLAINS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Swampland").setBaseHeight(1-2.8f).setHeightVariation(-2.6000001f), 16, 45).setSpawnBiome(), true, true, BiomeDictionary.Type.SWAMP);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Hills Edge").setBaseHeight(1-2.5f).setHeightVariation(-2.3f).setBaseBiome("tfc:high_hills")), false, false, BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Rolling Hills").setBaseHeight(1-2.6000001f).setHeightVariation(-2.3f)).setSpawnBiome(), true, true, BiomeDictionary.Type.HILLS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains").setBaseHeight(1-1.9000001f).setHeightVariation(-1.1f)).setSpawnBiome(), true, true, BiomeDictionary.Type.MOUNTAIN);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Mountains Edge").setBaseHeight(1-2.3f).setHeightVariation(-1.9000001f).setBaseBiome("tfc:mountains")), true, false, BiomeDictionary.Type.MOUNTAIN);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " High Plains").setBaseHeight(1-2.3f).setHeightVariation(-2.27f)).setSpawnBiome(), true, true, BiomeDictionary.Type.HILLS, BiomeDictionary.Type.PLAINS);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Deep Ocean").setBaseHeight(1-4.2f).setHeightVariation(0.2f-2.69999f).setBaseBiome("tfc:ocean")), false, false, BiomeDictionary.Type.OCEAN, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+        register(r, new BiomeTFC(new Biome.BiomeProperties(MOD_NAME + " Lake").setBaseHeight(0.8f-3.2f).setHeightVariation(0.1f-2.6990001f).setBaseBiome("tfc:ocean"), 4, 5), false, false, BiomeDictionary.Type.RIVER, BiomeDictionary.Type.WET, BiomeDictionary.Type.WATER);
+
     }
 
     public static boolean isOceanicBiome(int id)
@@ -84,10 +86,21 @@ public final class BiomesTFC
         return OCEAN == b || DEEP_OCEAN == b;
     }
 
+    public static boolean isRiverBiome(Biome b)
+    {
+        return RIVER == b;
+    }
+
+    public static boolean isLakeBiome(Biome b)
+    {
+        return LAKE == b;
+    }
+
     public static boolean isMountainBiome(Biome b)
     {
         return MOUNTAINS == b || MOUNTAINS_EDGE == b;
     }
+
 
     public static boolean isBeachBiome(Biome b)
     {

--- a/src/main/java/net/dries007/tfc/world/classic/genlayers/river/GenLayerRiverMixTFC.java
+++ b/src/main/java/net/dries007/tfc/world/classic/genlayers/river/GenLayerRiverMixTFC.java
@@ -92,7 +92,7 @@ public class GenLayerRiverMixTFC extends GenLayerTFC
                 zn = index - zSize;
                 zp = index + zSize;
 
-                if (BiomesTFC.isOceanicBiome(b) || BiomesTFC.isMountainBiome(b))
+                if (BiomesTFC.isOceanicBiome(b))
                     layerOut[index] = b;
                 else if (r > 0)
                 {
@@ -133,7 +133,6 @@ public class GenLayerRiverMixTFC extends GenLayerTFC
 
                 //Similar to above, if we're near a lake, we turn the river into lake.
                 removeRiver(index, Biome.getIdForBiome(BiomesTFC.LAKE));
-                removeRiver(index, Biome.getIdForBiome(BiomesTFC.MOUNTAINS_EDGE));
             }
         }
         return layerOut.clone();

--- a/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenTrees.java
+++ b/src/main/java/net/dries007/tfc/world/classic/worldgen/WorldGenTrees.java
@@ -44,7 +44,7 @@ public class WorldGenTrees implements IWorldGenerator
         if (!chunkData.isInitialized()) return;
 
         final Biome b = world.getBiome(chunkBlockPos);
-        if (!(b instanceof BiomeTFC) || b == BiomesTFC.OCEAN || b == BiomesTFC.DEEP_OCEAN || b == BiomesTFC.LAKE || b == BiomesTFC.RIVER)
+        if (!(b instanceof BiomeTFC) || b == BiomesTFC.OCEAN || b == BiomesTFC.DEEP_OCEAN)
             return;
 
         final TemplateManager manager = ((WorldServer) world).getStructureTemplateManager();


### PR DESCRIPTION
These commits fix several issues found in 1.12's worldgen.

List of issues fixed:

- Trees can now spawn next to lakes and rivers
- Rivers no longer dry up when they encounter elevated terrain. Instead, they can now form proper canyons.
- Cliffs can generate along beaches. This implementation is slightly different than 1.7.10's cliffs, as my implementation creates smoother, more realistic cliffs.
- Deep oceans now generate properly instead of generating a flat abyssal plain.