### PR TITLE
A few more fixes

### DIFF
--- a/src/main/java/net/dries007/tfc/api/capability/food/IFood.java
+++ b/src/main/java/net/dries007/tfc/api/capability/food/IFood.java
@@ -130,17 +130,17 @@ public interface IFood extends INBTSerializable<NBTTagCompound>
                 switch (ConfigTFC.CLIENT.decayTooltipMode)
                 {
                     case 0:
-                        return;
+                        break;
                     case 1:
                         text.add(TextFormatting.DARK_GREEN + I18n.format("tfc.tooltip.food_expiry_date", ICalendarFormatted.getTimeAndDate(rottenCalendarTime, CalendarTFC.CALENDAR_TIME.getDaysInMonth())));
-                        return;
+                        break;
                     case 2:
                         text.add(TextFormatting.BLUE + I18n.format("tfc.tooltip.food_expiry_date.days", String.valueOf(ICalendar.getTotalDays(daysToRotInTicks))));
-                        return;
+                        break;
                     case 3:
                         text.add(TextFormatting.DARK_GREEN + I18n.format("tfc.tooltip.food_expiry_date", ICalendarFormatted.getTimeAndDate(rottenCalendarTime, CalendarTFC.CALENDAR_TIME.getDaysInMonth())));
                         text.add(TextFormatting.BLUE + I18n.format("tfc.tooltip.food_expiry_date.days", String.valueOf(ICalendar.getTotalDays(daysToRotInTicks))));
-                        return;
+                        break;
                 }
             }
         }

--- a/src/main/java/net/dries007/tfc/api/recipes/anvil/AnvilRecipeSplitting.java
+++ b/src/main/java/net/dries007/tfc/api/recipes/anvil/AnvilRecipeSplitting.java
@@ -68,8 +68,7 @@ public class AnvilRecipeSplitting extends AnvilRecipeMeasurable
                     IForgeable cap = dump.getCapability(CapabilityForgeable.FORGEABLE_CAPABILITY, null);
                     if (cap instanceof IForgeableMeasurableMetal)
                     {
-                        cap.setWork(0); //Reset work without resetting temp
-                        cap.setRecipe((ResourceLocation) null);
+                        cap.reset();
                         ((IForgeableMeasurableMetal) cap).setMetalAmount(splitAmount);
                         ((IForgeableMeasurableMetal) cap).setMetal(metal);
                     }
@@ -81,8 +80,7 @@ public class AnvilRecipeSplitting extends AnvilRecipeMeasurable
                     IForgeable cap = dumpSurplus.getCapability(CapabilityForgeable.FORGEABLE_CAPABILITY, null);
                     if (cap instanceof IForgeableMeasurableMetal)
                     {
-                        cap.setWork(0); //Reset work without resetting temp
-                        cap.setRecipe((ResourceLocation) null);
+                        cap.reset();
                         ((IForgeableMeasurableMetal) cap).setMetalAmount(surplus);
                         ((IForgeableMeasurableMetal) cap).setMetal(metal);
                     }

--- a/src/main/java/net/dries007/tfc/client/ClientEvents.java
+++ b/src/main/java/net/dries007/tfc/client/ClientEvents.java
@@ -257,7 +257,8 @@ public class ClientEvents
             float skillMod = SmithingSkill.getSkillBonus(stack);
             if (skillMod > 0)
             {
-                tt.add(I18n.format("tfc.tooltip.smithing_skill", skillMod * 100));
+                String skillValue = String.format("%.2f", skillMod * 100);
+                tt.add(I18n.format("tfc.tooltip.smithing_skill", skillValue));
             }
 
             if (event.getFlags().isAdvanced()) // Only added with advanced tooltip mode

