### PR TITLE
Add barrel recipe for salt water. Closes TerraFirmaCraft#643

### DIFF
--- a/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
+++ b/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
@@ -131,7 +131,8 @@ public final class DefaultRecipes
             // this ratio works for 9b + 1b = 10b (full barrel) of brine/milk_vinegar, but leaves odd ninths of fluid around for other mixtures.
             //  previous todo had "make it a simpler calculation"
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of("dustFlux"), new FluidStack(LIMEWATER.get(), 500), ItemStack.EMPTY, 0).setRegistryName("limewater"),
-
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemPowder.get(Powder.SALT)), new FluidStack(SALT_WATER.get(), 500), ItemStack.EMPTY, 0).setRegistryName("salt_water"),
+            
             new BarrelRecipeTemperature(IIngredient.of(FRESH_WATER.get(), 1), 50).setRegistryName("fresh_water_cooling"),
             new BarrelRecipeTemperature(IIngredient.of(SALT_WATER.get(), 1), 50).setRegistryName("salt_water_cooling")
         );


### PR DESCRIPTION
This barrel recipe creates salt water at a ratio of 20 salt powder and a full barrel of fresh water to a barrel of salt water. This allows you to brine about 80 pieces of food with the same amount of salt powder needed to salt 20 pieces of food. That's much more brine than in reality, but it's more practical given the low amount of salt powder yielded by mining/grinding rock salt.