### PR TITLE
restrict berry bush / fruit tree spawning based on rainfall and temp

### DIFF
--- a/src/main/java/net/dries007/tfc/util/agriculture/BerryBush.java
+++ b/src/main/java/net/dries007/tfc/util/agriculture/BerryBush.java
@@ -18,17 +18,17 @@ import static net.dries007.tfc.api.types.IBerryBush.Size.*;
 
 public enum BerryBush implements IBerryBush
 {
-    BLACKBERRY(Food.BLACKBERRY, Month.MAY, 4, 5f, 25f, 125f, 400f, 0.8f, LARGE, true),
-    BLUEBERRY(Food.BLUEBERRY, Month.JUNE, 3, 5f, 25f, 125f, 200f, 0.8f, LARGE, false),
-    BUNCH_BERRY(Food.BUNCH_BERRY, Month.JUNE, 3, -5f, 20f, 125f, 280f, 0.8f, SMALL, false),
-    CLOUD_BERRY(Food.CLOUD_BERRY, Month.JUNE, 2, -5f, 20f, 175f, 280f, 0.8f, MEDIUM, false),
-    CRANBERRY(Food.CRANBERRY, Month.AUGUST, 3, -5f, 25f, 250f, 400f, 0.8f, MEDIUM, false),
-    ELDERBERRY(Food.ELDERBERRY, Month.JULY, 2, 5f, 25f, 175f, 280f, 0.8f, LARGE, false),
-    GOOSEBERRY(Food.GOOSEBERRY, Month.MARCH, 4, 5f, 25f, 175f, 280f, 0.8f, MEDIUM, false),
-    RASPBERRY(Food.RASPBERRY, Month.JUNE, 2, 5f, 25f, 175f, 280f, 0.8f, LARGE, true),
-    SNOW_BERRY(Food.SNOW_BERRY, Month.JULY, 2, -5f, 20f, 175f, 400f, 0.8f, SMALL, false),
-    STRAWBERRY(Food.STRAWBERRY, Month.MARCH, 3, 5f, 25f, 250f, 400f, 0.8f, SMALL, false),
-    WINTERGREEN_BERRY(Food.WINTERGREEN_BERRY, Month.AUGUST, 2, -5f, 20f, 250f, 400f, 0.8f, SMALL, false);
+    BLACKBERRY(Food.BLACKBERRY, Month.MAY, 4, 5f, 35f, 100f, 400f, 0.8f, LARGE, true),
+    BLUEBERRY(Food.BLUEBERRY, Month.JUNE, 3, 5f, 35f, 100f, 400f, 0.8f, LARGE, false),
+    BUNCH_BERRY(Food.BUNCH_BERRY, Month.JUNE, 3, 5f, 35f, 100f, 400f, 0.8f, SMALL, false),
+    CLOUD_BERRY(Food.CLOUD_BERRY, Month.JUNE, 2, 5f, 35f, 100f, 400f, 0.8f, MEDIUM, false),
+    CRANBERRY(Food.CRANBERRY, Month.AUGUST, 3, 5f, 35f, 100f, 400f, 0.8f, MEDIUM, false),
+    ELDERBERRY(Food.ELDERBERRY, Month.JULY, 2, 5f, 35f, 100f, 400f, 0.8f, LARGE, false),
+    GOOSEBERRY(Food.GOOSEBERRY, Month.MARCH, 4, 5f, 35f, 100f, 400f, 0.8f, MEDIUM, false),
+    RASPBERRY(Food.RASPBERRY, Month.JUNE, 2, 5f, 35f, 100f, 400f, 0.8f, LARGE, true),
+    SNOW_BERRY(Food.SNOW_BERRY, Month.JULY, 2, -5f, 25f, 100f, 400f, 0.8f, SMALL, false),
+    STRAWBERRY(Food.STRAWBERRY, Month.MARCH, 3, 5f, 35f, 100f, 400f, 0.8f, SMALL, false),
+    WINTERGREEN_BERRY(Food.WINTERGREEN_BERRY, Month.AUGUST, 2, -5f, 25f, 100f, 400f, 0.8f, SMALL, false);
 
     static
     {

--- a/src/main/java/net/dries007/tfc/util/agriculture/BerryBush.java
+++ b/src/main/java/net/dries007/tfc/util/agriculture/BerryBush.java
@@ -18,17 +18,17 @@ import static net.dries007.tfc.api.types.IBerryBush.Size.*;
 
 public enum BerryBush implements IBerryBush
 {
-    BLACKBERRY(Food.BLACKBERRY, Month.MAY, 4, 5f, 35f, 100f, 400f, 0.8f, LARGE, true),
-    BLUEBERRY(Food.BLUEBERRY, Month.JUNE, 3, 5f, 35f, 100f, 400f, 0.8f, LARGE, false),
-    BUNCH_BERRY(Food.BUNCH_BERRY, Month.JUNE, 3, 5f, 35f, 100f, 400f, 0.8f, SMALL, false),
-    CLOUD_BERRY(Food.CLOUD_BERRY, Month.JUNE, 2, 5f, 35f, 100f, 400f, 0.8f, MEDIUM, false),
-    CRANBERRY(Food.CRANBERRY, Month.AUGUST, 3, 5f, 35f, 100f, 400f, 0.8f, MEDIUM, false),
-    ELDERBERRY(Food.ELDERBERRY, Month.JULY, 2, 5f, 35f, 100f, 400f, 0.8f, LARGE, false),
-    GOOSEBERRY(Food.GOOSEBERRY, Month.MARCH, 4, 5f, 35f, 100f, 400f, 0.8f, MEDIUM, false),
-    RASPBERRY(Food.RASPBERRY, Month.JUNE, 2, 5f, 35f, 100f, 400f, 0.8f, LARGE, true),
-    SNOW_BERRY(Food.SNOW_BERRY, Month.JULY, 2, -5f, 25f, 100f, 400f, 0.8f, SMALL, false),
-    STRAWBERRY(Food.STRAWBERRY, Month.MARCH, 3, 5f, 35f, 100f, 400f, 0.8f, SMALL, false),
-    WINTERGREEN_BERRY(Food.WINTERGREEN_BERRY, Month.AUGUST, 2, -5f, 25f, 100f, 400f, 0.8f, SMALL, false);
+    BLACKBERRY(Food.BLACKBERRY, Month.MAY, 4, 7f, 20f, 100f, 400f, 0.8f, LARGE, true),
+    BLUEBERRY(Food.BLUEBERRY, Month.JUNE, 3, 7f, 25f, 100f, 400f, 0.8f, LARGE, false),
+    BUNCH_BERRY(Food.BUNCH_BERRY, Month.JUNE, 3, 15f, 30f, 100f, 400f, 0.8f, SMALL, false),
+    CLOUD_BERRY(Food.CLOUD_BERRY, Month.JUNE, 2, 3f, 17f, 100f, 400f, 0.8f, MEDIUM, false),
+    CRANBERRY(Food.CRANBERRY, Month.AUGUST, 3, 1f, 19f, 100f, 400f, 0.8f, MEDIUM, false),
+    ELDERBERRY(Food.ELDERBERRY, Month.JULY, 2, 10f, 29f, 100f, 400f, 0.8f, LARGE, false),
+    GOOSEBERRY(Food.GOOSEBERRY, Month.MARCH, 4, 5f, 27f, 100f, 400f, 0.8f, MEDIUM, false),
+    RASPBERRY(Food.RASPBERRY, Month.JUNE, 2, 5f, 20f, 100f, 400f, 0.8f, LARGE, true),
+    SNOW_BERRY(Food.SNOW_BERRY, Month.JULY, 2, -5f, 18f, 100f, 400f, 0.8f, SMALL, false),
+    STRAWBERRY(Food.STRAWBERRY, Month.MARCH, 3, 5f, 28f, 100f, 400f, 0.8f, SMALL, false),
+    WINTERGREEN_BERRY(Food.WINTERGREEN_BERRY, Month.AUGUST, 2, -5f, 17f, 100f, 400f, 0.8f, SMALL, false);
 
     static
     {

--- a/src/main/java/net/dries007/tfc/util/agriculture/FruitTree.java
+++ b/src/main/java/net/dries007/tfc/util/agriculture/FruitTree.java
@@ -16,15 +16,15 @@ import net.dries007.tfc.world.classic.worldgen.WorldGenFruitTrees;
 
 public enum FruitTree implements IFruitTree
 {
-    BANANA(Food.BANANA, Month.APRIL, 2, Month.SEPTEMBER, 1, 5f, 35f, 100f, 400f, 0.33f),
-    CHERRY(Food.CHERRY, Month.APRIL, 1, Month.JUNE, 1, 5f, 35f, 100f, 400f, 0.33f),
-    GREEN_APPLE(Food.GREEN_APPLE, Month.MAY, 2, Month.OCTOBER, 2, 5f, 35f, 100f, 400f, 0.33f),
-    LEMON(Food.LEMON, Month.MAY, 2, Month.AUGUST, 1, 5f, 35f, 100f, 400f, 0.33f),
-    OLIVE(Food.OLIVE, Month.JUNE, 1, Month.OCTOBER, 1, 5f, 35f, 100f, 400f, 0.33f),
-    ORANGE(Food.ORANGE, Month.FEBRUARY, 3, Month.NOVEMBER, 1, 5f, 35f, 100f, 400f, 0.33f),
-    PEACH(Food.PEACH, Month.APRIL, 2, Month.SEPTEMBER, 1, 5f, 35f, 100f, 400f, 0.33f),
-    PLUM(Food.PLUM, Month.MAY, 2, Month.JULY, 2, 5f, 35f, 100f, 400f, 0.33f),
-    RED_APPLE(Food.RED_APPLE, Month.MAY, 2, Month.OCTOBER, 2, 5f, 35f, 100f, 400f, 0.33f);
+    BANANA(Food.BANANA, Month.APRIL, 2, Month.SEPTEMBER, 1, 26f, 35f, 300f, 400f, 0.33f),
+    CHERRY(Food.CHERRY, Month.APRIL, 1, Month.JUNE, 1, 5f, 18f, 100f, 350f, 0.33f),
+    GREEN_APPLE(Food.GREEN_APPLE, Month.MAY, 2, Month.OCTOBER, 2, 9f, 21f, 110f, 280f, 0.33f),
+    LEMON(Food.LEMON, Month.MAY, 2, Month.AUGUST, 1, 14f, 30f, 200f, 400f, 0.33f),
+    OLIVE(Food.OLIVE, Month.JUNE, 1, Month.OCTOBER, 1, 19f, 35f, 180f, 380f, 0.33f),
+    ORANGE(Food.ORANGE, Month.FEBRUARY, 3, Month.NOVEMBER, 1, 23f, 33f, 260f, 400f, 0.33f),
+    PEACH(Food.PEACH, Month.APRIL, 2, Month.SEPTEMBER, 1, 9f, 23f, 60f, 230f, 0.33f),
+    PLUM(Food.PLUM, Month.MAY, 2, Month.JULY, 2, 24f, 28f, 250f, 400f, 0.33f),
+    RED_APPLE(Food.RED_APPLE, Month.MAY, 2, Month.OCTOBER, 2, 9f, 21f, 100f, 280f, 0.33f);
 
     static
     {


### PR DESCRIPTION
Changelog message for Moo to use:

- Fruit trees and bushes now will spawn only in areas where the rainfall and temperature allows them to, instead of all over the map.
    - Plums, oranges and bananas prefer the hotter environments
    - Lemons and olives spawn in hot as well as temperate environments.
    - Apples  like slightly colder and temperate environments, and prefer areas with less rainfall
    - Peaches will survive anywhere that isn't hot or rainy
    - Cherries extend the furthest into colder regions than any other fruit tree
    - Berries universally prefer colder weather. Wintergreen can even grow in negative temperatures
    - Elderberries, gooseberries, bunch berries, and strawberries are the only berries that are able to spawn in hotter regions