### PR TITLE
Prevent calendar from advancing with no players on

### DIFF
--- a/src/main/java/net/dries007/tfc/util/calendar/CalendarTFC.java
+++ b/src/main/java/net/dries007/tfc/util/calendar/CalendarTFC.java
@@ -274,7 +274,7 @@ public final class CalendarTFC implements INBTSerializable<NBTTagCompound>
      */
     public void onOverworldTick(World world)
     {
-        if (doDaylightCycle)
+        if (doDaylightCycle && arePlayersLoggedOn)
         {
             calendarTime++;
         }


### PR DESCRIPTION
Previously the calendar would continue ticking even when no players were logged on to a server, which appears to have been unintentional.

This is immediately noticeable when starting a server as
`[tfc]: World time and calendar time are out of sync by -2 ticks, correcting!`
is spammed repeatedly.