### PR TITLE
Make it possible to dig up safely

### DIFF
--- a/src/main/java/net/dries007/tfc/ConfigTFC.java
+++ b/src/main/java/net/dries007/tfc/ConfigTFC.java
@@ -196,10 +196,15 @@ public final class ConfigTFC
             @Config.LangKey("config." + MOD_ID + ".general.fallable.supportBeamRangeHor")
             public int supportBeamRangeHor = 4;
 
-            @Config.Comment("Vertical radius of the support range of support beams.")
+            @Config.Comment("Upwards support range of support beams.")
             @Config.RangeInt(min = 0, max = 3)
-            @Config.LangKey("config." + MOD_ID + ".general.fallable.supportBeamRangeVert")
-            public int supportBeamRangeVert = 1;
+            @Config.LangKey("config." + MOD_ID + ".general.fallable.supportBeamRangeUp")
+            public int supportBeamRangeUp = 1;
+
+            @Config.Comment("Downwards support range of support beams.")
+            @Config.RangeInt(min = 0, max = 3)
+            @Config.LangKey("config." + MOD_ID + ".general.fallable.supportBeamRangeDown")
+            public int supportBeamRangeDown = 1;
 
             @Config.Comment("Should chiseling raw stone blocks cause collapses?")
             @Config.LangKey("config." + MOD_ID + ".general.fallable.chiselCausesCollapse")

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSupport.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSupport.java
@@ -76,9 +76,9 @@ public class BlockSupport extends Block
     public static boolean isBeingSupported(World worldIn, BlockPos pos)
     {
         int sRangeHor = ConfigTFC.General.FALLABLE.supportBeamRangeHor;
-        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert + 1;
+        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeUp;
         int sRangeHorNeg = ConfigTFC.General.FALLABLE.supportBeamRangeHor * -1;
-        int sRangeVertNeg = ConfigTFC.General.FALLABLE.supportBeamRangeVert * -1;
+        int sRangeVertNeg = ConfigTFC.General.FALLABLE.supportBeamRangeDown * -1;
         if (!worldIn.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32)))
         {
             return true; // If world isn't loaded...
@@ -114,9 +114,9 @@ public class BlockSupport extends Block
         int minZ = Math.min(from.getZ(), to.getZ());
         int maxZ = Math.max(from.getZ(), to.getZ());
         int sRangeHor = ConfigTFC.General.FALLABLE.supportBeamRangeHor;
-        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert + 1;
+        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeUp;
         int sRangeHorNeg = ConfigTFC.General.FALLABLE.supportBeamRangeHor * -1;
-        int sRangeVertNeg = ConfigTFC.General.FALLABLE.supportBeamRangeVert * -1;
+        int sRangeVertNeg = ConfigTFC.General.FALLABLE.supportBeamRangeDown * -1;
         BlockPos minPoint = new BlockPos(minX, minY, minZ);
         BlockPos maxPoint = new BlockPos(maxX, maxY, maxZ);
         for (BlockPos.MutableBlockPos searchingPoint : BlockPos.getAllInBoxMutable(minPoint.add(sRangeHorNeg, sRangeVertNeg, sRangeHorNeg),

--- a/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSupport.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/wood/BlockSupport.java
@@ -76,9 +76,9 @@ public class BlockSupport extends Block
     public static boolean isBeingSupported(World worldIn, BlockPos pos)
     {
         int sRangeHor = ConfigTFC.General.FALLABLE.supportBeamRangeHor;
-        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert;
-        int sRangeHorNeg = sRangeHor * -1;
-        int sRangeVertNeg = sRangeVert * -1;
+        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert + 1;
+        int sRangeHorNeg = ConfigTFC.General.FALLABLE.supportBeamRangeHor * -1;
+        int sRangeVertNeg = ConfigTFC.General.FALLABLE.supportBeamRangeVert * -1;
         if (!worldIn.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32)))
         {
             return true; // If world isn't loaded...
@@ -114,9 +114,9 @@ public class BlockSupport extends Block
         int minZ = Math.min(from.getZ(), to.getZ());
         int maxZ = Math.max(from.getZ(), to.getZ());
         int sRangeHor = ConfigTFC.General.FALLABLE.supportBeamRangeHor;
-        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert;
-        int sRangeHorNeg = sRangeHor * -1;
-        int sRangeVertNeg = sRangeVert * -1;
+        int sRangeVert = ConfigTFC.General.FALLABLE.supportBeamRangeVert + 1;
+        int sRangeHorNeg = ConfigTFC.General.FALLABLE.supportBeamRangeHor * -1;
+        int sRangeVertNeg = ConfigTFC.General.FALLABLE.supportBeamRangeVert * -1;
         BlockPos minPoint = new BlockPos(minX, minY, minZ);
         BlockPos maxPoint = new BlockPos(maxX, maxY, maxZ);
         for (BlockPos.MutableBlockPos searchingPoint : BlockPos.getAllInBoxMutable(minPoint.add(sRangeHorNeg, sRangeVertNeg, sRangeHorNeg),

--- a/src/main/resources/assets/tfc/lang/en_us.lang
+++ b/src/main/resources/assets/tfc/lang/en_us.lang
@@ -318,8 +318,11 @@ config.tfc.general.fallable.propagateCollapseChance.tooltip=Chance that collapsi
 config.tfc.general.fallable.supportBeamRangeHor=Horizontal Support Range
 config.tfc.general.fallable.supportBeamRangeHor.tooltip=The horizontal radius of the support range of support beams.
 
-config.tfc.general.fallable.supportBeamRangeVert=Vertical Support Range
-config.tfc.general.fallable.supportBeamRangeVert.tooltip=The vertical radius of the support range of support beams.
+config.tfc.general.fallable.supportBeamRangeUp=Upwards Support Range
+config.tfc.general.fallable.supportBeamRangeUp.tooltip=The upwards range support range of support beams.
+
+config.tfc.general.fallable.supportBeamRangeDown=Downwards Support Range
+config.tfc.general.fallable.supportBeamRangeDown.tooltip=The downwards support range of support beams.
 
 config.tfc.general.fallable.chiselCausesCollapse=Chiseling Causes Collapses
 config.tfc.general.fallable.chiselCausesCollapse.tooltip=Should chiseling raw stone blocks cause collapses?


### PR DESCRIPTION
Consider this something of a feedback PR (since the change is so trivial, I might as well make it into a PR rather than an issue) and feel free to close at your discretion.

Currently, it's impossible to dig up using support beams without risking cave-ins. It's my personal belief that this is an oversight on the original developers' part, as one of them [incorrectly claims that digging up safely is possible](https://terrafirmacraft.com/f/topic/6958-digging-up-safely/) on the old forums (and then backpedals saying that "you aren't going to get very many cave ins unless the RNG just hates your guts" after realizing their mistake).

The problem is that getting even a single cave-in will create unsupported blocks in the ceiling, and it's virtually impossible to re-support them from below if they extend more than two blocks above the closest block below them. Due to how the cave-in mechanic works, digging "safe" supported blocks close to these unsupported blocks can still cause the unsupported blocks to cave in, effectively destabilizing your mine and making recovery prohibitively difficult. Therefore having even one cave-in can cause a failcascade leading to a mine that's just going to keep caving in repeatedly.

The fix here is simple: extend the *upwards* support range of support beams by 1. This allows you to dig one block upwards without creating an unsupported ceiling. You can then extend support beams to the new ceiling and dig up another block. The downside is that support beams will allow blocks to float above them, but they can kinda already do that anyway and fixing this isn't possible without substantially changing the algorithm.