### PR TITLE
Check if it's a vanilla MC Chicken and cancel it.

### DIFF
--- a/src/main/java/net/dries007/tfc/CommonEventHandler.java
+++ b/src/main/java/net/dries007/tfc/CommonEventHandler.java
@@ -723,7 +723,7 @@ public final class CommonEventHandler
         if (event.getWorld().getWorldType() == TerraFirmaCraft.getWorldType() && event.getWorld().provider.getDimensionType() == DimensionType.OVERWORLD)
         {
             // Fix chickens spawning in caves (which is caused by zombie jockeys)
-            if (entity instanceof EntityChicken && ((EntityChicken) entity).isChickenJockey())
+            if (entity instanceof EntityChicken)
             {
                 event.setCanceled(true); // NO!
             }


### PR DESCRIPTION
The isChickenJockey() is returning false when initially spawned, thus the chicken instead gets converted to a TFC chicken. Which causes no end of issues. Just stop with the vanilla chickens... period. The lag they cause is immense on SMP servers.