### PR TITLE
A few fixes

### DIFF
--- a/src/main/java/net/dries007/tfc/ConfigTFC.java
+++ b/src/main/java/net/dries007/tfc/ConfigTFC.java
@@ -725,6 +725,11 @@ public final class ConfigTFC
             @Config.Comment("Let crucibles accept pouring metal (from small vessels / molds) from all 9 input slots at the same time.")
             @Config.LangKey("config." + MOD_ID + ".devices.crucible.enableAllSlots")
             public boolean enableAllSlots = false;
+
+            @Config.Comment("How fast should crucibles accept fluids from molds / small vessel?")
+            @Config.RangeInt(min = 1)
+            @Config.LangKey("config." + MOD_ID + ".devices.crucible.pouringSpeed")
+            public int pouringSpeed = 1;
         }
 
         public static final class CharcoalPitCFG

--- a/src/main/java/net/dries007/tfc/api/types/Rock.java
+++ b/src/main/java/net/dries007/tfc/api/types/Rock.java
@@ -116,6 +116,7 @@ public class Rock extends IForgeRegistryEntry.Impl<Rock>
     public enum Type
     {
         RAW(Material.ROCK, FALL_VERTICAL, false, BlockRockRaw::new),
+        ANVIL(Material.ROCK, FALL_VERTICAL, false, BlockStoneAnvil::new),
         SPIKE(Material.ROCK, NO_FALL, false, BlockRockSpike::new),
         SMOOTH(Material.ROCK, NO_FALL, false),
         COBBLE(Material.ROCK, FALL_HORIZONTAL, false),

--- a/src/main/java/net/dries007/tfc/client/model/animal/ModelHorseTFC.java
+++ b/src/main/java/net/dries007/tfc/client/model/animal/ModelHorseTFC.java
@@ -275,6 +275,12 @@ public class ModelHorseTFC extends ModelHorse
 
         this.head.render(scale);
         GlStateManager.popMatrix();
+
+        if (!this.isChild && horse instanceof AbstractChestHorse && ((AbstractChestHorse)horse).hasChest())
+        {
+            this.muleLeftChest.render(scale);
+            this.muleRightChest.render(scale);
+        }
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/compat/waila/interfaces/HwylaBlockInterface.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/interfaces/HwylaBlockInterface.java
@@ -65,7 +65,12 @@ public class HwylaBlockInterface implements IWailaDataProvider, IWailaPlugin
     @Override
     public List<String> getWailaHead(ItemStack itemStack, List<String> currentTooltip, IWailaDataAccessor accessor, IWailaConfigHandler config)
     {
-        currentTooltip.add(TextFormatting.WHITE.toString() + internal.getTitle(accessor.getWorld(), accessor.getPosition(), accessor.getNBTData()));
+        String title = internal.getTitle(accessor.getWorld(), accessor.getPosition(), accessor.getNBTData());
+        if (!title.isEmpty())
+        {
+            currentTooltip.clear();
+            currentTooltip.add(TextFormatting.WHITE.toString() + title);
+        }
         return currentTooltip;
     }
 

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlocksTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlocksTFC.java
@@ -370,8 +370,20 @@ public final class BlocksTFC
         {
             Builder<BlockRockVariant> b = ImmutableList.builder();
             for (Rock.Type type : Rock.Type.values())
+            {
                 for (Rock rock : TFCRegistries.ROCKS.getValuesCollection())
-                    b.add(register(r, type.name().toLowerCase() + "/" + rock.getRegistryName().getPath(), BlockRockVariant.create(rock, type), CT_ROCK_BLOCKS));
+                {
+                    if (type != Rock.Type.ANVIL)
+                    {
+                        b.add(register(r, type.name().toLowerCase() + "/" + rock.getRegistryName().getPath(), BlockRockVariant.create(rock, type), CT_ROCK_BLOCKS));
+                    }
+                    else if (rock.getRockCategory().hasAnvil())
+                    {
+                        // Anvil registration is special, is has it's own folder
+                        register(r, "anvil/" + rock.getRegistryName().getPath(), BlockRockVariant.create(rock, type));
+                    }
+                }
+            }
             allBlockRockVariants = b.build();
             allBlockRockVariants.forEach(x ->
             {
@@ -379,7 +391,7 @@ public final class BlocksTFC
                 {
                     normalItemBlocks.add(new ItemBlockHeat(x, 1, 600));
                 }
-                else if (x.getType() != Rock.Type.SPIKE)
+                else if (x.getType() != Rock.Type.SPIKE && x.getType() != Rock.Type.ANVIL)
                 {
                     normalItemBlocks.add(new ItemBlockTFC(x));
                 }
@@ -507,11 +519,6 @@ public final class BlocksTFC
                 inventoryItemBlocks.add(new ItemBlockTFC(register(r, "stone/button/" + rock.getRegistryName().getPath().toLowerCase(), new BlockButtonStoneTFC(rock), CT_DECORATIONS)));
                 inventoryItemBlocks.add(new ItemBlockTFC(register(r, "stone/pressure_plate/" + rock.getRegistryName().getPath().toLowerCase(), new BlockPressurePlateTFC(rock), CT_DECORATIONS)));
             }
-
-            // Anvils are special because they don't have an ItemBlock + they only exist for certian types
-            for (Rock rock : TFCRegistries.ROCKS.getValuesCollection())
-                if (rock.getRockCategory().hasAnvil())
-                    register(r, "anvil/" + rock.getRegistryName().getPath(), new BlockStoneAnvil(rock));
 
             allWallBlocks = b.build();
             allStairsBlocks = stairs.build();

--- a/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockRaw.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockRaw.java
@@ -102,10 +102,10 @@ public class BlockRockRaw extends BlockRockVariant implements ICollapsableBlock
             if (!worldIn.isRemote)
             {
                 // Create a stone anvil
-                BlockStoneAnvil block = BlockStoneAnvil.get(this.rock);
-                if (block != null)
+                BlockRockVariant anvil = BlockRockVariant.get(this.rock, Rock.Type.ANVIL);
+                if (anvil instanceof BlockStoneAnvil)
                 {
-                    worldIn.setBlockState(pos, block.getDefaultState());
+                    worldIn.setBlockState(pos, anvil.getDefaultState());
                 }
             }
             return true;

--- a/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockVariant.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockVariant.java
@@ -66,6 +66,8 @@ public class BlockRockVariant extends Block implements IItemSize
         {
             case RAW:
                 return new BlockRockRaw(type, rock);
+            case ANVIL:
+                return new BlockStoneAnvil(type, rock);
             case SPIKE:
                 return new BlockRockSpike(type, rock);
             case FARMLAND:
@@ -107,6 +109,7 @@ public class BlockRockVariant extends Block implements IItemSize
         {
             case BRICKS:
             case RAW:
+            case ANVIL:
             case SPIKE:
             case SMOOTH:
                 setSoundType(SoundType.STONE);

--- a/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockStoneAnvil.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockStoneAnvil.java
@@ -5,16 +5,11 @@
 
 package net.dries007.tfc.objects.blocks.stone;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Random;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import net.minecraft.block.Block;
-import net.minecraft.block.SoundType;
-import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -35,54 +30,23 @@ import net.minecraftforge.items.IItemHandler;
 
 import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.api.types.Rock;
-import net.dries007.tfc.api.types.RockCategory;
-import net.dries007.tfc.api.util.IRockObject;
 import net.dries007.tfc.client.TFCGuiHandler;
 import net.dries007.tfc.client.TFCSounds;
 import net.dries007.tfc.objects.items.rock.ItemRock;
 import net.dries007.tfc.objects.te.TEAnvilTFC;
 import net.dries007.tfc.util.Helpers;
+import net.dries007.tfc.util.ICollapsableBlock;
 
 import static net.dries007.tfc.objects.te.TEAnvilTFC.SLOT_HAMMER;
 
 @ParametersAreNonnullByDefault
-public class BlockStoneAnvil extends Block implements IRockObject
+public class BlockStoneAnvil extends BlockRockVariant implements ICollapsableBlock
 {
-    private static final Map<Rock, BlockStoneAnvil> MAP = new HashMap<>();
     private static final AxisAlignedBB AABB = new AxisAlignedBB(0, 0, 0, 1, 0.875, 1);
 
-    public static BlockStoneAnvil get(Rock rock)
+    public BlockStoneAnvil(Rock.Type type, Rock rock)
     {
-        return MAP.get(rock);
-    }
-
-    private final Rock rock;
-
-    public BlockStoneAnvil(Rock rock)
-    {
-        super(Material.ROCK);
-
-        setSoundType(SoundType.STONE);
-        setHardness(rock.getRockCategory().getHardness());
-        setResistance(rock.getRockCategory().getResistance());
-        setHarvestLevel("pickaxe", 0);
-
-        this.rock = rock;
-        MAP.put(rock, this);
-    }
-
-    @Nonnull
-    @Override
-    public Rock getRock(ItemStack stack)
-    {
-        return rock;
-    }
-
-    @Nonnull
-    @Override
-    public RockCategory getRockCategory(ItemStack stack)
-    {
-        return rock.getRockCategory();
+        super(type, rock);
     }
 
     @Override
@@ -285,5 +249,11 @@ public class BlockStoneAnvil extends Block implements IRockObject
     public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
     {
         return new ItemStack(BlockRockRaw.get(rock, Rock.Type.RAW));
+    }
+
+    @Override
+    public BlockRockVariantFallable getFallingVariant()
+    {
+        return (BlockRockVariantFallable) BlockRockVariant.get(rock, Rock.Type.COBBLE);
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/entity/animal/EntityMuleTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/entity/animal/EntityMuleTFC.java
@@ -16,6 +16,7 @@ import net.minecraft.block.BlockChest;
 import net.minecraft.entity.EntityAgeable;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIFollowParent;
 import net.minecraft.entity.ai.EntityAIRunAroundLikeCrazy;
 import net.minecraft.entity.passive.EntityAnimal;
@@ -30,6 +31,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
@@ -42,11 +44,15 @@ import net.dries007.tfc.ConfigTFC;
 import net.dries007.tfc.Constants;
 import net.dries007.tfc.api.capability.food.CapabilityFood;
 import net.dries007.tfc.api.capability.food.IFood;
+import net.dries007.tfc.api.capability.size.CapabilityItemSize;
+import net.dries007.tfc.api.capability.size.Size;
+import net.dries007.tfc.api.capability.size.Weight;
 import net.dries007.tfc.api.types.IAnimalTFC;
 import net.dries007.tfc.api.types.ILivestock;
 import net.dries007.tfc.objects.LootTablesTFC;
 import net.dries007.tfc.objects.advancements.TFCTriggers;
 import net.dries007.tfc.objects.blocks.BlocksTFC;
+import net.dries007.tfc.objects.potioneffects.PotionEffectsTFC;
 import net.dries007.tfc.util.calendar.CalendarTFC;
 
 import static net.dries007.tfc.TerraFirmaCraft.MOD_ID;
@@ -268,6 +274,28 @@ public class EntityMuleTFC extends EntityMule implements IAnimalTFC, ILivestock
         }
         if (!this.world.isRemote)
         {
+            if (this.hasChest() && this.ticksExisted % 20 == 0)
+            {
+                // Apply overburdened when carrying more than one heavy item
+                int hugeHeavyCount = 0;
+                for (int i = 2; i < this.horseChest.getSizeInventory(); ++i)
+                {
+                    ItemStack stack = this.horseChest.getStackInSlot(i);
+                    if (CapabilityItemSize.checkItemSize(stack, Size.HUGE, Weight.VERY_HEAVY))
+                    {
+                        hugeHeavyCount++;
+                        if(hugeHeavyCount >= 2)
+                        {
+                            break;
+                        }
+                    }
+                }
+                if(hugeHeavyCount >= 2)
+                {
+                    // Does not work when ridden, mojang bug: https://bugs.mojang.com/browse/MC-121788
+                    this.addPotionEffect(new PotionEffect(PotionEffectsTFC.OVERBURDENED, 25, 125, false, false));
+                }
+            }
             // Is it time to decay familiarity?
             // If this entity was never fed(eg: new born, wild)
             // or wasn't fed yesterday(this is the starting of the second day)

--- a/src/main/java/net/dries007/tfc/objects/entity/animal/EntityMuleTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/entity/animal/EntityMuleTFC.java
@@ -16,7 +16,6 @@ import net.minecraft.block.BlockChest;
 import net.minecraft.entity.EntityAgeable;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.ai.EntityAIFollowParent;
 import net.minecraft.entity.ai.EntityAIRunAroundLikeCrazy;
 import net.minecraft.entity.passive.EntityAnimal;
@@ -32,6 +31,7 @@ import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
@@ -284,13 +284,13 @@ public class EntityMuleTFC extends EntityMule implements IAnimalTFC, ILivestock
                     if (CapabilityItemSize.checkItemSize(stack, Size.HUGE, Weight.VERY_HEAVY))
                     {
                         hugeHeavyCount++;
-                        if(hugeHeavyCount >= 2)
+                        if (hugeHeavyCount >= 2)
                         {
                             break;
                         }
                     }
                 }
-                if(hugeHeavyCount >= 2)
+                if (hugeHeavyCount >= 2)
                 {
                     // Does not work when ridden, mojang bug: https://bugs.mojang.com/browse/MC-121788
                     this.addPotionEffect(new PotionEffect(PotionEffectsTFC.OVERBURDENED, 25, 125, false, false));
@@ -355,6 +355,16 @@ public class EntityMuleTFC extends EntityMule implements IAnimalTFC, ILivestock
         getDataManager().register(GENDER, true);
         getDataManager().register(BIRTHDAY, 0);
         getDataManager().register(FAMILIARITY, 0f);
+    }
+
+    @Override
+    public void onDeath(DamageSource cause)
+    {
+        if (!world.isRemote)
+        {
+            setChested(false); // Don't drop chest
+        }
+        super.onDeath(cause);
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/objects/entity/animal/EntityOcelotTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/entity/animal/EntityOcelotTFC.java
@@ -10,6 +10,7 @@ import java.util.Random;
 import java.util.function.BiConsumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.EntityAITargetNonTamed;
@@ -39,7 +40,7 @@ import net.dries007.tfc.Constants;
 import net.dries007.tfc.api.capability.food.CapabilityFood;
 import net.dries007.tfc.api.capability.food.IFood;
 import net.dries007.tfc.api.types.IAnimalTFC;
-import net.dries007.tfc.api.types.IHuntable;
+import net.dries007.tfc.api.types.ILivestock;
 import net.dries007.tfc.objects.LootTablesTFC;
 import net.dries007.tfc.objects.advancements.TFCTriggers;
 import net.dries007.tfc.objects.blocks.BlocksTFC;
@@ -49,9 +50,9 @@ import net.dries007.tfc.world.classic.biomes.BiomesTFC;
 
 import static net.dries007.tfc.TerraFirmaCraft.MOD_ID;
 
-// This one is special, since it's familiarizable and also attacks other livestock for food.
-// Should fit more in the huntable list
-public class EntityOcelotTFC extends EntityOcelot implements IAnimalTFC, IHuntable
+@ParametersAreNonnullByDefault
+// Changes in config allow placing this animal in livestock and still respawn
+public class EntityOcelotTFC extends EntityOcelot implements IAnimalTFC, ILivestock
 {
     //Values that has a visual effect on client
     private static final DataParameter<Boolean> GENDER = EntityDataManager.createKey(EntityOcelotTFC.class, DataSerializers.BOOLEAN);

--- a/src/main/java/net/dries007/tfc/objects/entity/animal/EntityWolfTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/entity/animal/EntityWolfTFC.java
@@ -41,7 +41,7 @@ import net.dries007.tfc.Constants;
 import net.dries007.tfc.api.capability.food.CapabilityFood;
 import net.dries007.tfc.api.capability.food.IFood;
 import net.dries007.tfc.api.types.IAnimalTFC;
-import net.dries007.tfc.api.types.IHuntable;
+import net.dries007.tfc.api.types.ILivestock;
 import net.dries007.tfc.objects.LootTablesTFC;
 import net.dries007.tfc.objects.advancements.TFCTriggers;
 import net.dries007.tfc.objects.blocks.BlocksTFC;
@@ -53,9 +53,8 @@ import net.dries007.tfc.world.classic.biomes.BiomesTFC;
 import static net.dries007.tfc.TerraFirmaCraft.MOD_ID;
 
 @ParametersAreNonnullByDefault
-// This one is special, since it's familiarizable and is also a predator since it will attack you if provoked plus will hunt other livestock for food.
-// Since this don't fit in the predators list, but should be respawned over time, putting it into the huntable list
-public class EntityWolfTFC extends EntityWolf implements IAnimalTFC, IHuntable
+// Changes in config allow placing this animal in livestock and still respawn
+public class EntityWolfTFC extends EntityWolf implements IAnimalTFC, ILivestock
 {
     //Values that has a visual effect on client
     private static final DataParameter<Boolean> GENDER = EntityDataManager.createKey(EntityWolfTFC.class, DataSerializers.BOOLEAN);

--- a/src/main/java/net/dries007/tfc/objects/te/TECrucible.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TECrucible.java
@@ -145,7 +145,7 @@ public class TECrucible extends TETickableInventory implements ITickable, ITileF
                         {
                             // Use mold.getMetal() to avoid off by one errors during draining
                             Metal metal = mold.getMetal();
-                            FluidStack fluidStack = mold.drain(1, true);
+                            FluidStack fluidStack = mold.drain(ConfigTFC.Devices.CRUCIBLE.pouringSpeed, true);
                             if (fluidStack != null && fluidStack.amount > 0)
                             {
                                 lastFillTimer = 5;

--- a/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
+++ b/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
@@ -102,7 +102,7 @@ public final class DefaultRecipes
             // Misc
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 1000), IIngredient.of("logWoodTannin"), new FluidStack(TANNIN.get(), 10000), ItemStack.EMPTY, 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("tannin"),
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 200), IIngredient.of(ItemsTFC.JUTE), null, new ItemStack(ItemsTFC.JUTE_FIBER), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("jute_fiber"),
-            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 600), IIngredient.of(ItemFoodTFC.get(Food.SUGARCANE), 5), null, new ItemStack(Items.SUGAR), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("sugar"),
+            new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 600), new IngredientItemFood(IIngredient.of(ItemFoodTFC.get(Food.SUGARCANE), 5)), null, new ItemStack(Items.SUGAR), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("sugar"),
             new BarrelRecipe(IIngredient.of(LIMEWATER.get(), 500), IIngredient.of(new ItemStack(Items.DYE, 1, EnumDyeColor.WHITE.getDyeDamage())), null, new ItemStack(ItemsTFC.GLUE), 8 * ICalendar.TICKS_IN_HOUR).setRegistryName("glue"),
             // Alcohol - Classic created 1000mb with 4oz, which would be 8 items per full barrel at 5 oz/item. Instead we now require 20 items, so conversion is 2 oz/item here
             new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 500), IIngredient.of(ItemFoodTFC.get(Food.BARLEY_FLOUR)), new FluidStack(FluidsTFC.BEER.get(), 500), ItemStack.EMPTY, 72 * ICalendar.TICKS_IN_HOUR).setRegistryName("beer"),
@@ -571,7 +571,7 @@ public final class DefaultRecipes
             new QuernRecipe(IIngredient.of("grainWheat"), new ItemStack(ItemFoodTFC.get(Food.WHEAT_FLOUR), 1)).setRegistryName("wheat"),
             new QuernRecipe(IIngredient.of("grainMaize"), new ItemStack(ItemFoodTFC.get(Food.CORNMEAL_FLOUR), 1)).setRegistryName("maize"),
 
-            new QuernRecipe(IIngredient.of(ItemFoodTFC.get(Food.OLIVE)), new ItemStack(ItemsTFC.OLIVE_PASTE, 1)).setRegistryName("olive"),
+            new QuernRecipe(new IngredientItemFood(IIngredient.of(ItemFoodTFC.get(Food.OLIVE))), new ItemStack(ItemsTFC.OLIVE_PASTE, 1)).setRegistryName("olive"),
 
             //Flux
             new QuernRecipe(IIngredient.of("gemBorax"), new ItemStack(ItemPowder.get(Powder.FLUX), 6)).setRegistryName("boarx"),

--- a/src/main/java/net/dries007/tfc/util/OreDictionaryHelper.java
+++ b/src/main/java/net/dries007/tfc/util/OreDictionaryHelper.java
@@ -101,6 +101,7 @@ public class OreDictionaryHelper
         OreDictionary.registerOre("carpet", new ItemStack(Blocks.CARPET, 1, OreDictionary.WILDCARD_VALUE));
         OreDictionary.registerOre("powderConcrete", new ItemStack(Blocks.CONCRETE_POWDER, 1, OreDictionary.WILDCARD_VALUE));
         OreDictionary.registerOre("terracotta", new ItemStack(Blocks.HARDENED_CLAY, 1, OreDictionary.WILDCARD_VALUE));
+        OreDictionary.registerOre("terracotta", new ItemStack(Blocks.STAINED_HARDENED_CLAY, 1, OreDictionary.WILDCARD_VALUE));
 
         //oredict support for TFC dyes
         OreDictionary.registerOre("dyePink", new ItemStack(ItemPowder.get(Powder.KAOLINITE)));

--- a/src/main/resources/assets/tfc/lang/en_us.lang
+++ b/src/main/resources/assets/tfc/lang/en_us.lang
@@ -633,13 +633,16 @@ config.tfc.devices.bloomery.ticks.tooltip=Number of ticks required for a bloomer
 
 
 ### Crucible
-config.tfc.devices.crucible=Bloomery
+config.tfc.devices.crucible=Crucible
 
 config.tfc.devices.crucible.tank=Tank Storage
 config.tfc.devices.crucible.tank.tooltip=How much metal (units / mB) can a crucible hold?
 
 config.tfc.devices.crucible.enableAllSlots=Accept Pouring from All Slots
 config.tfc.devices.crucible.enableAllSlots.tooltip=Let crucibles accept pouring metal (from small vessels / molds) from all 9 input slots at the same time.
+
+config.tfc.devices.crucible.pouringSpeed=Pouring Speed
+config.tfc.devices.crucible.pouringSpeed.tooltip=How fast should crucibles accept fluids from molds / small vessel?
 
 
 ### Charcoal Pit

--- a/src/main/resources/assets/tfc/lang/en_us.lang
+++ b/src/main/resources/assets/tfc/lang/en_us.lang
@@ -320,11 +320,11 @@ config.tfc.general.fallable.explosionCausesCollapse.tooltip=Should exploding raw
 ### Difficulty
 config.tfc.general.difficulty=Difficulty Settings
 
-config.tfc.general.difficulty.animalSpawnCount=Animal Spawn Count
-config.tfc.general.difficulty.animalSpawnCount.tooltip=This controls how many animals (any kind) are loaded(spawned) / player. Higher values means more animals near a player, which in turn raises difficulty and meat abundance (caution, a value too high can also negatively impact performance).
+config.tfc.general.difficulty.animalSpawnCount=Animal Respawn Count
+config.tfc.general.difficulty.animalSpawnCount.tooltip=This controls how many animals (any kind) are loaded (by respawn) / player. Higher values means more animals near a player, which in turn raises difficulty and meat abundance (caution, a value too high can also negatively impact performance).
 
-config.tfc.general.difficulty.mobSpawnCount=Mob Spawn Count
-config.tfc.general.difficulty.mobSpawnCount.tooltip=This controls how many mobs are loaded(spawned) / player. Higher values means more mobs near a player, which in turn raises difficulty (caution, a value too high may also negatively impact performance).
+config.tfc.general.difficulty.mobSpawnCount=Mob Respawn Count
+config.tfc.general.difficulty.mobSpawnCount.tooltip=This controls how many mobs are loaded(by respawn) / player. Higher values means more mobs near a player, which in turn raises difficulty (caution, a value too high may also negatively impact performance).
 
 config.tfc.general.difficulty.preventMobsOnSurface=Prevent Mobs On Surface
 config.tfc.general.difficulty.preventMobsOnSurface.tooltip=Prevent mob spawning on surface?


### PR DESCRIPTION
- Stone anvils now have the same properites as the raw rock variant: falls and is slow to mine (Closes #1390)
- Added missing ore dict "terracotta" to stained ones, which fixed heat capability (Closes #1343).
- Animal Spawn Count renamed to Animal Respawn Count (Closes #1384).
- Fixed hwyla title not being override (Closes #1370).
- Fixed Donkeys and Mules not rendering chests (Closes #1355).
- Chested animals won't drop chests on death (Closes #1394).
- Wolves and Ocelots now grow old (Closes #1354).
- Added config to change the pouring speed accept by crucible (Closes #1330).
- Fixed some more unintended uses for rotten food (Closes #1397).
- Added overburnedend potion effect to donkeys and mules when carrying more than one heavy item (Closes #1369). Note: There's a mojang bug where potion effects does not matter when riding entities.