### PR TITLE
Decrease most skill progression

### DIFF
--- a/src/main/java/net/dries007/tfc/util/skills/ProspectingSkill.java
+++ b/src/main/java/net/dries007/tfc/util/skills/ProspectingSkill.java
@@ -31,14 +31,14 @@ public class ProspectingSkill extends Skill
     @Nonnull
     public SkillTier getTier()
     {
-        return SkillTier.valueOf(level / 5);
+        return SkillTier.valueOf(level / 10);
     }
 
     @Override
     public float getLevel()
     {
-        // checks >=20 for full progress bar in MASTER tier.
-        return level >= 20 ? 1.0F : (level % 5) / 5.0f;
+        // checks >=40 for full progress bar in MASTER tier.
+        return level >= 40 ? 1.0F : (level % 10) / 10.0f;
     }
 
     @Override
@@ -52,7 +52,7 @@ public class ProspectingSkill extends Skill
         {
             value = 1;
         }
-        level = (int) (value * 20);
+        level = (int) (value * 40);
         updateAndSync();
     }
 

--- a/src/main/java/net/dries007/tfc/util/skills/SimpleSkill.java
+++ b/src/main/java/net/dries007/tfc/util/skills/SimpleSkill.java
@@ -52,7 +52,7 @@ public class SimpleSkill extends Skill
 
     public void add(float amount)
     {
-        this.amount += amount;
+        this.amount += amount/Math.pow(2,(float)getTier().ordinal());
         if (this.amount > 4f)
         {
             this.amount = 4f;


### PR DESCRIPTION
See #1143 for Agriculture and Butchering. Also doubles requirement for Prospecting, but doesn't decay gain rate because implementation requires integer representation of level.
Current prospecting skill levels will be cut in half.