### PR TITLE
Fix the placement state of blocks chiseled from the side.

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemMetalChisel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemMetalChisel.java
@@ -136,6 +136,9 @@ public class ItemMetalChisel extends ItemMetalTool
 
                     if ((chiselMode == Mode.SLAB && block instanceof BlockSlab) || (chiselMode == Mode.STAIR && block instanceof BlockStairs))
                     {
+                        if (facing.getAxis().getPlane() != EnumFacing.Plane.VERTICAL)
+                            hitY = 1 - hitY;
+
                         return block.getStateForPlacement(worldIn, pos, facing, hitX, hitY, hitZ, resultItemStack.getMetadata(), player);
                     }
                 }


### PR DESCRIPTION
Fix the vertically of chiselled blocks when chiselled from the side.

This was originally working as intended but was broken in the Alc's ItemMetalChisel rewrite.