### PR TITLE
Replace Saplings as well as Leaves when placing templates.

### DIFF
--- a/src/main/java/net/dries007/tfc/world/classic/StructureHelper.java
+++ b/src/main/java/net/dries007/tfc/world/classic/StructureHelper.java
@@ -22,6 +22,7 @@ import net.minecraft.world.gen.structure.template.Template;
 
 import mcp.MethodsReturnNonnullByDefault;
 import net.dries007.tfc.objects.blocks.wood.BlockLeavesTFC;
+import net.dries007.tfc.objects.blocks.wood.BlockSaplingTFC;
 
 @ParametersAreNonnullByDefault
 @MethodsReturnNonnullByDefault
@@ -56,7 +57,7 @@ public final class StructureHelper
                     IBlockState iblockstate = template$blockinfo1.blockState.withMirror(placementIn.getMirror());
                     IBlockState iblockstate1 = iblockstate.withRotation(placementIn.getRotation());
 
-                    if (worldIn.getBlockState(blockpos).getMaterial().isReplaceable() || worldIn.getBlockState(blockpos).getBlock() instanceof BlockLeavesTFC)
+                    if (worldIn.getBlockState(blockpos).getMaterial().isReplaceable() || worldIn.getBlockState(blockpos).getBlock() instanceof BlockSaplingTFC || worldIn.getBlockState(blockpos).getBlock() instanceof BlockLeavesTFC)
                         worldIn.setBlockState(blockpos, iblockstate1, 2);
 
                 }


### PR DESCRIPTION
Correctly fixes #695, while not reverting the fixes for #617.
Selected the same test as used in TreeGenAcacia when placing logs.