### PR TITLE
Some small bugfixes.

### DIFF
--- a/src/main/java/net/dries007/tfc/api/capability/heat/CapabilityItemHeat.java
+++ b/src/main/java/net/dries007/tfc/api/capability/heat/CapabilityItemHeat.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
@@ -36,6 +37,8 @@ public final class CapabilityItemHeat
     public static void preInit()
     {
         CapabilityManager.INSTANCE.register(IItemHeat.class, new DumbStorage<>(), ItemHeatHandler::new);
+        //register heat on vanilla egg for cooking
+        CapabilityItemHeat.CUSTOM_ITEMS.put(IIngredient.of(Items.EGG), () -> new ItemHeatHandler(null, 1, 480));
     }
 
     /**

--- a/src/main/java/net/dries007/tfc/api/recipes/barrel/BarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/api/recipes/barrel/BarrelRecipe.java
@@ -198,7 +198,15 @@ public class BarrelRecipe extends IForgeRegistryEntry.Impl<BarrelRecipe>
     {
         if (isValidInput(inputFluid, inputStack))
         {
-            return Math.min(inputFluid.amount / this.inputFluid.getAmount(), inputStack.getCount() / this.inputStack.getAmount());
+            if (this.inputFluid.getAmount() == 0 ) {
+                return inputStack.getCount() / this.inputStack.getAmount();
+            }
+            else if (this.inputStack.getAmount() == 0) {
+                return inputFluid.amount / this.inputFluid.getAmount();
+            }
+            else {
+                return Math.min(inputFluid.amount / this.inputFluid.getAmount(), inputStack.getCount() / this.inputStack.getAmount());
+            }
         }
         return 0;
     }

--- a/src/main/java/net/dries007/tfc/api/recipes/barrel/BarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/api/recipes/barrel/BarrelRecipe.java
@@ -198,13 +198,16 @@ public class BarrelRecipe extends IForgeRegistryEntry.Impl<BarrelRecipe>
     {
         if (isValidInput(inputFluid, inputStack))
         {
-            if (this.inputFluid.getAmount() == 0 ) {
+            if (this.inputFluid.getAmount() == 0)
+            {
                 return inputStack.getCount() / this.inputStack.getAmount();
             }
-            else if (this.inputStack.getAmount() == 0) {
+            else if (this.inputStack.getAmount() == 0)
+            {
                 return inputFluid.amount / this.inputFluid.getAmount();
             }
-            else {
+            else
+            {
                 return Math.min(inputFluid.amount / this.inputFluid.getAmount(), inputStack.getCount() / this.inputStack.getAmount());
             }
         }

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockFenceGateTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockFenceGateTFC.java
@@ -32,6 +32,8 @@ public class BlockFenceGateTFC extends BlockFenceGate
         if (MAP.put(wood, this) != null) throw new IllegalStateException("There can only be one.");
         this.wood = wood;
         setHarvestLevel("axe", 0);
+        setHardness(2.0F); // match vanilla
+        setResistance(15.0F);
         OreDictionaryHelper.register(this, "fence", "gate", "wood");
         //noinspection ConstantConditions
         OreDictionaryHelper.register(this, "fence", "gate", "wood", wood.getRegistryName().getPath());

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockFenceTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockFenceTFC.java
@@ -32,6 +32,8 @@ public class BlockFenceTFC extends BlockFence
         if (MAP.put(wood, this) != null) throw new IllegalStateException("There can only be one.");
         this.wood = wood;
         setHarvestLevel("axe", 0);
+        setHardness(2.0F); // match vanilla
+        setResistance(15.0F);
         OreDictionaryHelper.register(this, "fence", "wood");
         //noinspection ConstantConditions
         OreDictionaryHelper.register(this, "fence", "wood", wood.getRegistryName().getPath());

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSaplingTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSaplingTFC.java
@@ -148,7 +148,6 @@ public class BlockSaplingTFC extends BlockBush implements IGrowable
     @Override
     public void grow(World world, Random random, BlockPos blockPos, IBlockState blockState)
     {
-        // Remove the sapling first, since the tree generator isn't required to check for it
         wood.makeTree(world, blockPos, random, false);
     }
 

--- a/src/main/java/net/dries007/tfc/objects/entity/animal/EntityAnimalOviparous.java
+++ b/src/main/java/net/dries007/tfc/objects/entity/animal/EntityAnimalOviparous.java
@@ -50,6 +50,7 @@ public abstract class EntityAnimalOviparous extends EntityAnimalTFC
     /**
      * Ignore fall damage like vanilla chickens. Implemented here because all TFC Oviparous animals don't take fall damage.
      * Ostriches would escape fall damage too.
+     *
      * @param distance
      * @param damageMultiplier
      */

