### PR TITLE
Allow turning plain dirt into paths with shovel right-click

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemMetalTool.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemMetalTool.java
@@ -208,7 +208,7 @@ public class ItemMetalTool extends ItemMetal
                 return EnumActionResult.PASS;
             }
             BlockRockVariant rockVariant = (BlockRockVariant) block;
-            if (ConfigTFC.General.OVERRIDES.enableGrassPath && facing != EnumFacing.DOWN && worldIn.getBlockState(pos.up()).getMaterial() == Material.AIR && rockVariant.getType() == Rock.Type.GRASS || rockVariant.getType() == Rock.Type.DRY_GRASS)
+            if (ConfigTFC.General.OVERRIDES.enableGrassPath && facing != EnumFacing.DOWN && worldIn.getBlockState(pos.up()).getMaterial() == Material.AIR && rockVariant.getType() == Rock.Type.GRASS || rockVariant.getType() == Rock.Type.DRY_GRASS || rockVariant.getType() == Rock.Type.DIRT)
             {
                 IBlockState iblockstate1 = BlockRockVariant.get(rockVariant.getRock(), Rock.Type.PATH).getDefaultState();
                 worldIn.playSound(player, pos, SoundEvents.ITEM_SHOVEL_FLATTEN, SoundCategory.BLOCKS, 1.0F, 1.0F);

--- a/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockShovel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/rock/ItemRockShovel.java
@@ -92,7 +92,7 @@ public class ItemRockShovel extends ItemSpade implements IItemSize, IRockObject
                 return EnumActionResult.PASS;
             }
             BlockRockVariant rockVariant = (BlockRockVariant) block;
-            if (ConfigTFC.General.OVERRIDES.enableGrassPath && facing != EnumFacing.DOWN && worldIn.getBlockState(pos.up()).getMaterial() == Material.AIR && rockVariant.getType() == Rock.Type.GRASS || rockVariant.getType() == Rock.Type.DRY_GRASS)
+            if (ConfigTFC.General.OVERRIDES.enableGrassPath && facing != EnumFacing.DOWN && worldIn.getBlockState(pos.up()).getMaterial() == Material.AIR && rockVariant.getType() == Rock.Type.GRASS || rockVariant.getType() == Rock.Type.DRY_GRASS || rockVariant.getType() == Rock.Type.DIRT)
             {
                 IBlockState iblockstate1 = BlockRockVariant.get(rockVariant.getRock(), Rock.Type.PATH).getDefaultState();
                 worldIn.playSound(player, pos, SoundEvents.ITEM_SHOVEL_FLATTEN, SoundCategory.BLOCKS, 1.0F, 1.0F);


### PR DESCRIPTION
If the enableGrassPath config option is true, shovel right-clicking on grass turns it into what looks like a well-trodden dirt path, mimicing the vanilla Minecraft paths feature.

These can only be made out of grass, not dirt, so if you accidentally break the path (by eg. having blocks fall on top of it, or placing a block on it yourself), you can't re-make it until grass grows back on the dirt. I found this counterintuitive; while it mirrors vanilla Minecraft behaviour, in Terrafirmacraft the paths look like dirt paths rather than grass paths like in vanilla, and there's no obvious reason you shouldn't be able to turn dirt into such a path.