### PR TITLE
Fixes Plains plant types not able to be planted on adjacent Farmlands

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockVariant.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockVariant.java
@@ -331,7 +331,7 @@ public class BlockRockVariant extends Block implements IItemSize
         switch (plantable.getPlantType(world, pos.offset(direction)))
         {
             case Plains:
-                return type == Rock.Type.DIRT || type == Rock.Type.GRASS || type == Rock.Type.DRY_GRASS || type == Rock.Type.CLAY || type == Rock.Type.CLAY_GRASS;
+                return type == Rock.Type.DIRT || type == Rock.Type.GRASS || type == Rock.Type.FARMLAND || type == Rock.Type.DRY_GRASS || type == Rock.Type.CLAY || type == Rock.Type.CLAY_GRASS;
             case Crop:
                 return type == Rock.Type.FARMLAND;
             case Desert:


### PR DESCRIPTION
- By definition, Plains plant types ARE supposed to be able to be planted on farmlands
- This fixes Bewitchment (and some other mod) 'crops' (which mostly extend BlockBush) not able to be planted on farmlands