### PR TITLE
Fixed fluid registry issue with already registered fluids

### DIFF
--- a/src/main/java/net/dries007/tfc/CommonEventHandler.java
+++ b/src/main/java/net/dries007/tfc/CommonEventHandler.java
@@ -256,7 +256,7 @@ public final class CommonEventHandler
             if (result != null && result.typeOfHit == RayTraceResult.Type.BLOCK)
             {
                 IBlockState waterState = world.getBlockState(result.getBlockPos());
-                boolean isFreshWater = BlocksTFC.isFreshWater(waterState), isSaltWater = BlocksTFC.isSaltWater(waterState);
+                boolean isFreshWater = BlocksTFC.isFluidFreshWater(waterState), isSaltWater = BlocksTFC.isFluidSaltWater(waterState);
                 if ((isFreshWater && foodStats.attemptDrink(10, true)) || (isSaltWater && foodStats.attemptDrink(-1, true)))
                 {
                     //Simulated so client will check if he would drink before updating stats

--- a/src/main/java/net/dries007/tfc/objects/blocks/BlocksTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/BlocksTFC.java
@@ -19,6 +19,9 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fluids.BlockFluidBase;
+import net.minecraftforge.fluids.BlockFluidClassic;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -720,6 +723,28 @@ public final class BlocksTFC
     public static boolean isWater(IBlockState current)
     {
         return current.getMaterial() == Material.WATER;
+    }
+
+    public static boolean isFluidFreshWater(IBlockState current)
+    {
+        if (current.getBlock() instanceof BlockFluidClassic)
+        {
+            return ((BlockFluidClassic)current.getBlock()).getFluid() == FluidsTFC.FRESH_WATER.get();
+        }
+
+        Fluid currentFluid = FluidRegistry.lookupFluidForBlock(current.getBlock());
+        return currentFluid != null && currentFluid == FluidsTFC.FRESH_WATER.get();
+    }
+
+    public static boolean isFluidSaltWater(IBlockState current)
+    {
+        if (current.getBlock() instanceof BlockFluidClassic)
+        {
+            return ((BlockFluidClassic)current.getBlock()).getFluid() == FluidsTFC.SALT_WATER.get();
+        }
+
+        Fluid currentFluid = FluidRegistry.lookupFluidForBlock(current.getBlock());
+        return currentFluid != null && currentFluid == FluidsTFC.SALT_WATER.get();
     }
 
     public static boolean isFreshWater(IBlockState current)

--- a/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
@@ -219,11 +219,17 @@ public final class FluidsTFC
     @Nonnull
     private static FluidWrapper registerFluid(@Nonnull Fluid newFluid)
     {
-        boolean isDefault = FluidRegistry.registerFluid(newFluid);
+        boolean isDefault = !FluidRegistry.isFluidRegistered(newFluid.getName());
+
         if (!isDefault)
         {
             // Fluid was already registered with this name, default to that fluid
             newFluid = FluidRegistry.getFluid(newFluid.getName());
+        }
+        else
+        {
+            // No fluid found we are safe to register our default
+            FluidRegistry.registerFluid(newFluid);
         }
         FluidRegistry.addBucketForFluid(newFluid);
         FluidWrapper properties = new FluidWrapper(newFluid, isDefault);


### PR DESCRIPTION
Compatibility Fix for fluids: https://github.com/turbodiesel4598/NuclearCraft/issues/651#issuecomment-686262754

When attempting to register TFC metal fluids even though the Fluid already exists forge will still add reference in the FluidRegistry delegates for it, this causes Compatibility issues when passing the Fluid through a FluidStack as it grabs the TFC Fluid first instead of the correct fluid.

I'm not sure if this is the best and or intended design of how this should work but it fixes the issue above and allows copper to be melted again.