### PR TITLE
Make support beam range configurable

### DIFF
--- a/src/main/java/net/dries007/tfc/ConfigTFC.java
+++ b/src/main/java/net/dries007/tfc/ConfigTFC.java
@@ -191,6 +191,16 @@ public final class ConfigTFC
             @Config.LangKey("config." + MOD_ID + ".general.fallable.propagateCollapseChance")
             public double propagateCollapseChance = 0.55;
 
+            @Config.Comment("Horizontal radius of the support range of support beams.")
+            @Config.RangeInt(min = 0, max = 8)
+            @Config.LangKey("config." + MOD_ID + ".general.fallable.supportBeamRangeHor")
+            public int supportBeamRangeHor = 4;
+
+            @Config.Comment("Vertical radius of the support range of support beams.")
+            @Config.RangeInt(min = 0, max = 3)
+            @Config.LangKey("config." + MOD_ID + ".general.fallable.supportBeamRangeVert")
+            public int supportBeamRangeVert = 1;
+
             @Config.Comment("Should chiseling raw stone blocks cause collapses?")
             @Config.LangKey("config." + MOD_ID + ".general.fallable.chiselCausesCollapse")
             public boolean chiselCausesCollapse = true;

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSupport.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSupport.java
@@ -54,12 +54,26 @@ public class BlockSupport extends Block
     private static final AxisAlignedBB CONNECTION_E_AABB = new AxisAlignedBB(0.6875D, 0.625D, 0.3125D, 1.0D, 1.0D, 0.6875D);
     private static final AxisAlignedBB CONNECTION_W_AABB = new AxisAlignedBB(0.0D, 0.625D, 0.3125D, 0.3125D, 1.0D, 0.6875D);
 
-    private static final int sRangeHor = ConfigTFC.General.FALLABLE.supportBeamRangeHor;
-    private static final int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert;
-    private static final int sRangeHorNeg = sRangeHor * -1;
-    private static final int sRangeVertNeg = sRangeVert * -1;
-
     private static final Map<Tree, BlockSupport> MAP = new HashMap<>();
