### PR TITLE
Stop wild dead crops popping off

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockCropDead.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockCropDead.java
@@ -31,6 +31,7 @@ import net.minecraftforge.common.EnumPlantType;
 
 import net.dries007.tfc.api.capability.player.CapabilityPlayerData;
 import net.dries007.tfc.api.types.ICrop;
+import net.dries007.tfc.objects.blocks.BlocksTFC;
 import net.dries007.tfc.objects.items.ItemSeedsTFC;
 import net.dries007.tfc.util.agriculture.Crop;
 import net.dries007.tfc.util.skills.SimpleSkill;
@@ -140,6 +141,12 @@ public class BlockCropDead extends BlockBush
         return count;
     }
 
+    @Override
+    public boolean canBlockStay(World world, BlockPos pos, IBlockState state) {
+        IBlockState below = world.getBlockState(pos.down());
+        return BlocksTFC.isGrowableSoil(below);
+    }
+    
     @Override
     @Nonnull
     public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)

--- a/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockCropDead.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockCropDead.java
@@ -22,12 +22,14 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.EnumPlantType;
+import net.minecraftforge.common.IPlantable;
 
 import net.dries007.tfc.api.capability.player.CapabilityPlayerData;
 import net.dries007.tfc.api.types.ICrop;
@@ -143,8 +145,8 @@ public class BlockCropDead extends BlockBush
 
     @Override
     public boolean canBlockStay(World world, BlockPos pos, IBlockState state) {
-        IBlockState below = world.getBlockState(pos.down());
-        return BlocksTFC.isGrowableSoil(below);
+        IBlockState soil = world.getBlockState(pos.down());
+        return soil.getBlock().canSustainPlant(soil, world, pos.down(), net.minecraft.util.EnumFacing.UP, this);
     }
     
     @Override

--- a/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockCropDead.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockCropDead.java
@@ -147,7 +147,7 @@ public class BlockCropDead extends BlockBush
     public boolean canBlockStay(World world, BlockPos pos, IBlockState state)
     {
         IBlockState soil = world.getBlockState(pos.down());
-        return soil.getBlock().canSustainPlant(soil, world, pos.down(), net.minecraft.util.EnumFacing.UP, this);
+        return soil.getBlock().canSustainPlant(soil, world, pos.down(), EnumFacing.UP, this);
     }
     
     @Override

--- a/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockCropDead.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockCropDead.java
@@ -144,7 +144,8 @@ public class BlockCropDead extends BlockBush
     }
 
     @Override
-    public boolean canBlockStay(World world, BlockPos pos, IBlockState state) {
+    public boolean canBlockStay(World world, BlockPos pos, IBlockState state)
+    {
         IBlockState soil = world.getBlockState(pos.down());
         return soil.getBlock().canSustainPlant(soil, world, pos.down(), net.minecraft.util.EnumFacing.UP, this);
     }


### PR DESCRIPTION
Currently, when they die in the wild they pop off with any block update