### PR TITLE
Immersive ways of cooling heatable items - Resolves #1347

### DIFF
--- a/src/main/java/net/dries007/tfc/CommonEventHandler.java
+++ b/src/main/java/net/dries007/tfc/CommonEventHandler.java
@@ -756,7 +756,7 @@ public final class CommonEventHandler
                 }
             }
         }
-        if (ConfigTFC.Devices.TEMPERATURE.coolHeatablesInWater && entity instanceof EntityItem)
+        if (ConfigTFC.Devices.TEMPERATURE.coolHeatablesInWorld && entity instanceof EntityItem)
         {
             EntityItem entityItem = (EntityItem) entity;
             ItemStack stack = entityItem.getItem();
@@ -791,7 +791,7 @@ public final class CommonEventHandler
         EntityItem entityItem = event.getEntityItem();
         ItemStack stack = entityItem.getItem();
         IItemHeat heatCap;
-        if (ConfigTFC.Devices.TEMPERATURE.coolHeatablesInWater && entityItem.getTags().contains("TFCHeatableItem") && (heatCap = stack.getCapability(CapabilityItemHeat.ITEM_HEAT_CAPABILITY, null)) != null)
+        if (ConfigTFC.Devices.TEMPERATURE.coolHeatablesInWorld && entityItem.getTags().contains("TFCHeatableItem") && (heatCap = stack.getCapability(CapabilityItemHeat.ITEM_HEAT_CAPABILITY, null)) != null)
         {
             int lifespan = stack.getItem().getEntityLifespan(stack, entityItem.world);
             if (entityItem.lifespan >= lifespan)

--- a/src/main/java/net/dries007/tfc/CommonEventHandler.java
+++ b/src/main/java/net/dries007/tfc/CommonEventHandler.java
@@ -852,7 +852,7 @@ public final class CommonEventHandler
                         entityItem.world.setBlockState(pos, FluidsTFC.FRESH_WATER.get().getBlock().getDefaultState(), 2); // 1/200 chance of the packed ice turning into water.
                     }
                 }
-                event.setExtraLife(ConfigTFC.Devices.TEMPERATURE.ticksBeforeAttemptToCool); // Set half a second onto the lifespan
+                event.setExtraLife(itemTemp == 0 ? lifespan : ConfigTFC.Devices.TEMPERATURE.ticksBeforeAttemptToCool); // Set lifespan accordingly
                 entityItem.setNoPickupDelay(); // For some reason when lifespan is added, pickup delay is reset, we disable this to make the experience seamless
             }
             else

--- a/src/main/java/net/dries007/tfc/CommonEventHandler.java
+++ b/src/main/java/net/dries007/tfc/CommonEventHandler.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLeaves;
+import net.minecraft.block.BlockSnow;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -813,13 +814,30 @@ public final class CommonEventHandler
                         ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, entityItem.posX, entityItem.posY, entityItem.posZ, 42, 0.0D, 0.15D, 0.0D, 0.08D);
                         if (rand <= 0.001F)
                         {
-                            entityItem.world.setBlockToAir(pos); // 1/1000 chance of the fluid being used up. Attempts to match the barrel recipe as it takes 1mb of water per operation.
+                            entityItem.world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2); // 1/1000 chance of the fluid being used up. Attempts to match the barrel recipe as it takes 1mb of water per operation.
                         }
                     }
                     event.setExtraLife(ConfigTFC.Devices.TEMPERATURE.ticksBeforeAttemptToCool); // Set half a second onto the lifespan
                     event.setCanceled(true);
                     entityItem.setNoPickupDelay(); // For some reason when lifespan is added, pickup delay is reset, we disable this to make the experience seamless
                     return;
+                }
+                else if (state.getPropertyKeys().contains(BlockSnow.LAYERS))
+                {
+                    heatCap.setTemperature(Math.max(0, itemTemp - 70));
+                    entityItem.world.playSound(null, pos, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 0.55f, 0.8f + rand * 0.4f);
+                    ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, entityItem.posX, entityItem.posY, entityItem.posZ, 42, 0.0D, 0.15D, 0.0D, 0.08D);
+                    if (rand <= 0.1F)
+                    {
+                        if (state.getValue(BlockSnow.LAYERS) > 1)
+                        {
+                            entityItem.world.setBlockState(pos, state.withProperty(BlockSnow.LAYERS, state.getValue(BlockSnow.LAYERS) - 1), 2);
+                        }
+                        else
+                        {
+                            entityItem.world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2);
+                        }
+                    }
                 }
                 pos.setY(pos.getY() - 1);
                 if ((state = entityItem.world.getBlockState(pos)).getMaterial() == Material.SNOW || state.getMaterial() == Material.CRAFTED_SNOW)