--- a/src/main/java/net/dries007/tfc/objects/entity/animal/EntityAnimalOviparous.java
+++ b/src/main/java/net/dries007/tfc/objects/entity/animal/EntityAnimalOviparous.java
@@ -48,6 +48,17 @@ public abstract class EntityAnimalOviparous extends EntityAnimalTFC
     }
 
     /**
+     * Ignore fall damage like vanilla chickens. Implemented here because all TFC Oviparous animals don't take fall damage.
+     * Ostriches would escape fall damage too.
+     * @param distance
+     * @param damageMultiplier
+     */
+
+    @Override
+    public void fall(float distance, float damageMultiplier) {} //disable fall damage like vanilla
+
+
+    /**
      * Check if this female is ready to lay eggs
      *
      * @return true if ready

--- a/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
@@ -52,6 +52,9 @@ public final class FluidsTFC
     public static FluidWrapper TANNIN;
     public static FluidWrapper VINEGAR;
     public static FluidWrapper BRINE;
+    public static FluidWrapper MILK;
+    public static FluidWrapper CURDLED_MILK;
+    public static FluidWrapper MILK_VINEGAR;
     // Alcohols
     public static FluidWrapper CIDER;
     public static FluidWrapper VODKA;
@@ -154,12 +157,12 @@ public final class FluidsTFC
             .add(
                 VINEGAR = registerFluid(new Fluid("vinegar", STILL, FLOW, 0xFFC7C2AA)).with(PreservingProperty.PRESERVING, new PreservingProperty(FoodTrait.VINEGAR, new IngredientItemFoodTrait(IIngredient.any(), FoodTrait.PICKLED))),
                 BRINE = registerFluid(new Fluid("brine", STILL, FLOW, 0xFFDCD3C9)),
-                registerFluid(new Fluid("milk", STILL, FLOW, 0xFFFFFFFF)),
+                MILK = registerFluid(new Fluid("milk", STILL, FLOW, 0xFFFFFFFF)),
                 registerFluid(new Fluid("olive_oil", STILL, FLOW, 0xFF6A7537).setRarity(EnumRarity.RARE)),
                 TANNIN = registerFluid(new Fluid("tannin", STILL, FLOW, 0xFF63594E)),
                 LIMEWATER = registerFluid(new Fluid("limewater", STILL, FLOW, 0xFFB4B4B4)),
-                registerFluid(new Fluid("milk_curdled", STILL, FLOW, 0xFFFFFBE8)),
-                registerFluid(new Fluid("milk_vinegar", STILL, FLOW, 0xFFFFFBE8))
+                CURDLED_MILK = registerFluid(new Fluid("milk_curdled", STILL, FLOW, 0xFFFFFBE8)),
+                MILK_VINEGAR = registerFluid(new Fluid("milk_vinegar", STILL, FLOW, 0xFFFFFBE8))
             )
             .build();
 

--- a/src/main/java/net/dries007/tfc/objects/inventory/ingredient/IngredientItemStack.java
+++ b/src/main/java/net/dries007/tfc/objects/inventory/ingredient/IngredientItemStack.java
@@ -35,7 +35,7 @@ public class IngredientItemStack implements IIngredient<ItemStack>
     @Override
     public boolean testIgnoreCount(ItemStack stack)
     {
-        if (stack != null && !stack.isEmpty())
+        if (stack != null && (!stack.isEmpty() || inputStack.isEmpty()))
         {
             if (inputStack.getItem() == stack.getItem())
             {

--- a/src/main/java/net/dries007/tfc/objects/items/ItemsTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemsTFC.java
@@ -323,7 +323,6 @@ public final class ItemsTFC
             new ItemBlockTorch(Blocks.TORCH).setRegistryName("minecraft", "torch"),
             new ItemGlassBottleTFC().setRegistryName(Items.GLASS_BOTTLE.getRegistryName()).setTranslationKey("glassBottle")
         );
-        CapabilityItemHeat.CUSTOM_ITEMS.put(IIngredient.of(Items.EGG), () -> new ItemHeatHandler(null, 1, 480));
     }
 
     public static void init()

--- a/src/main/java/net/dries007/tfc/objects/items/ItemsTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemsTFC.java
@@ -7,6 +7,9 @@ package net.dries007.tfc.objects.items;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
+import net.dries007.tfc.api.capability.heat.CapabilityItemHeat;
+import net.dries007.tfc.api.capability.heat.ItemHeatHandler;
+import net.dries007.tfc.objects.inventory.ingredient.IIngredient;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
@@ -320,6 +323,7 @@ public final class ItemsTFC
             new ItemBlockTorch(Blocks.TORCH).setRegistryName("minecraft", "torch"),
             new ItemGlassBottleTFC().setRegistryName(Items.GLASS_BOTTLE.getRegistryName()).setTranslationKey("glassBottle")
         );
+        CapabilityItemHeat.CUSTOM_ITEMS.put(IIngredient.of(Items.EGG), () -> new ItemHeatHandler(null, 1, 480));
     }
 
     public static void init()

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemMetalTool.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemMetalTool.java
@@ -277,6 +277,8 @@ public class ItemMetalTool extends ItemMetal
                 return material == Material.SNOW || material == Material.CRAFTED_SNOW;
             case SCYTHE:
                 return material == Material.PLANTS || material == Material.VINE || material == Material.LEAVES;
+            case SWORD:
+                return material == Material.WEB;
         }
         return false;
     }

--- a/src/main/java/net/dries007/tfc/objects/te/TEBarrel.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEBarrel.java
@@ -259,8 +259,10 @@ public class TEBarrel extends TEInventory implements ITickable, IItemHandlerSide
                         surplus.addAll(output);
                         IBlockState state = world.getBlockState(pos);
                         world.notifyBlockUpdate(pos, state, state, 3);
+                        onSealed(); //run the sealed check again in case we have a new valid recipe.
                     }
-                    recipe = null;
+                    else recipe = null;
+
                 }
             }
 

--- a/src/main/java/net/dries007/tfc/objects/te/TEBarrel.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEBarrel.java
@@ -261,8 +261,10 @@ public class TEBarrel extends TEInventory implements ITickable, IItemHandlerSide
                         world.notifyBlockUpdate(pos, state, state, 3);
                         onSealed(); //run the sealed check again in case we have a new valid recipe.
                     }
-                    else recipe = null;
-
+                    else
+                    {
+                        recipe = null;
+                    }
                 }
             }
 

--- a/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
+++ b/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
@@ -96,7 +96,7 @@ public final class DefaultRecipes
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 1000), IIngredient.of("logWoodTannin"), new FluidStack(TANNIN.get(), 10000), ItemStack.EMPTY, 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("tannin"),
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 200), IIngredient.of(ItemsTFC.JUTE), null, new ItemStack(ItemsTFC.JUTE_FIBER), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("jute_fiber"),
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 600), IIngredient.of(ItemsTFC.SUGARCANE, 5), null, new ItemStack(Items.SUGAR), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("sugar"),
-            // Alcohol
+            // Alcohol - Classic created 1000mb with 4oz, which would be 8 items per full barrel at 5 oz/item. Instead we now require 20 items, so conversion is 2 oz/item here
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.BARLEY_FLOUR)), new FluidStack(FluidsTFC.BEER.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("beer"),
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of("apple"), new FluidStack(FluidsTFC.CIDER.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("cider"),
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(Items.SUGAR), new FluidStack(FluidsTFC.RUM.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("rum"),
@@ -105,7 +105,7 @@ public final class DefaultRecipes
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.WHEAT_FLOUR)), new FluidStack(FluidsTFC.WHISKEY.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("whiskey"),
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.CORNMEAL_FLOUR)), new FluidStack(FluidsTFC.CORN_WHISKEY.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("corn_whiskey"),
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.RYE_FLOUR)), new FluidStack(FluidsTFC.RYE_WHISKEY.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("rye_whiskey"),
-            // Vinegar
+            // Vinegar - Classic created 1000mb with 10 oz, which would be 20 items per full barrel at 5 oz/item. Instead we now require 40 items, so conversion is 2.5 oz/item.
             new BarrelRecipe(IIngredient.of(250, FluidsTFC.BEER.get(), FluidsTFC.CIDER.get(), FluidsTFC.RUM.get(), FluidsTFC.SAKE.get(), FluidsTFC.VODKA.get(), FluidsTFC.WHISKEY.get(), FluidsTFC.CORN_WHISKEY.get(), FluidsTFC.RYE_WHISKEY.get()), IIngredient.of("categoryFruit"), new FluidStack(FluidsTFC.VINEGAR.get(), 250), ItemStack.EMPTY, 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("vinegar"),
             // Food preservation
             BarrelRecipeFoodTraits.pickling(IIngredient.of("categoryFruit")).setRegistryName("pickling_fruit"),
@@ -116,12 +116,17 @@ public final class DefaultRecipes
             BarrelRecipeFoodTraits.brining(IIngredient.of("categoryMeat")).setRegistryName("brining_meat"),
 
             new BarrelRecipe(IIngredient.of(LIMEWATER.get(), 100), IIngredient.of("sand"), null, new ItemStack(ItemsTFC.MORTAR, 16), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("mortar"),
-            // todo: curdled milk -> cheese (use an empty IIngredient for the item)
+            new BarrelRecipe(IIngredient.of(MILK_VINEGAR.get(), 1), IIngredient.of(ItemStack.EMPTY), new FluidStack(CURDLED_MILK.get(), 1), ItemStack.EMPTY, 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("curdled_milk"),
+            // based on eating 5 oz in classic, and 1 item in TNG, the full barrel recipe generated 160 oz of cheese, now 32 items. Therefore 625mb creates 2 cheese.
+            new BarrelRecipe(IIngredient.of(CURDLED_MILK.get(), 625), IIngredient.of(ItemStack.EMPTY), null, new ItemStack(ItemFoodTFC.get(Food.CHEESE), 2), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("cheese"),
 
             // Instant recipes: set the duration to 0
-            new BarrelRecipeFluidMixing(IIngredient.of(VINEGAR.get(), 9), new IngredientFluidItem(SALT_WATER.get(), 1), new FluidStack(BRINE.get(), 10), 0).setRegistryName("brining"),
+            new BarrelRecipeFluidMixing(IIngredient.of(VINEGAR.get(), 9), new IngredientFluidItem(SALT_WATER.get(), 1), new FluidStack(BRINE.get(), 10), 0).setRegistryName("brine"),
+            new BarrelRecipeFluidMixing(IIngredient.of(MILK.get(), 9), new IngredientFluidItem(VINEGAR.get(), 1), new FluidStack(MILK_VINEGAR.get(), 10), 0).setRegistryName("milk_vinegar"),
+            // todo: net instead of ratios for curdled milk/brine? Classic would get 2000mb brine from 1000mb vinegar + 1000mb salt water, this gets 10/9 or 1111mb
+            // this ratio works for 9b + 1b = 10b (full barrel) of brine/milk_vinegar, but leaves odd ninths of fluid around for other mixtures.
+            //  previous todo had "make it a simpler calculation"
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of("dustFlux"), new FluidStack(LIMEWATER.get(), 500), ItemStack.EMPTY, 0).setRegistryName("limewater"),
-            // todo: curdled milk (make it a simpler calculation)
 
             new BarrelRecipeTemperature(IIngredient.of(FRESH_WATER.get(), 1), 50).setRegistryName("fresh_water_cooling"),
             new BarrelRecipeTemperature(IIngredient.of(SALT_WATER.get(), 1), 50).setRegistryName("salt_water_cooling")

--- a/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
+++ b/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
@@ -119,7 +119,7 @@ public final class DefaultRecipes
             // todo: curdled milk -> cheese (use an empty IIngredient for the item)
 
             // Instant recipes: set the duration to 0
-            new BarrelRecipeFluidMixing(IIngredient.of(FRESH_WATER.get(), 10), new IngredientFluidItem(SALT_WATER.get(), 1), new FluidStack(BRINE.get(), 10), 0).setRegistryName("brining"),
+            new BarrelRecipeFluidMixing(IIngredient.of(VINEGAR.get(), 9), new IngredientFluidItem(SALT_WATER.get(), 1), new FluidStack(BRINE.get(), 10), 0).setRegistryName("brining"),
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of("dustFlux"), new FluidStack(LIMEWATER.get(), 500), ItemStack.EMPTY, 0).setRegistryName("limewater"),
             // todo: curdled milk (make it a simpler calculation)
 

--- a/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
+++ b/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
@@ -265,6 +265,9 @@ public final class DefaultRecipes
             new HeatRecipeSimple(IIngredient.of(ItemFoodTFC.get(Food.RABBIT)), new ItemStack(ItemFoodTFC.get(Food.COOKED_RABBIT)), 200, 480).setRegistryName("cooked_rabbit"),
             new HeatRecipeSimple(IIngredient.of(ItemFoodTFC.get(Food.WOLF)), new ItemStack(ItemFoodTFC.get(Food.COOKED_WOLF)), 200, 480).setRegistryName("cooked_wolf"),
 
+            // Egg
+            new HeatRecipeSimple(IIngredient.of(Items.EGG), new ItemStack(ItemFoodTFC.get(Food.COOKED_EGG)), 200, 480).setRegistryName("cooked_egg"),
+
             // Bread
             HeatRecipe.destroy(IIngredient.of(ItemFoodTFC.get(Food.BARLEY_BREAD)), 480).setRegistryName("burned_barley_bread"),
             HeatRecipe.destroy(IIngredient.of(ItemFoodTFC.get(Food.CORNBREAD)), 480).setRegistryName("burned_cornbread"),
@@ -285,7 +288,11 @@ public final class DefaultRecipes
             HeatRecipe.destroy(IIngredient.of(ItemFoodTFC.get(Food.COOKED_PHEASANT)), 480).setRegistryName("burned_pheasant"),
             HeatRecipe.destroy(IIngredient.of(ItemFoodTFC.get(Food.COOKED_RABBIT)), 480).setRegistryName("burned_rabbit"),
             HeatRecipe.destroy(IIngredient.of(ItemFoodTFC.get(Food.COOKED_WOLF)), 480).setRegistryName("burned_wolf"),
-            HeatRecipe.destroy(IIngredient.of(ItemFoodTFC.get(Food.COOKED_VENISON)), 480).setRegistryName("burned_venison")
+            HeatRecipe.destroy(IIngredient.of(ItemFoodTFC.get(Food.COOKED_VENISON)), 480).setRegistryName("burned_venison"),
+
+            // Egg
+            HeatRecipe.destroy(IIngredient.of(Items.EGG), 480).setRegistryName("burned_egg")
+
         );
     }
 


### PR DESCRIPTION
Fix #687 by adding hardness and resistance matching vanilla
Fix #684 for TFC chickens and pheasants
Fix #676 by adding heat capacity to vanilla egg and a heating recipe for cooked eggs.
Fix #673 by adding a check for sword vs web to canHarvestBlock
Fix #663 by removing extra recipes, and changing output ratio of flour+water
Fix #678 by fixing brine recipe. Still consumes wooden bucket though.
Fix #701 by adding recipes for vinegar milk, curdled milk, and cheese. Adds empty input stack ability.