### PR TITLE
Size and Weight Refactor

### DIFF
--- a/src/main/java/net/dries007/tfc/CommonEventHandler.java
+++ b/src/main/java/net/dries007/tfc/CommonEventHandler.java
@@ -730,7 +730,7 @@ public final class CommonEventHandler
         int hugeHeavyCount = 0;
         for (ItemStack stack : inventory.mainInventory)
         {
-            if (CapabilityItemSize.checkItemSize(stack, Size.HUGE, Weight.HEAVY))
+            if (CapabilityItemSize.checkItemSize(stack, Size.HUGE, Weight.VERY_HEAVY))
             {
                 hugeHeavyCount++;
                 if (hugeHeavyCount >= 2)
@@ -741,7 +741,7 @@ public final class CommonEventHandler
         }
         for (ItemStack stack : inventory.armorInventory)
         {
-            if (CapabilityItemSize.checkItemSize(stack, Size.HUGE, Weight.HEAVY))
+            if (CapabilityItemSize.checkItemSize(stack, Size.HUGE, Weight.VERY_HEAVY))
             {
                 hugeHeavyCount++;
                 if (hugeHeavyCount >= 2)
@@ -752,7 +752,7 @@ public final class CommonEventHandler
         }
         for (ItemStack stack : inventory.offHandInventory)
         {
-            if (CapabilityItemSize.checkItemSize(stack, Size.HUGE, Weight.HEAVY))
+            if (CapabilityItemSize.checkItemSize(stack, Size.HUGE, Weight.VERY_HEAVY))
             {
                 hugeHeavyCount++;
                 if (hugeHeavyCount >= 2)

--- a/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
+++ b/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
@@ -187,6 +187,9 @@ public final class TerraFirmaCraft
         }
 
         worldTypeTFC = new WorldTypeTFC();
+
+        CapabilityItemSize.init();
+        CapabilityItemHeat.init();
     }
 
     @Mod.EventHandler

--- a/src/main/java/net/dries007/tfc/api/capability/ItemStickCapability.java
+++ b/src/main/java/net/dries007/tfc/api/capability/ItemStickCapability.java
@@ -64,14 +64,14 @@ public class ItemStickCapability extends ItemHeatHandler implements IItemSize
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.SMALL;
+        return Size.SMALL; // Store anywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.VERY_LIGHT; // Stacksize = 64
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/api/capability/heat/CapabilityItemHeat.java
+++ b/src/main/java/net/dries007/tfc/api/capability/heat/CapabilityItemHeat.java
@@ -37,6 +37,11 @@ public final class CapabilityItemHeat
     public static void preInit()
     {
         CapabilityManager.INSTANCE.register(IItemHeat.class, new DumbStorage<>(), ItemHeatHandler::new);
+
+    }
+
+    public static void init()
+    {
         //register heat on vanilla egg for cooking
         CapabilityItemHeat.CUSTOM_ITEMS.put(IIngredient.of(Items.EGG), () -> new ItemHeatHandler(null, 1, 480));
     }

--- a/src/main/java/net/dries007/tfc/api/capability/size/CapabilityItemSize.java
+++ b/src/main/java/net/dries007/tfc/api/capability/size/CapabilityItemSize.java
@@ -37,17 +37,21 @@ public final class CapabilityItemSize
 
     public static void preInit()
     {
+        // Register the capability
         CapabilityManager.INSTANCE.register(IItemSize.class, new DumbStorage<>(), ItemSizeHandler::new);
+    }
 
+    public static void init()
+    {
         // Add hardcoded size values for vanilla items
-        CUSTOM_ITEMS.put(IIngredient.of(Items.COAL), () -> new ItemSizeHandler(Size.SMALL, Weight.MEDIUM, true));
-        CUSTOM_ITEMS.put(IIngredient.of(Items.STICK), ItemStickCapability::new);
-        CUSTOM_ITEMS.put(IIngredient.of(Items.CLAY_BALL), () -> new ItemSizeHandler(Size.SMALL, Weight.LIGHT, true));
-        CUSTOM_ITEMS.put(IIngredient.of(Items.BED), () -> new ItemSizeHandler(Size.LARGE, Weight.MEDIUM, false));
-        CUSTOM_ITEMS.put(IIngredient.of(Items.MINECART), () -> new ItemSizeHandler(Size.VERY_LARGE, Weight.HEAVY, false));
-        CUSTOM_ITEMS.put(IIngredient.of(Items.ARMOR_STAND), () -> new ItemSizeHandler(Size.LARGE, Weight.LIGHT, true));
-        CUSTOM_ITEMS.put(IIngredient.of(Items.CAULDRON), () -> new ItemSizeHandler(Size.SMALL, Weight.MEDIUM, true));
-        CUSTOM_ITEMS.put(IIngredient.of(Blocks.TRIPWIRE_HOOK), () -> new ItemSizeHandler(Size.VERY_SMALL, Weight.LIGHT, true));
+        CUSTOM_ITEMS.put(IIngredient.of(Items.COAL), () -> new ItemSizeHandler(Size.SMALL, Weight.LIGHT, true)); // Store anywhere stacksize = 32
+        CUSTOM_ITEMS.put(IIngredient.of(Items.STICK), ItemStickCapability::new); // Store anywhere stacksize = 64
+        CUSTOM_ITEMS.put(IIngredient.of(Items.CLAY_BALL), () -> new ItemSizeHandler(Size.SMALL, Weight.VERY_LIGHT, true)); // Store anywhere stacksize = 64
+        CUSTOM_ITEMS.put(IIngredient.of(Items.BED), () -> new ItemSizeHandler(Size.LARGE, Weight.VERY_HEAVY, false)); // Store only in chests stacksize = 1
+        CUSTOM_ITEMS.put(IIngredient.of(Items.MINECART), () -> new ItemSizeHandler(Size.LARGE, Weight.VERY_HEAVY, false)); // Store only in chests stacksize = 1
+        CUSTOM_ITEMS.put(IIngredient.of(Items.ARMOR_STAND), () -> new ItemSizeHandler(Size.LARGE, Weight.HEAVY, true)); // Store only in chests stacksize = 4
+        CUSTOM_ITEMS.put(IIngredient.of(Items.CAULDRON), () -> new ItemSizeHandler(Size.LARGE, Weight.LIGHT, true)); // Store only in chests stacksize = 32
+        CUSTOM_ITEMS.put(IIngredient.of(Blocks.TRIPWIRE_HOOK), () -> new ItemSizeHandler(Size.SMALL, Weight.VERY_LIGHT, true)); // Store anywhere stacksize = 64
     }
 
     /**
@@ -103,25 +107,25 @@ public final class CapabilityItemSize
         }
         // Check for generic item types
         Item item = stack.getItem();
-        if (item instanceof ItemTool)
+        if (item instanceof ItemTool || item instanceof ItemSword)
         {
-            return new ItemSizeHandler(Size.LARGE, Weight.MEDIUM, true);
+            return new ItemSizeHandler(Size.LARGE, Weight.MEDIUM, true); // Stored only in chests, stacksize should be limited to 1 since it is a tool
         }
         else if (item instanceof ItemArmor)
         {
-            return new ItemSizeHandler(Size.LARGE, Weight.HEAVY, true);
+            return new ItemSizeHandler(Size.LARGE, Weight.VERY_HEAVY, true); // Stored only in chests and stacksize = 1
         }
         else if (item instanceof ItemBlock && ((ItemBlock) item).getBlock() instanceof BlockLadder)
         {
-            return new ItemSizeHandler(Size.SMALL, Weight.LIGHT, true);
+            return new ItemSizeHandler(Size.SMALL, Weight.VERY_LIGHT, true); // Fits small vessels and stacksize = 64
         }
         else if (item instanceof ItemBlock)
         {
-            return new ItemSizeHandler(Size.SMALL, Weight.MEDIUM, true); // does not match classic, needed to fix #561
+            return new ItemSizeHandler(Size.SMALL, Weight.LIGHT, true); // Fits small vessels and stacksize = 32
         }
         else
         {
-            return new ItemSizeHandler(Size.VERY_SMALL, Weight.LIGHT, true);
+            return new ItemSizeHandler(Size.VERY_SMALL, Weight.VERY_LIGHT, true); // Stored anywhere and stacksize = 64
         }
     }
 }

--- a/src/main/java/net/dries007/tfc/api/capability/size/IItemSize.java
+++ b/src/main/java/net/dries007/tfc/api/capability/size/IItemSize.java
@@ -30,7 +30,7 @@ public interface IItemSize
 {
     static int getStackSize(Size size, Weight weight, boolean canStack)
     {
-        return canStack ? Math.min(size.stackSize * weight.multiplier, 64) : 1;
+        return canStack ? weight.stackSize : 1;
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/api/capability/size/ItemSizeHandler.java
+++ b/src/main/java/net/dries007/tfc/api/capability/size/ItemSizeHandler.java
@@ -28,7 +28,7 @@ public class ItemSizeHandler implements ICapabilityProvider, IItemSize
 
     public ItemSizeHandler()
     {
-        this(Size.NORMAL, Weight.MEDIUM, true);
+        this(Size.SMALL, Weight.LIGHT, true); // Default to fitting in small vessels and stacksize = 32
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/api/capability/size/Size.java
+++ b/src/main/java/net/dries007/tfc/api/capability/size/Size.java
@@ -7,26 +7,23 @@ package net.dries007.tfc.api.capability.size;
 
 public enum Size
 {
-    TINY("tiny", 64),
-    VERY_SMALL("very_small", 32),
-    SMALL("small", 16),
-    NORMAL("normal", 8),
-    LARGE("large", 4),
-    VERY_LARGE("very_large", 2),
-    HUGE("huge", 1);
+    TINY("tiny"),
+    VERY_SMALL("very_small"),
+    SMALL("small"),
+    NORMAL("normal"),
+    LARGE("large"),
+    VERY_LARGE("very_large"),
+    HUGE("huge");
 
-    public final int stackSize;
     public final String name;
 
-    Size(String name, int stackSize)
+    Size(String name)
     {
         this.name = name;
-        this.stackSize = stackSize;
     }
 
     public boolean isSmallerThan(Size other)
     {
-        return this.stackSize > other.stackSize;
+        return this.ordinal() < other.ordinal();
     }
-
 }

--- a/src/main/java/net/dries007/tfc/api/capability/size/Weight.java
+++ b/src/main/java/net/dries007/tfc/api/capability/size/Weight.java
@@ -7,21 +7,23 @@ package net.dries007.tfc.api.capability.size;
 
 public enum Weight
 {
-    LIGHT("light", 4),
-    MEDIUM("medium", 2),
-    HEAVY("heavy", 1);
+    VERY_LIGHT("very_light", 64),
+    LIGHT("light", 32),
+    MEDIUM("medium", 16),
+    HEAVY("heavy", 4),
+    VERY_HEAVY("very_heavy", 1);
 
+    public final int stackSize;
     public final String name;
-    public final int multiplier;
 
-    Weight(String name, int multiplier)
+    Weight(String name, int stackSize)
     {
         this.name = name;
-        this.multiplier = multiplier;
+        this.stackSize = stackSize;
     }
 
     public boolean isSmallerThan(Weight other)
     {
-        return this.multiplier > other.multiplier;
+        return this.stackSize > other.stackSize;
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlockFireBrick.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlockFireBrick.java
@@ -31,13 +31,13 @@ public class BlockFireBrick extends Block implements IItemSize
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.VERY_SMALL;
+        return Size.SMALL; // Stored everywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.LIGHT; // Stacksize = 32
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlockLargeVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlockLargeVessel.java
@@ -84,14 +84,14 @@ public class BlockLargeVessel extends Block implements IItemSize
     @Nonnull
     public Size getSize(ItemStack stack)
     {
-        return Size.HUGE;
+        return stack.getTagCompound() == null ? Size.VERY_LARGE : Size.HUGE; // Causes overburden if sealed
     }
 
     @Override
     @Nonnull
     public Weight getWeight(ItemStack stack)
     {
-        return stack.getTagCompound() == null ? Weight.MEDIUM : Weight.HEAVY;
+        return Weight.VERY_HEAVY; // Stacksize = 1
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlockTorchTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlockTorchTFC.java
@@ -65,14 +65,14 @@ public class BlockTorchTFC extends BlockTorch implements IItemSize, ILightableBl
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.NORMAL;
+        return Size.SMALL; // Can store anywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.LIGHT; // Stacksize = 32
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockBloomery.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockBloomery.java
@@ -214,14 +214,14 @@ public class BlockBloomery extends BlockHorizontal implements IItemSize, ILighta
     @Nonnull
     public Size getSize(ItemStack stack)
     {
-        return Size.VERY_SMALL;
+        return Size.LARGE; // Only in chests
     }
 
     @Override
     @Nonnull
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.VERY_HEAVY;  // stacksize = 1
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockCrucible.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockCrucible.java
@@ -72,14 +72,14 @@ public class BlockCrucible extends Block implements IHeatConsumerBlock, IItemSiz
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.HUGE;
+        return stack.getTagCompound() == null ? Size.LARGE : Size.HUGE; // Can only store in chests if not full, overburden if full and more than one is carried
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return stack.getTagCompound() == null ? Weight.MEDIUM : Weight.HEAVY;
+        return Weight.VERY_HEAVY;  // stacksize = 1
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockQuern.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockQuern.java
@@ -62,14 +62,14 @@ public class BlockQuern extends Block implements IItemSize, IHighlightHandler
     @Nonnull
     public Size getSize(ItemStack stack)
     {
-        return Size.VERY_LARGE;
+        return Size.VERY_LARGE; // Can't store anywhere, but don't overburden
     }
 
     @Override
     @Nonnull
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.VERY_HEAVY; // Stacksize = 1
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockSluice.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockSluice.java
@@ -74,14 +74,14 @@ public class BlockSluice extends BlockHorizontal implements IItemSize
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.HUGE;
+        return Size.LARGE; // Only in chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.VERY_HEAVY; // Stack size = 1
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/net/dries007/tfc/objects/blocks/plants/BlockCactusTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/plants/BlockCactusTFC.java
@@ -121,14 +121,14 @@ public class BlockCactusTFC extends BlockPlantTFC implements IGrowable, ITallPla
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.NORMAL;
+        return Size.SMALL; // Can store everywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.MEDIUM; // stacksize = 16
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/blocks/plants/BlockPlantTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/plants/BlockPlantTFC.java
@@ -237,14 +237,14 @@ public class BlockPlantTFC extends BlockBush implements IItemSize
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.SMALL;
+        return Size.TINY; // Store anywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.VERY_LIGHT; // Stacksize = 64
     }
 
     public double getGrowthRate(World world, BlockPos pos)

--- a/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockVariant.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockVariant.java
@@ -368,14 +368,14 @@ public class BlockRockVariant extends Block implements IItemSize
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.SMALL;
+        return Size.SMALL; // Store anywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.MEDIUM;
+        return Weight.LIGHT; // Stacksize = 32
     }
 
     protected void onRockSlide(World world, BlockPos pos)

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockBarrel.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockBarrel.java
@@ -90,14 +90,14 @@ public class BlockBarrel extends Block implements IItemSize
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.HUGE;
+        return stack.getTagCompound() == null ? Size.VERY_LARGE : Size.HUGE; // Causes overburden if sealed
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return stack.getTagCompound() == null ? Weight.MEDIUM : Weight.HEAVY;
+        return Weight.VERY_HEAVY; // Stacksize = 1
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockChestTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockChestTFC.java
@@ -7,6 +7,7 @@ package net.dries007.tfc.objects.blocks.wood;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -18,6 +19,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.passive.EntityOcelot;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
 import net.minecraft.util.EnumFacing;
@@ -27,6 +29,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ILockableContainer;
 import net.minecraft.world.World;
 
+import net.dries007.tfc.api.capability.size.IItemSize;
+import net.dries007.tfc.api.capability.size.Size;
+import net.dries007.tfc.api.capability.size.Weight;
 import net.dries007.tfc.api.types.Tree;
 import net.dries007.tfc.client.TFCGuiHandler;
 import net.dries007.tfc.objects.inventory.capability.TFCInventoryLargeChest;
@@ -34,7 +39,7 @@ import net.dries007.tfc.objects.te.TEChestTFC;
 import net.dries007.tfc.util.OreDictionaryHelper;
 
 @ParametersAreNonnullByDefault
-public class BlockChestTFC extends BlockChest
+public class BlockChestTFC extends BlockChest implements IItemSize
 {
     private static final Map<Tree, BlockChestTFC> MAP_BASIC = new HashMap<>();
     private static final Map<Tree, BlockChestTFC> MAP_TRAP = new HashMap<>();
@@ -147,6 +152,20 @@ public class BlockChestTFC extends BlockChest
     public TileEntity createNewTileEntity(World worldIn, int meta)
     {
         return new TEChestTFC();
+    }
+
+    @Nonnull
+    @Override
+    public Size getSize(@Nonnull ItemStack stack)
+    {
+        return Size.LARGE; // Can only be stored in itself (and since this can't be carried with items, makes sense
+    }
+
+    @Nonnull
+    @Override
+    public Weight getWeight(@Nonnull ItemStack stack)
+    {
+        return Weight.LIGHT; // Stacksize = 32
     }
 
     private boolean isBlocked(World worldIn, BlockPos pos)

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockLogTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockLogTFC.java
@@ -237,13 +237,13 @@ public class BlockLogTFC extends BlockLog implements IItemSize
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.VERY_LARGE; // Can't store anywhere, but not overburden
     }
 
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.MEDIUM; // Stacksize = 16
     }
 
     private boolean removeTree(World world, BlockPos pos, @Nullable EntityPlayer player, ItemStack stack, boolean stoneTool)

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockLoom.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockLoom.java
@@ -73,14 +73,14 @@ public class BlockLoom extends BlockContainer implements IItemSize
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Can only store in chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.VERY_HEAVY; // Stacksize = 1
     }
 
     @Nullable

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockToolRack.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockToolRack.java
@@ -63,14 +63,14 @@ public class BlockToolRack extends BlockContainer implements IItemSize
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Stored only in chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.VERY_HEAVY; // Stacksize = 1
     }
 
     @Nullable

--- a/src/main/java/net/dries007/tfc/objects/container/ContainerChestTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/container/ContainerChestTFC.java
@@ -137,7 +137,7 @@ public class ContainerChestTFC extends Container
             IItemSize cap = CapabilityItemSize.getIItemSize(stack);
             if (cap != null)
             {
-                return cap.getSize(stack).isSmallerThan(Size.LARGE);
+                return cap.getSize(stack).isSmallerThan(Size.VERY_LARGE);
             }
             return true;
         }

--- a/src/main/java/net/dries007/tfc/objects/container/ContainerSmallVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/container/ContainerSmallVessel.java
@@ -32,7 +32,7 @@ public class ContainerSmallVessel extends ContainerItemStack implements ISlotCal
         IItemSize size = CapabilityItemSize.getIItemSize(stack);
         if (size != null)
         {
-            return size.getSize(stack).isSmallerThan(Size.LARGE);
+            return size.getSize(stack).isSmallerThan(Size.NORMAL);
         }
         return false;
     }

--- a/src/main/java/net/dries007/tfc/objects/items/ItemAnimalHide.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemAnimalHide.java
@@ -104,23 +104,23 @@ public class ItemAnimalHide extends ItemTFC
     @Nonnull
     public Size getSize(ItemStack stack)
     {
-        switch (size)
-        {
-            case LARGE:
-                return Size.SMALL;
-            case MEDIUM:
-                return Size.VERY_SMALL;
-            case SMALL:
-            default:
-                return Size.TINY;
-        }
+        return Size.NORMAL; // Stored in chests and Large Vessels
     }
 
     @Override
     @Nonnull
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        switch (size)
+        {
+            case LARGE:
+                return Weight.MEDIUM; // Stacksize = 16
+            case MEDIUM:
+                return Weight.LIGHT; // Stacksize = 32
+            case SMALL:
+            default:
+                return Weight.VERY_LIGHT; // Stacksize = 64
+        }
     }
 
     public enum HideSize implements IStringSerializable

--- a/src/main/java/net/dries007/tfc/objects/items/ItemArmorTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemArmorTFC.java
@@ -50,14 +50,14 @@ public class ItemArmorTFC extends ItemArmor implements IItemSize, IDamageResista
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Stored in chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.HEAVY; // Stacksize is already restricted to 1
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/ItemBloom.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemBloom.java
@@ -43,14 +43,14 @@ public class ItemBloom extends ItemTFC implements IMetalItem
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Stored in chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.HEAVY; // Stacksize = 4
     }
 
     @Nullable

--- a/src/main/java/net/dries007/tfc/objects/items/ItemFireStarter.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemFireStarter.java
@@ -264,14 +264,14 @@ public class ItemFireStarter extends ItemTFC
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.SMALL;
+        return Size.SMALL; // Stored anywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.LIGHT; // Stacksize is always 1, don't need to change this
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/ItemGem.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemGem.java
@@ -81,14 +81,14 @@ public class ItemGem extends ItemTFC
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.TINY;
+        return Size.SMALL; // Stored anywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.VERY_LIGHT; // Stacksize = 64
     }
 
     @Nullable

--- a/src/main/java/net/dries007/tfc/objects/items/ItemGoldPan.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemGoldPan.java
@@ -184,14 +184,14 @@ public class ItemGoldPan extends ItemTFC
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.SMALL;
+        return Size.NORMAL; // Stored in large vessels and chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.MEDIUM; // Stacksize = 16
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/ItemPowder.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemPowder.java
@@ -50,14 +50,14 @@ public class ItemPowder extends ItemTFC
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.TINY;
+        return Size.SMALL; // Stored everywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.VERY_LIGHT; // Stacksize = 64
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/ItemSlabTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemSlabTFC.java
@@ -30,13 +30,13 @@ public class ItemSlabTFC extends ItemSlab implements IItemSize
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.SMALL;
+        return Size.SMALL; // if blocks fits in small vessels, this should too
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.MEDIUM;
+        return Weight.VERY_LIGHT; // Double the stacksize of a block (or 64)
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/items/ItemsTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemsTFC.java
@@ -158,7 +158,7 @@ public final class ItemsTFC
         Builder<Item> simpleItems = ImmutableList.builder();
 
         simpleItems.add(register(r, "wand", new ItemDebug(), CT_MISC));
-        simpleItems.add(register(r, "mortar", new ItemMisc(Size.TINY, Weight.LIGHT, "mortar"), CT_MISC));
+        simpleItems.add(register(r, "mortar", new ItemMisc(Size.TINY, Weight.VERY_LIGHT, "mortar"), CT_MISC));
         register(r, "wooden_bucket", new ItemWoodenBucket(), CT_WOOD); //not a simple item, use a custom model
         register(r, "metal/bucket/blue_steel", new ItemMetalBucket(Metal.BLUE_STEEL, Metal.ItemType.BUCKET), CT_METAL); //not a simple item, use a custom model
         register(r, "metal/bucket/red_steel", new ItemMetalBucket(Metal.RED_STEEL, Metal.ItemType.BUCKET), CT_METAL); //not a simple item, use a custom model
@@ -261,7 +261,7 @@ public final class ItemsTFC
             registerPottery(simpleItems, r, "ceramics/unfired/spindle", "ceramics/fired/spindle");
             registerPottery(simpleItems, r, "ceramics/unfired/fire_brick", "ceramics/fired/fire_brick");
 
-            simpleItems.add(register(r, "ceramics/fire_clay", new ItemMisc(Size.VERY_SMALL, Weight.MEDIUM, "fire_clay"), CT_MISC));
+            simpleItems.add(register(r, "ceramics/fire_clay", new ItemMisc(Size.VERY_SMALL, Weight.VERY_LIGHT, "fire_clay"), CT_MISC));
 
             simpleItems.add(register(r, "ceramics/unfired/jug", new ItemPottery(), CT_POTTERY));
             register(r, "ceramics/fired/jug", new ItemJug(), CT_POTTERY);
@@ -273,9 +273,9 @@ public final class ItemsTFC
             simpleItems.add(register(r, "crop/seeds/" + crop.name().toLowerCase(), new ItemSeedsTFC(crop), CT_FOOD));
         }
 
-        simpleItems.add(register(r, "crop/product/jute", new ItemMisc(Size.TINY, Weight.LIGHT), CT_MISC));
-        simpleItems.add(register(r, "crop/product/jute_fiber", new ItemMisc(Size.TINY, Weight.LIGHT), CT_MISC));
-        simpleItems.add(register(r, "crop/product/burlap_cloth", new ItemMisc(Size.TINY, Weight.LIGHT), CT_MISC));
+        simpleItems.add(register(r, "crop/product/jute", new ItemMisc(Size.SMALL, Weight.VERY_LIGHT), CT_MISC));
+        simpleItems.add(register(r, "crop/product/jute_fiber", new ItemMisc(Size.SMALL, Weight.VERY_LIGHT), CT_MISC));
+        simpleItems.add(register(r, "crop/product/burlap_cloth", new ItemMisc(Size.SMALL, Weight.VERY_LIGHT), CT_MISC));
 
         // All simple foods (not meals) just use ItemFood and are registered here
         for (Food food : Food.values())
@@ -300,8 +300,8 @@ public final class ItemsTFC
         }
 
         simpleItems.add(register(r, "firestarter", new ItemFireStarter(), CT_MISC));
-        simpleItems.add(register(r, "straw", new ItemMisc(Size.SMALL, Weight.LIGHT, "kindling", "straw"), CT_MISC));
-        simpleItems.add(register(r, "handstone", new ItemCraftingTool(250, Size.NORMAL, Weight.HEAVY, "handstone"), CT_MISC));
+        simpleItems.add(register(r, "straw", new ItemMisc(Size.SMALL, Weight.VERY_LIGHT, "kindling", "straw"), CT_MISC));
+        simpleItems.add(register(r, "handstone", new ItemCraftingTool(250, Size.NORMAL, Weight.VERY_HEAVY, "handstone"), CT_MISC));
 
         simpleItems.add(register(r, "spindle", new ItemCraftingTool(40, Size.NORMAL, Weight.MEDIUM, "spindle"), CT_MISC));
 
@@ -317,13 +317,13 @@ public final class ItemsTFC
             }
         }
 
-        simpleItems.add(register(r, "animal/product/wool", new ItemMisc(Size.TINY, Weight.LIGHT), CT_MISC));
-        simpleItems.add(register(r, "animal/product/wool_yarn", new ItemMisc(Size.TINY, Weight.LIGHT, "string"), CT_MISC));
-        simpleItems.add(register(r, "animal/product/wool_cloth", new ItemMisc(Size.TINY, Weight.LIGHT, "cloth_high_quality"), CT_MISC));
-        simpleItems.add(register(r, "animal/product/silk_cloth", new ItemMisc(Size.TINY, Weight.LIGHT, "cloth_high_quality"), CT_MISC));
+        simpleItems.add(register(r, "animal/product/wool", new ItemMisc(Size.SMALL, Weight.LIGHT), CT_MISC));
+        simpleItems.add(register(r, "animal/product/wool_yarn", new ItemMisc(Size.VERY_SMALL, Weight.VERY_LIGHT, "string"), CT_MISC));
+        simpleItems.add(register(r, "animal/product/wool_cloth", new ItemMisc(Size.SMALL, Weight.LIGHT, "cloth_high_quality"), CT_MISC));
+        simpleItems.add(register(r, "animal/product/silk_cloth", new ItemMisc(Size.SMALL, Weight.LIGHT, "cloth_high_quality"), CT_MISC));
 
         register(r, "goldpan", new ItemGoldPan(), CT_MISC);
-        simpleItems.add(register(r, "wrought_iron_grill", new ItemMisc(Size.LARGE, Weight.MEDIUM, "grill"), CT_MISC));
+        simpleItems.add(register(r, "wrought_iron_grill", new ItemMisc(Size.LARGE, Weight.HEAVY, "grill"), CT_MISC));
 
         allSimpleItems = simpleItems.build();
 

--- a/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemPottery.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemPottery.java
@@ -23,14 +23,14 @@ public class ItemPottery extends ItemTFC
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.SMALL;
+        return Size.NORMAL; // Fits in large vessels and chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.MEDIUM;
+        return Weight.LIGHT; // Stacksize = 32
     }
 
     @Nullable

--- a/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
@@ -158,14 +158,14 @@ public class ItemSmallVessel extends ItemPottery
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.SMALL;
+        return Size.NORMAL; // Can't be stored in itself
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.VERY_HEAVY; // Stacksize = 1
     }
 
     @Nullable
@@ -393,7 +393,7 @@ public class ItemSmallVessel extends ItemPottery
             IItemSize size = CapabilityItemSize.getIItemSize(stack);
             if (size != null)
             {
-                return size.getSize(stack).isSmallerThan(Size.LARGE) && size.getWeight(stack).isSmallerThan(Weight.HEAVY);
+                return size.getSize(stack).isSmallerThan(Size.NORMAL);
             }
             return false;
         }

--- a/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemUnfiredLargeVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemUnfiredLargeVessel.java
@@ -18,13 +18,13 @@ public class ItemUnfiredLargeVessel extends ItemPottery
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.HUGE;
+        return Size.VERY_LARGE; // Don't fit in chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.MEDIUM;
+        return Weight.VERY_HEAVY; // Stack size = 1
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/items/itemblock/ItemBlockTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/itemblock/ItemBlockTFC.java
@@ -36,14 +36,14 @@ public class ItemBlockTFC extends ItemBlock implements IItemSize
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return size != null ? size.getSize(stack) : Size.VERY_SMALL;
+        return size != null ? size.getSize(stack) : Size.SMALL; // Stored everywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return size != null ? size.getWeight(stack) : Weight.MEDIUM;
+        return size != null ? size.getWeight(stack) : Weight.LIGHT; // Stacksize = 32
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemAnvil.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemAnvil.java
@@ -38,14 +38,14 @@ public class ItemAnvil extends ItemMetal
     @Nonnull
     public Size getSize(ItemStack stack)
     {
-        return Size.HUGE;
+        return Size.HUGE; // Can't be stored and causes overburden
     }
 
     @Override
     @Nonnull
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.HEAVY;
+        return Weight.VERY_HEAVY; // Stacksize = 1
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemMetal.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemMetal.java
@@ -129,41 +129,28 @@ public class ItemMetal extends ItemTFC implements IMetalItem
     {
         switch (type)
         {
-            case HAMMER:
-            case DOUBLE_INGOT:
-            case SHEET:
-            case SCRAP:
-            case LAMP:
-            case TUYERE:
-            case PICK_HEAD:
-            case SHOVEL_HEAD:
-            case AXE_HEAD:
-            case HOE_HEAD:
-            case CHISEL:
-            case CHISEL_HEAD:
-            case SWORD_BLADE:
-            case MACE_HEAD:
-            case SAW_BLADE:
-            case JAVELIN_HEAD:
-            case HAMMER_HEAD:
-            case PROPICK:
-            case PROPICK_HEAD:
-            case KNIFE:
-            case KNIFE_BLADE:
-            case SCYTHE:
-                return Size.SMALL;
-            case SAW:
-            case DOUBLE_SHEET:
-                return Size.NORMAL;
-            case ANVIL:
-                return Size.HUGE;
-            case INGOT:
-            case DUST:
-                return Size.VERY_SMALL;
             case NUGGET:
-                return Size.TINY;
+            case DUST:
+            case SCRAP:
+                return Size.SMALL; // Fits in Small Vessels
+            case PICK_HEAD:
+            case HAMMER_HEAD:
+            case HOE_HEAD:
+            case AXE_HEAD:
+            case CHISEL_HEAD:
+            case JAVELIN_HEAD:
+            case MACE_HEAD:
+            case PROPICK_HEAD:
+            case SHOVEL_HEAD:
+            case KNIFE_BLADE:
+            case SAW_BLADE:
+            case SCYTHE_BLADE:
+            case SWORD_BLADE:
+                return Size.NORMAL; // Tool heads fits in large vessels
+            case ANVIL:
+                return Size.HUGE; // Overburdens
             default:
-                return Size.LARGE;
+                return Size.LARGE; // Everything else fits only in chests
         }
     }
 
@@ -173,28 +160,27 @@ public class ItemMetal extends ItemTFC implements IMetalItem
     {
         switch (type)
         {
+            case DUST:
+            case NUGGET:
+            case SCRAP:
+                return Weight.VERY_LIGHT; // Stacksize = 64
             case INGOT:
             case DOUBLE_INGOT:
             case SHEET:
             case DOUBLE_SHEET:
+                return Weight.LIGHT; // Stacksize = 32
             case ANVIL:
             case HELMET:
             case GREAVES:
             case CHESTPLATE:
             case BOOTS:
-                return Weight.HEAVY;
-            case HOE:
-            case DUST:
-            case NUGGET:
-            case LAMP:
-            case TUYERE:
             case UNFINISHED_CHESTPLATE:
             case UNFINISHED_GREAVES:
             case UNFINISHED_HELMET:
             case UNFINISHED_BOOTS:
-                return Weight.LIGHT;
+                return Weight.VERY_HEAVY; // Stacksize = 1
             default:
-                return Weight.MEDIUM;
+                return Weight.MEDIUM; // Stacksize = 16 for everything else, but tools will still stack only to 1
         }
     }
 

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemOreTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemOreTFC.java
@@ -172,13 +172,13 @@ public class ItemOreTFC extends ItemTFC implements IMetalItem
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.NORMAL;
+        return Size.SMALL; // Fits in Small Vessels
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.MEDIUM;
+        return Weight.MEDIUM; // Stacksize = 16
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemSmallOre.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemSmallOre.java
@@ -93,14 +93,14 @@ public class ItemSmallOre extends ItemTFC implements IMetalItem
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.NORMAL;
+        return Size.SMALL; // Fits in Small vessels
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.MEDIUM;
+        return Weight.MEDIUM; // Stacksize = 16
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemBrickTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemBrickTFC.java
@@ -50,14 +50,14 @@ public class ItemBrickTFC extends ItemTFC implements IRockObject
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.TINY;
+        return Size.SMALL; // Stored everywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.LIGHT; // Stacksize = 32
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRock.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRock.java
@@ -78,14 +78,14 @@ public class ItemRock extends ItemTFC implements IRockObject
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.TINY;
+        return Size.SMALL; // Stored everywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.VERY_LIGHT; // Stacksize = 64
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockAxe.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockAxe.java
@@ -65,7 +65,7 @@ public class ItemRockAxe extends ItemAxe implements IItemSize, IRockObject
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Stored only in chests
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockHammer.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockHammer.java
@@ -66,7 +66,7 @@ public class ItemRockHammer extends ItemTool implements IItemSize, IRockObject
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE;  // Stored only in chests
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockHoe.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockHoe.java
@@ -63,7 +63,7 @@ public class ItemRockHoe extends ItemHoe implements IItemSize, IRockObject
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Stored only in chests
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockJavelin.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockJavelin.java
@@ -77,7 +77,7 @@ public class ItemRockJavelin extends ItemTool implements IItemSize, IRockObject
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Stored only in chests
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockKnife.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockKnife.java
@@ -78,7 +78,7 @@ public class ItemRockKnife extends ItemTool implements IItemSize, IRockObject
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.NORMAL;
+        return Size.NORMAL; // Stored in large vessels
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockShovel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockShovel.java
@@ -109,7 +109,7 @@ public class ItemRockShovel extends ItemSpade implements IItemSize, IRockObject
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Stored only in chests
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockToolHead.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockToolHead.java
@@ -49,14 +49,14 @@ public class ItemRockToolHead extends ItemTFC implements IRockObject
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.TINY;
+        return Size.SMALL; // Stored everywhere
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.LIGHT; // Stacksize = 32
     }
 
     @Nullable

--- a/src/main/java/net/dries007/tfc/objects/items/wood/ItemBoatTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/wood/ItemBoatTFC.java
@@ -63,14 +63,14 @@ public class ItemBoatTFC extends ItemTFC
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Stored in chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.MEDIUM; // Stacksize = 16
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/wood/ItemDoorTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/wood/ItemDoorTFC.java
@@ -48,14 +48,14 @@ public class ItemDoorTFC extends ItemDoor implements IItemSize
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.HUGE;
+        return Size.VERY_LARGE; // Can't be stored
     }
 
     @Nonnull
     @Override
     public Weight getWeight(ItemStack stack)
     {
-        return Weight.MEDIUM;
+        return Weight.HEAVY; // Stacksize = 4
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/items/wood/ItemLumberTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/wood/ItemLumberTFC.java
@@ -51,7 +51,7 @@ public class ItemLumberTFC extends ItemTFC
     @Override
     public Size getSize(ItemStack stack)
     {
-        return Size.NORMAL;
+        return Size.NORMAL; // Stored in Large Vessels and Chests
     }
 
     @Nonnull

--- a/src/main/java/net/dries007/tfc/objects/items/wood/ItemWoodenBucket.java
+++ b/src/main/java/net/dries007/tfc/objects/items/wood/ItemWoodenBucket.java
@@ -53,14 +53,14 @@ public class ItemWoodenBucket extends ItemTFC
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return Size.LARGE;
+        return Size.LARGE; // Can be stored in chests
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return Weight.LIGHT;
+        return Weight.MEDIUM; // Stacksize 16
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/te/TEBarrel.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEBarrel.java
@@ -30,9 +30,6 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.dries007.tfc.ConfigTFC;
 import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.api.capability.food.CapabilityFood;
-import net.dries007.tfc.api.capability.size.CapabilityItemSize;
-import net.dries007.tfc.api.capability.size.IItemSize;
-import net.dries007.tfc.api.capability.size.Size;
 import net.dries007.tfc.api.recipes.barrel.BarrelRecipe;
 import net.dries007.tfc.network.PacketBarrelUpdate;
 import net.dries007.tfc.objects.fluids.FluidsTFC;
@@ -415,11 +412,6 @@ public class TEBarrel extends TEInventory implements ITickable, IItemHandlerSide
             case SLOT_FLUID_CONTAINER_IN:
                 return stack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
             case SLOT_ITEM:
-                IItemSize sizeCap = CapabilityItemSize.getIItemSize(stack);
-                if (sizeCap != null)
-                {
-                    return sizeCap.getSize(stack).isSmallerThan(Size.VERY_LARGE);
-                }
                 return true;
             default:
                 return false;

--- a/src/main/java/net/dries007/tfc/objects/te/TEChestTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEChestTFC.java
@@ -31,7 +31,6 @@ import mcp.MethodsReturnNonnullByDefault;
 import net.dries007.tfc.api.capability.size.CapabilityItemSize;
 import net.dries007.tfc.api.capability.size.IItemSize;
 import net.dries007.tfc.api.capability.size.Size;
-import net.dries007.tfc.api.capability.size.Weight;
 import net.dries007.tfc.api.types.Tree;
 import net.dries007.tfc.objects.blocks.wood.BlockChestTFC;
 import net.dries007.tfc.objects.container.ContainerChestTFC;
@@ -205,7 +204,7 @@ public class TEChestTFC extends TileEntityChest implements ISlotCallback
         IItemSize cap = CapabilityItemSize.getIItemSize(stack);
         if (cap != null)
         {
-            return cap.getSize(stack).isSmallerThan(Size.LARGE) && cap.getWeight(stack).isSmallerThan(Weight.HEAVY);
+            return cap.getSize(stack).isSmallerThan(Size.VERY_LARGE);
         }
         return true;
     }

--- a/src/main/java/net/dries007/tfc/objects/te/TELargeVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TELargeVessel.java
@@ -26,7 +26,6 @@ import net.dries007.tfc.api.capability.food.FoodTrait;
 import net.dries007.tfc.api.capability.size.CapabilityItemSize;
 import net.dries007.tfc.api.capability.size.IItemSize;
 import net.dries007.tfc.api.capability.size.Size;
-import net.dries007.tfc.api.capability.size.Weight;
 import net.dries007.tfc.network.PacketLargeVesselUpdate;
 import net.dries007.tfc.objects.blocks.BlockLargeVessel;
 import net.dries007.tfc.objects.inventory.capability.IItemHandlerSidedCallback;
@@ -194,7 +193,7 @@ public class TELargeVessel extends TEInventory implements IItemHandlerSidedCallb
         IItemSize sizeCap = CapabilityItemSize.getIItemSize(stack);
         if (sizeCap != null)
         {
-            return sizeCap.getSize(stack).isSmallerThan(Size.LARGE) && sizeCap.getWeight(stack).isSmallerThan(Weight.HEAVY);
+            return sizeCap.getSize(stack).isSmallerThan(Size.LARGE);
         }
         return true;
     }

--- a/src/main/java/net/dries007/tfc/objects/te/TEPlacedItem.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEPlacedItem.java
@@ -137,7 +137,7 @@ public class TEPlacedItem extends TEInventory
                 size = sizeCap.getSize(stack);
             }
 
-            if (size.isSmallerThan(Size.HUGE) && !isHoldingLargeItem)
+            if (size.isSmallerThan(Size.VERY_LARGE) && !isHoldingLargeItem)
             {
                 // Normal and smaller can be placed normally
                 if (inventory.getStackInSlot(slot).isEmpty())
@@ -147,7 +147,7 @@ public class TEPlacedItem extends TEInventory
                     return true;
                 }
             }
-            else if (size == Size.HUGE)
+            else if (!size.isSmallerThan(Size.VERY_LARGE)) // Very Large or Huge
             {
                 // Large items are placed in the single center slot
                 if (isEmpty())

--- a/src/main/resources/assets/tfc/lang/en_us.lang
+++ b/src/main/resources/assets/tfc/lang/en_us.lang
@@ -566,9 +566,11 @@ tfc.enum.size.very_large=Very Large
 tfc.enum.size.huge=Huge
 
 ## Weight
+tfc.enum.weight.very_light=Very Light
 tfc.enum.weight.light=Light
 tfc.enum.weight.medium=Medium
 tfc.enum.weight.heavy=Heavy
+tfc.enum.weight.very_heavy=Very Heavy
 
 ## Heat
 tfc.enum.heat.warming=Warming


### PR DESCRIPTION
- Weight controls stack size while size controls container suitability.
- Added Very Light and Very Heavy Weights (stack sizes = 1, 4, 16, 32, 64).
- Chests restricts to Large and below.
- Large vessels restricts to Normal and below.
- Small vessels restricts to Small and below.
- Placed items (fire pit) holds only 1 stack if said item is Very Large or Huge.
- Went over and changed values for every item to match.