### PR TITLE
Fixed fluid registry issue with already registered fluids

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/fluids/FluidsTFC.java
@@ -214,11 +214,17 @@ public final class FluidsTFC
     @Nonnull
     private static FluidWrapper registerFluid(@Nonnull Fluid newFluid)
     {
-        boolean isDefault = FluidRegistry.registerFluid(newFluid);
+        boolean isDefault = !FluidRegistry.isFluidRegistered(newFluid.getName());
+
         if (!isDefault)
         {
             // Fluid was already registered with this name, default to that fluid
             newFluid = FluidRegistry.getFluid(newFluid.getName());
+        }
+        else
+        {
+            // No fluid found we are safe to register our default
+            FluidRegistry.registerFluid(newFluid);
         }
         FluidRegistry.addBucketForFluid(newFluid);
         FluidWrapper properties = new FluidWrapper(newFluid, isDefault);


### PR DESCRIPTION
Compatibility Fix for fluids: turbodiesel4598/NuclearCraft#651 (comment)

When attempting to register TFC metal fluids even though the Fluid already exists forge will still add reference in the FluidRegistry delegates for it, this causes Compatibility issues when passing the Fluid through a FluidStack as it grabs the TFC Fluid first instead of the correct fluid.

I'm not sure if this is the best and or intended design of how this should work but it fixes the issue above and allows copper to be melted again.