+    private final Tree wood;
+
+    public BlockSupport(Tree wood)
+    {
+        super(Material.WOOD, Material.WOOD.getMaterialMapColor());
+        if (MAP.put(wood, this) != null) throw new IllegalStateException("There can only be one.");
+        setHardness(2.0F);
+        setHarvestLevel("axe", 0);
+        setSoundType(SoundType.WOOD);
+        this.wood = wood;
+        OreDictionaryHelper.register(this, "support");
+        Blocks.FIRE.setFireInfo(this, 5, 20);
+        setDefaultState(blockState.getBaseState()
+            .withProperty(AXIS, EnumFacing.Axis.Y)
+            .withProperty(NORTH, false)
+            .withProperty(SOUTH, false)
+            .withProperty(EAST, false)
+            .withProperty(WEST, false));
+    }
 
     public static BlockSupport get(Tree wood)
     {
@@ -80,14 +94,22 @@ public class BlockSupport extends Block
      */
     public static boolean isBeingSupported(World worldIn, BlockPos pos)
     {
-        if (!worldIn.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32))) {
+        int sRangeHor = ConfigTFC.General.FALLABLE.supportBeamRangeHor;
+        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert;
+        int sRangeHorNeg = sRangeHor * -1;
+        int sRangeVertNeg = sRangeVert * -1;
+        if (!worldIn.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32)))
+        {
             return true; // If world isn't loaded...
         }
         for (BlockPos.MutableBlockPos searchSupport : BlockPos.getAllInBoxMutable(
-                pos.add(sRangeHorNeg, sRangeVertNeg, sRangeHorNeg), pos.add(sRangeHor, sRangeVert, sRangeHor))) {
+            pos.add(sRangeHorNeg, sRangeVertNeg, sRangeHorNeg), pos.add(sRangeHor, sRangeVert, sRangeHor)))
+        {
             IBlockState st = worldIn.getBlockState(searchSupport);
-            if (st.getBlock() instanceof BlockSupport) {
-                if (((BlockSupport) st.getBlock()).canSupportBlocks(worldIn, searchSupport)) {
+            if (st.getBlock() instanceof BlockSupport)
+            {
+                if (((BlockSupport) st.getBlock()).canSupportBlocks(worldIn, searchSupport))
+                {
                     return true; // Found support block that can support this position
                 }
             }
@@ -100,7 +122,8 @@ public class BlockSupport extends Block
      * cave in, instead of checking every single block individually and calling
      * BlockSupper#isBeingSupported
      */
-    public static Set<BlockPos> getAllUnsupportedBlocksIn(World worldIn, BlockPos from, BlockPos to) {
+    public static Set<BlockPos> getAllUnsupportedBlocksIn(World worldIn, BlockPos from, BlockPos to)
+    {
         Set<BlockPos> listSupported = new HashSet<>();
         Set<BlockPos> listUnsupported = new HashSet<>();
         int minX = Math.min(from.getX(), to.getX());
@@ -109,10 +132,14 @@ public class BlockSupport extends Block
         int maxY = Math.max(from.getY(), to.getY());
         int minZ = Math.min(from.getZ(), to.getZ());
         int maxZ = Math.max(from.getZ(), to.getZ());
+        int sRangeHor = ConfigTFC.General.FALLABLE.supportBeamRangeHor;
+        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert;
+        int sRangeHorNeg = sRangeHor * -1;
+        int sRangeVertNeg = sRangeVert * -1;
         BlockPos minPoint = new BlockPos(minX, minY, minZ);
         BlockPos maxPoint = new BlockPos(maxX, maxY, maxZ);
         for (BlockPos.MutableBlockPos searchingPoint : BlockPos.getAllInBoxMutable(minPoint.add(sRangeHorNeg, sRangeVertNeg, sRangeHorNeg),
-                maxPoint.add(sRangeHor, sRangeVert, sRangeHor)))
+            maxPoint.add(sRangeHor, sRangeVert, sRangeHor)))
         {
             if (!listSupported.contains(searchingPoint))
             {
@@ -138,26 +165,6 @@ public class BlockSupport extends Block
             || content.getZ() < minZ || content.getZ() > maxZ);
 
         return listUnsupported;
-    }
-
-    private final Tree wood;
-
-    public BlockSupport(Tree wood)
-    {
-        super(Material.WOOD, Material.WOOD.getMaterialMapColor());
-        if (MAP.put(wood, this) != null) throw new IllegalStateException("There can only be one.");
-        setHardness(2.0F);
-        setHarvestLevel("axe", 0);
-        setSoundType(SoundType.WOOD);
-        this.wood = wood;
-        OreDictionaryHelper.register(this, "support");
-        Blocks.FIRE.setFireInfo(this, 5, 20);
-        setDefaultState(blockState.getBaseState()
-            .withProperty(AXIS, EnumFacing.Axis.Y)
-            .withProperty(NORTH, false)
-            .withProperty(SOUTH, false)
-            .withProperty(EAST, false)
-            .withProperty(WEST, false));
     }
 
     public Tree getWood() { return this.wood; }

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSupport.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSupport.java
@@ -31,6 +31,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
+import net.dries007.tfc.ConfigTFC;
 import net.dries007.tfc.api.types.Tree;
 import net.dries007.tfc.util.OreDictionaryHelper;
 
@@ -53,6 +54,11 @@ public class BlockSupport extends Block
     private static final AxisAlignedBB CONNECTION_E_AABB = new AxisAlignedBB(0.6875D, 0.625D, 0.3125D, 1.0D, 1.0D, 0.6875D);
     private static final AxisAlignedBB CONNECTION_W_AABB = new AxisAlignedBB(0.0D, 0.625D, 0.3125D, 0.3125D, 1.0D, 0.6875D);
 
+    private static final int sRangeHor = ConfigTFC.General.FALLABLE.supportBeamRangeHor;
+    private static final int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert;
+    private static final int sRangeHorNeg = sRangeHor * -1;
+    private static final int sRangeVertNeg = sRangeVert * -1;
+
     private static final Map<Tree, BlockSupport> MAP = new HashMap<>();
 
     public static BlockSupport get(Tree wood)
@@ -74,18 +80,15 @@ public class BlockSupport extends Block
      */
     public static boolean isBeingSupported(World worldIn, BlockPos pos)
     {
-        if (!worldIn.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32)))
-        {
-            return true; //If world isn't loaded...
+        if (!worldIn.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32))) {
+            return true; // If world isn't loaded...
         }
-        for (BlockPos.MutableBlockPos searchSupport : BlockPos.getAllInBoxMutable(pos.add(-4, -1, -4), pos.add(4, 1, 4)))
-        {
+        for (BlockPos.MutableBlockPos searchSupport : BlockPos.getAllInBoxMutable(
+                pos.add(sRangeHorNeg, sRangeVertNeg, sRangeHorNeg), pos.add(sRangeHor, sRangeVert, sRangeHor))) {
             IBlockState st = worldIn.getBlockState(searchSupport);
-            if (st.getBlock() instanceof BlockSupport)
-            {
-                if (((BlockSupport) st.getBlock()).canSupportBlocks(worldIn, searchSupport))
-                {
-                    return true; //Found support block that can support this position
+            if (st.getBlock() instanceof BlockSupport) {
+                if (((BlockSupport) st.getBlock()).canSupportBlocks(worldIn, searchSupport)) {
+                    return true; // Found support block that can support this position
                 }
             }
         }
@@ -93,10 +96,11 @@ public class BlockSupport extends Block
     }
 
     /**
-     * This is an optimized way to check for blocks that aren't supported during a cave in, instead of checking every single block individually and calling BlockSupper#isBeingSupported
+     * This is an optimized way to check for blocks that aren't supported during a
+     * cave in, instead of checking every single block individually and calling
+     * BlockSupper#isBeingSupported
      */
-    public static Set<BlockPos> getAllUnsupportedBlocksIn(World worldIn, BlockPos from, BlockPos to)
-    {
+    public static Set<BlockPos> getAllUnsupportedBlocksIn(World worldIn, BlockPos from, BlockPos to) {
         Set<BlockPos> listSupported = new HashSet<>();
         Set<BlockPos> listUnsupported = new HashSet<>();
         int minX = Math.min(from.getX(), to.getX());
@@ -107,7 +111,8 @@ public class BlockSupport extends Block
         int maxZ = Math.max(from.getZ(), to.getZ());
         BlockPos minPoint = new BlockPos(minX, minY, minZ);
         BlockPos maxPoint = new BlockPos(maxX, maxY, maxZ);
-        for (BlockPos.MutableBlockPos searchingPoint : BlockPos.getAllInBoxMutable(minPoint.add(-4, -1, -4), maxPoint.add(4, 1, 4)))
+        for (BlockPos.MutableBlockPos searchingPoint : BlockPos.getAllInBoxMutable(minPoint.add(sRangeHorNeg, sRangeVertNeg, sRangeHorNeg),
+                maxPoint.add(sRangeHor, sRangeVert, sRangeHor)))
         {
             if (!listSupported.contains(searchingPoint))
             {
@@ -118,7 +123,7 @@ public class BlockSupport extends Block
             {
                 if (((BlockSupport) st.getBlock()).canSupportBlocks(worldIn, searchingPoint))
                 {
-                    for (BlockPos.MutableBlockPos supported : BlockPos.getAllInBoxMutable(searchingPoint.add(-4, -1, -4), searchingPoint.add(4, 1, 4)))
+                    for (BlockPos.MutableBlockPos supported : BlockPos.getAllInBoxMutable(searchingPoint.add(sRangeHorNeg, sRangeVertNeg, sRangeHorNeg), searchingPoint.add(sRangeHor, sRangeVert, sRangeHor)))
                     {
                         listSupported.add(supported.toImmutable()); //Adding all supported blocks by this support
                         listUnsupported.remove(supported); //Remove if this block was added earlier

--- a/src/main/resources/assets/tfc/lang/en_us.lang
+++ b/src/main/resources/assets/tfc/lang/en_us.lang
@@ -315,6 +315,12 @@ config.tfc.general.fallable.collapseChance.tooltip=Chance that mining a raw rock
 config.tfc.general.fallable.propagateCollapseChance=Propagate Collapse Chance
 config.tfc.general.fallable.propagateCollapseChance.tooltip=Chance that collapsing blocks propagate the collapse. Influenced by distance from epicenter of collapse.
 
+config.tfc.general.fallable.supportBeamRangeHor=Horizontal Support Range
+config.tfc.general.fallable.supportBeamRangeHor.tooltip=The horizontal radius of the support range of support beams.
+
+config.tfc.general.fallable.supportBeamRangeVert=Vertical Support Range
+config.tfc.general.fallable.supportBeamRangeVert.tooltip=The vertical radius of the support range of support beams.
+
 config.tfc.general.fallable.chiselCausesCollapse=Chiseling Causes Collapses
 config.tfc.general.fallable.chiselCausesCollapse.tooltip=Should chiseling raw stone blocks cause collapses?
 


### PR DESCRIPTION
A pet peeve of mine with the cave-in system has always been that it makes it impossible to safely dig up using supports. Rather than disable the system entirely, the last time I played 1.7 TFC I modified the mod to make the range configurable, and then extended it to 2 tiles vertically.

This PR adds that functionality to 1.12 TFC. I limited the maximum ranges relatively low here because of potential performance issues, but quick local testing (and past playing in the far less optimized 1.7 TFC cave-in system) suggests that these values are safe enough.