@@ -829,7 +847,7 @@ public final class CommonEventHandler
                     ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, entityItem.posX, entityItem.posY, entityItem.posZ, 42, 0.0D, 0.15D, 0.0D, 0.08D);
                     if (rand <= 0.01F)
                     {
-                        entityItem.world.setBlockToAir(pos); // 1/100 chance of the snow evaporating.
+                        entityItem.world.setBlockState(pos, Blocks.AIR.getDefaultState(), 2); // 1/100 chance of the snow block evaporating.
                     }
                 }
                 else if (state.getMaterial() == Material.ICE)

--- a/src/main/java/net/dries007/tfc/CommonEventHandler.java
+++ b/src/main/java/net/dries007/tfc/CommonEventHandler.java
@@ -810,7 +810,7 @@ public final class CommonEventHandler
                     {
                         heatCap.setTemperature(Math.max(0, Math.min(itemTemp, itemTemp - 350 + fluidTemp)));
                         entityItem.world.playSound(null, pos, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 0.5f, 0.8f + rand * 0.4f);
-                        ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, pos.getX(), pos.getY(), pos.getZ(), 42, 0.0D, 0.15D, 0.0D, 0.08D);
+                        ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, entityItem.posX, entityItem.posY, entityItem.posZ, 42, 0.0D, 0.15D, 0.0D, 0.08D);
                         if (rand <= 0.001F)
                         {
                             entityItem.world.setBlockToAir(pos); // 1/1000 chance of the fluid being used up. Attempts to match the barrel recipe as it takes 1mb of water per operation.
@@ -826,7 +826,7 @@ public final class CommonEventHandler
                 {
                     heatCap.setTemperature(Math.max(0, itemTemp - 75));
                     entityItem.world.playSound(null, pos, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 0.65f, 0.8f + rand * 0.4f);
-                    ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, pos.getX(), pos.getY(), pos.getZ(), 42, 0.0D, 0.15D, 0.0D, 0.08D);
+                    ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, entityItem.posX, entityItem.posY, entityItem.posZ, 42, 0.0D, 0.15D, 0.0D, 0.08D);
                     if (rand <= 0.01F)
                     {
                         entityItem.world.setBlockToAir(pos); // 1/100 chance of the snow evaporating.
@@ -836,7 +836,7 @@ public final class CommonEventHandler
                 {
                     heatCap.setTemperature(Math.max(0, itemTemp - 100));
                     entityItem.world.playSound(null, pos, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 0.8f, 0.8f + rand * 0.4f);
-                    ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, pos.getX(), pos.getY(), pos.getZ(), 42, 0.0D, 0.15D, 0.0D, 0.08D);
+                    ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, entityItem.posX, entityItem.posY, entityItem.posZ, 42, 0.0D, 0.15D, 0.0D, 0.08D);
                     if (rand <= 0.01F)
                     {
                         entityItem.world.setBlockState(pos, FluidsTFC.FRESH_WATER.get().getBlock().getDefaultState(), 2); // 1/100 chance of the ice turning into water.
@@ -846,7 +846,7 @@ public final class CommonEventHandler
                 {
                     heatCap.setTemperature(Math.max(0, itemTemp - 125));
                     entityItem.world.playSound(null, pos, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 1f, 0.8f + rand * 0.4f);
-                    ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, pos.getX(), pos.getY(), pos.getZ(), 42, 0.0D, 0.15D, 0.0D, 0.08D);
+                    ((WorldServer) entityItem.world).spawnParticle(EnumParticleTypes.SMOKE_NORMAL, entityItem.posX, entityItem.posY, entityItem.posZ, 42, 0.0D, 0.15D, 0.0D, 0.08D);
                     if (rand <= 0.005F)
                     {
                         entityItem.world.setBlockState(pos, FluidsTFC.FRESH_WATER.get().getBlock().getDefaultState(), 2); // 1/200 chance of the packed ice turning into water.

--- a/src/main/java/net/dries007/tfc/CommonEventHandler.java
+++ b/src/main/java/net/dries007/tfc/CommonEventHandler.java
@@ -806,7 +806,7 @@ public final class CommonEventHandler
                 if ((state = entityItem.world.getBlockState(pos)).getBlock() instanceof BlockFluidBase)
                 {
                     int fluidTemp = ((BlockFluidBase) state.getBlock()).getFluid().getTemperature();
-                    if (fluidTemp <= 300 && fluidTemp < itemTemp)
+                    if (fluidTemp <= 300)
                     {
                         heatCap.setTemperature(Math.max(0, Math.min(itemTemp, itemTemp - 350 + fluidTemp)));
                         entityItem.world.playSound(null, pos, SoundEvents.BLOCK_LAVA_EXTINGUISH, SoundCategory.BLOCKS, 0.5f, 0.8f + rand * 0.4f);

--- a/src/main/java/net/dries007/tfc/ConfigTFC.java
+++ b/src/main/java/net/dries007/tfc/ConfigTFC.java
@@ -733,13 +733,13 @@ public final class ConfigTFC
             @Config.LangKey("config." + MOD_ID + ".devices.temperature.heatingModifier")
             public double heatingModifier = 1;
 
-            @Config.Comment("Can heatable items be cooled down in a pool of water?")
-            @Config.LangKey("config." + MOD_ID + ".devices.temperature.coolHeatablesInWater")
-            public boolean coolHeatablesInWater = true;
+            @Config.Comment("Can heatable items be cooled down in the world? Such as putting it in a pool of water or on top of some snow?")
+            @Config.LangKey("config." + MOD_ID + ".devices.temperature.coolHeatablesInWorld")
+            public boolean coolHeatablesInWorld = true;
 
-            @Config.Comment("If heatable items can be cooled down in a pool of water, after how many ticks should the item attempt to be cooled down?")
+            @Config.Comment("If heatable items can be cooled down in world, after how many ticks should the item attempt to be cooled down?")
             @Config.LangKey("config." + MOD_ID + ".devices.temperature.ticksBeforeAttemptToCool")
-            @Config.RangeInt(min = 1)
+            @Config.RangeInt(min = 1, max = 5999)
             public int ticksBeforeAttemptToCool = 10;
         }
 

--- a/src/main/java/net/dries007/tfc/ConfigTFC.java
+++ b/src/main/java/net/dries007/tfc/ConfigTFC.java
@@ -732,6 +732,15 @@ public final class ConfigTFC
             @Config.RangeDouble(min = 0, max = 10)
             @Config.LangKey("config." + MOD_ID + ".devices.temperature.heatingModifier")
             public double heatingModifier = 1;
+
+            @Config.Comment("Can heatable items be cooled down in a pool of water?")
+            @Config.LangKey("config." + MOD_ID + ".devices.temperature.coolHeatablesInWater")
+            public boolean coolHeatablesInWater = true;
+
+            @Config.Comment("If heatable items can be cooled down in a pool of water, after how many ticks should the item attempt to be cooled down?")
+            @Config.LangKey("config." + MOD_ID + ".devices.temperature.ticksBeforeAttemptToCool")
+            @Config.RangeInt(min = 1)
+            public int ticksBeforeAttemptToCool = 10;
         }
 
         public static final class BarrelCFG

--- a/src/main/resources/assets/tfc/lang/en_us.lang
+++ b/src/main/resources/assets/tfc/lang/en_us.lang
@@ -642,6 +642,12 @@ config.tfc.devices.temperature.globalModifier.tooltip=Modifier for how quickly i
 config.tfc.devices.temperature.heatingModifier=Heating Temperature Modifier
 config.tfc.devices.temperature.heatingModifier.tooltip=Modifier for how quickly devices (i.e. charcoal forge, fire pit) gain and lose heat. Smaller number = slower temperature changes.
 
+config.tfc.devices.temperature.coolHeatablesInWorld=Cool Heatable Items in the World
+config.tfc.devices.temperature.coolHeatablesInWorld.tooltip=Can heatable items be cooled down in the world? Such as putting it in a pool of water or on top of some snow?
+
+config.tfc.devices.temperature.ticksBeforeAttemptToCool=Ticks Before attempting to Cool
+config.tfc.devices.temperature.ticksBeforeAttemptToCool.tooltip=If heatable items can be cooled down in world, after how many ticks should the item attempt to be cooled down?
+
 
 ### Barrel
 config.tfc.devices.barrel=Barrel


### PR DESCRIPTION
- Also adds faster rate of cool down when its a cooler liquid than water
- If the item is on top of a block that has ice, packed ice or snow material, it also cools down accordingly


This implementation utilizes EntityJoinWorldEvent and ItemExpireEvent, they go hand-in-hand with each other. 

By manually editing the tag of the EntityItem upon spawning, we can identify what EntityItems should be subjected to the cooling process. We also apply an extremely short lifespan to mimic the speed of the barrel recipe, albeit slightly longer (half a second, but modifiable via config). Then all the checks are done in ItemExpireEvent to set a new cooler temperature depending on if the conditions are met. 

First of all, if temperature is 0 or less, then nothing needs to be done and the original lifespan is restored/added on.

If no conditions are met, the same, short length of lifespan is added on so a quick check can be done once again in case the condition will be met later. Now if, this has been repeated for a long time up until it meets the item's normal lifespan, it will despawn.

Finally, if a condition is met, we extend its lifespan once again so more checks can be done to cool down even further.

Fixes #1347 