--- a/src/main/java/net/dries007/tfc/compat/waila/BloomeryProvider.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/BloomeryProvider.java
@@ -44,7 +44,7 @@ public class BloomeryProvider implements IWailaDataProvider, IWailaPlugin
             {
                 List<ItemStack> oreStacks = bloomery.getOreStacks();
                 BloomeryRecipe recipe = oreStacks.size() > 0 ? BloomeryRecipe.get(oreStacks.get(0)) : null;
-                long remainingMinutes = Math.round(bloomery.getBurnTicksLeft() / 1200.0f);
+                long remainingMinutes = Math.round(bloomery.getReaminingTicks() / 1200.0f);
                 currentTooltip.add(new TextComponentTranslation("waila.tfc.devices.remaining", remainingMinutes).getFormattedText());
                 if (recipe != null)
                 {

--- a/src/main/java/net/dries007/tfc/compat/waila/BloomeryProvider.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/BloomeryProvider.java
@@ -44,7 +44,7 @@ public class BloomeryProvider implements IWailaDataProvider, IWailaPlugin
             {
                 List<ItemStack> oreStacks = bloomery.getOreStacks();
                 BloomeryRecipe recipe = oreStacks.size() > 0 ? BloomeryRecipe.get(oreStacks.get(0)) : null;
-                long remainingMinutes = Math.round(bloomery.getReaminingTicks() / 1200.0f);
+                long remainingMinutes = Math.round(bloomery.getRemainingTicks() / 1200.0f);
                 currentTooltip.add(new TextComponentTranslation("waila.tfc.devices.remaining", remainingMinutes).getFormattedText());
                 if (recipe != null)
                 {

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemOreTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemOreTFC.java
@@ -112,29 +112,38 @@ public class ItemOreTFC extends ItemTFC implements IMetalItem
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn)
+    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag flagIn)
     {
         Metal metal = getMetal(stack);
         if (metal != null)
         {
-            // Like classic, "Metal: xx units"
-            String info = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units", getSmeltAmount(stack)));
-            // not like Classic, "Metal: xx total units" Adds the whole stacks worth up.
-            String stackTotal = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units.total", getSmeltAmount(stack) * stack.getCount()));
-
+            int smeltAmount = this.getSmeltAmount(stack);
             switch (ConfigTFC.CLIENT.oreTooltipMode)
             {
                 case 0:
                     break;
                 case 1:
+                    // Like classic, "Metal: xx units"
+                    String info = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units", smeltAmount));
                     tooltip.add(info);
                     break;
                 case 2:
+                    // not like Classic, "Metal: xx total units" Adds the whole stacks worth up.
+                    String stackTotal = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units.total", smeltAmount * stack.getCount()));
                     tooltip.add(stackTotal);
                     break;
                 case 3:
-                    tooltip.add(info);
-                    tooltip.add(stackTotal);
+                    // All info: "Metal: xx units / xx total"
+                    String infoTotal;
+                    if(stack.getCount() > 1)
+                    {
+                        infoTotal = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units.info_total", smeltAmount, smeltAmount * stack.getCount()));
+                    }
+                    else
+                    {
+                        infoTotal = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units", smeltAmount));
+                    }
+                    tooltip.add(infoTotal);
             }
         }
     }

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemSmallOre.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemSmallOre.java
@@ -111,29 +111,38 @@ public class ItemSmallOre extends ItemTFC implements IMetalItem
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn)
+    public void addInformation(@Nonnull ItemStack stack, @Nullable World worldIn, @Nonnull List<String> tooltip, @Nonnull ITooltipFlag flagIn)
     {
         Metal metal = getMetal(stack);
         if (metal != null)
         {
-            // Like classic, "Metal: xx units"
-            String info = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units", getSmeltAmount(stack)));
-            // not like Classic, "Metal: xx total units" Adds the whole stacks worth up.
-            String stackTotal = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units.total", getSmeltAmount(stack) * stack.getCount()));
-
+            int smeltAmount = this.getSmeltAmount(stack);
             switch (ConfigTFC.CLIENT.oreTooltipMode)
             {
                 case 0:
                     break;
                 case 1:
+                    // Like classic, "Metal: xx units"
+                    String info = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units", smeltAmount));
                     tooltip.add(info);
                     break;
                 case 2:
+                    // not like Classic, "Metal: xx total units" Adds the whole stacks worth up.
+                    String stackTotal = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units.total", smeltAmount * stack.getCount()));
                     tooltip.add(stackTotal);
                     break;
                 case 3:
-                    tooltip.add(info);
-                    tooltip.add(stackTotal);
+                    // All info: "Metal: xx units / xx total"
+                    String infoTotal;
+                    if(stack.getCount() > 1)
+                    {
+                        infoTotal = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units.info_total", smeltAmount, smeltAmount * stack.getCount()));
+                    }
+                    else
+                    {
+                        infoTotal = String.format("%s: %s", I18n.format(Helpers.getTypeName(metal)), I18n.format("tfc.tooltip.units", smeltAmount));
+                    }
+                    tooltip.add(infoTotal);
             }
         }
     }

--- a/src/main/java/net/dries007/tfc/objects/recipes/ShapelessSaltingRecipe.java
+++ b/src/main/java/net/dries007/tfc/objects/recipes/ShapelessSaltingRecipe.java
@@ -41,13 +41,13 @@ public class ShapelessSaltingRecipe extends ShapelessOreRecipe
         for (int i = 0; i < inv.getSizeInventory(); i++)
         {
             ItemStack stack = inv.getStackInSlot(i).copy();
+            stack.setCount(1);
             IFood food = stack.getCapability(CapabilityFood.CAPABILITY, null);
-            if (food != null)
+            if (food != null && !food.getTraits().contains(FoodTrait.SALTED))
             {
                 // Only apply salt to first food item found
                 CapabilityFood.applyTrait(food, FoodTrait.SALTED);
-                result = stack.copy();
-                result.setCount(1);
+                result = stack;
                 break;
             }
         }

--- a/src/main/java/net/dries007/tfc/objects/te/TEBloomery.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEBloomery.java
@@ -34,7 +34,6 @@ import net.dries007.tfc.objects.blocks.BlocksTFC;
 import net.dries007.tfc.objects.blocks.devices.BlockBloomery;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.calendar.CalendarTFC;
-import net.dries007.tfc.util.calendar.ICalendarTickable;
 
 import static net.dries007.tfc.objects.blocks.property.ILightableBlock.LIT;
 import static net.minecraft.block.BlockHorizontal.FACING;
@@ -127,7 +126,7 @@ public class TEBloomery extends TETickableInventory implements ITickable
             IBlockState state = world.getBlockState(pos);
             if (state.getValue(LIT))
             {
-                if (this.getReaminingTicks() <= 0)
+                if (this.getRemainingTicks() <= 0)
                 {
                     if (cachedRecipe == null && !oreStacks.isEmpty())
                     {
@@ -215,7 +214,7 @@ public class TEBloomery extends TETickableInventory implements ITickable
         }
     }
 
-    public long getReaminingTicks()
+    public long getRemainingTicks()
     {
         return ConfigTFC.GENERAL.bloomeryTime - (CalendarTFC.PLAYER_TIME.getTicks() - litTick);
     }

--- a/src/main/resources/assets/tfc/lang/en_us.lang
+++ b/src/main/resources/assets/tfc/lang/en_us.lang
@@ -84,6 +84,7 @@ tfc.tooltip.metal=§fMetal:§7 %s
 tfc.tooltip.units=%d units
 tfc.tooltip.crucible_units=%d / %d units
 tfc.tooltip.units.total=§6%d total units
+tfc.tooltip.units.info_total=%d units / §6%d total
 tfc.tooltip.smelting=Smelt in %s
 tfc.tooltip.liquid= - Liquid
 tfc.tooltip.solid= - Solid


### PR DESCRIPTION
- Reworked bloomery logic (Fixes #1194).
- Fixed traits tooltip and also made salting recipe only apply once (Closes #1198).
- Reworked melting units tooltip in ores and small ores (Closes #1193).
- Reworked Waila integration to Crops (Closes #1188).
- Smithing bonus now is rounded (Closes #1175).
- Fixed bloom's not resetting work properly on splitting recipes (Closes #1166).