### PR TITLE
Added concrete barrel recipes (powder to concrete)

### DIFF
--- a/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
+++ b/src/main/java/net/dries007/tfc/types/DefaultRecipes.java
@@ -168,9 +168,13 @@ public final class DefaultRecipes
                 new BarrelRecipe(IIngredient.of(FluidsTFC.getFluidFromDye(dyeColor).get(), 25), IIngredient.of("carpet"), null, new ItemStack(Blocks.CARPET, 1, dyeMeta), ICalendar.TICKS_IN_HOUR).setRegistryName("carpet_" + dyeName),
                 new BarrelRecipe(IIngredient.of(FluidsTFC.getFluidFromDye(dyeColor).get(), 125), IIngredient.of("bed"), null, new ItemStack(Items.BED, 1, dyeMeta), ICalendar.TICKS_IN_HOUR).setRegistryName("bed_" + dyeName),
                 new BarrelRecipe(IIngredient.of(FluidsTFC.getFluidFromDye(dyeColor).get(), 125), IIngredient.of("terracotta"), null, new ItemStack(Blocks.STAINED_HARDENED_CLAY, 1, dyeMeta), ICalendar.TICKS_IN_HOUR).setRegistryName("terracotta_" + dyeName),
-                // Concrete (vanilla + aggregate)
+                // Concrete Powder (vanilla + aggregate)
                 new BarrelRecipe(IIngredient.of(FluidsTFC.getFluidFromDye(dyeColor).get(), 125), IIngredient.of("powderConcrete"), null, new ItemStack(Blocks.CONCRETE_POWDER, 1, dyeMeta), ICalendar.TICKS_IN_HOUR).setRegistryName("concrete_" + dyeName),
                 new BarrelRecipe(IIngredient.of(FluidsTFC.getFluidFromDye(dyeColor).get(), 125), IIngredient.of(BlocksTFC.AGGREGATE), null, new ItemStack(Blocks.CONCRETE_POWDER, 1, dyeMeta), ICalendar.TICKS_IN_HOUR).setRegistryName("aggregate_" + dyeName),
+                // Concrete (water + powder, in vanilla created by placing concrete powder next to water blocks)
+                new BarrelRecipe(IIngredient.of(FRESH_WATER.get(), 125), IIngredient.of(new ItemStack(Blocks.CONCRETE_POWDER, 1, dyeMeta)), null, new ItemStack(Blocks.CONCRETE, 1, dyeMeta), ICalendar.TICKS_IN_HOUR).setRegistryName("concrete_solidifying_" + dyeName),
+                new BarrelRecipe(IIngredient.of(FluidsTFC.getFluidFromDye(dyeColor).get(), 125), IIngredient.of("concrete"), null, new ItemStack(Blocks.CONCRETE, 1, dyeMeta), ICalendar.TICKS_IN_HOUR).setRegistryName("concrete_solid_dyeing_" + dyeName),
+                
                 // Alabaster
                 new BarrelRecipe(IIngredient.of(FluidsTFC.getFluidFromDye(dyeColor).get(), 125), IIngredient.of("alabasterBricks"), null, new ItemStack(BlockDecorativeStone.ALABASTER_BRICKS.get(dyeColor)), ICalendar.TICKS_IN_HOUR).setRegistryName("alabaster_bricks_" + dyeColor.getName()),
                 new BarrelRecipe(IIngredient.of(FluidsTFC.getFluidFromDye(dyeColor).get(), 125), IIngredient.of("alabasterRaw"), null, new ItemStack(BlockDecorativeStone.ALABASTER_RAW.get(dyeColor)), ICalendar.TICKS_IN_HOUR).setRegistryName("alabaster_raw_" + dyeColor.getName()),


### PR DESCRIPTION
In vanilla you would have to place the concrete powder block next to a water source block to turn it into concrete, which is slow but vanilla doesn't really have a better way to do that. It doesn't fit TFC exactly, and TFC also has the benefit of barrel recipes. Thus I added a recipe for concrete powder + 125 mb of fresh water for 1 hour to make concrete powder. It matches the recipes for dyeing and making concrete powder which 125 mb per item and 1 hour completion time. You could change it to take hot spring water if you want, but with fresh water it at least matches the vanilla way of requiring water to convert.