### PR TITLE
Sanity check on raw blocks

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockRaw.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/stone/BlockRockRaw.java
@@ -60,7 +60,14 @@ public class BlockRockRaw extends BlockRockVariant implements ICollapsableBlock
     @Override
     public int getMetaFromState(IBlockState state)
     {
-        return state.getValue(CAN_FALL) ? 0 : 1;
+        if (state.getBlock() != this)
+        {
+            return 0;
+        }
+        else
+        {
+            return state.getValue(CAN_FALL) ? 0 : 1;
+        }
     }
 
     @Override


### PR DESCRIPTION
Small change to stop server crashes with AoE mining tools getting out of sync with the server. 

Using the IE Mining Drill, on servers we encounter the issue of this crash:
Time: 2020-09-26 01:08:44 MDT
Description: Ticking player

java.lang.IllegalArgumentException: Cannot get property PropertyBool{name=can_fall, clazz=class java.lang.Boolean, values=[true, false]} as it does not exist in BlockStateContainer{block=tfc:cobble/andesite, properties=[]}
at net.minecraft.block.state.BlockStateContainer$StateImplementation.getValue(BlockStateContainer.java:201)
at net.dries007.tfc.objects.blocks.stone.BlockRockRaw.getMetaFromState(BlockRockRaw.java:63)
at net.minecraft.block.Block.getHarvestTool(Block.java:2057)
at net.minecraftforge.common.ForgeHooks.canHarvestBlock(ForgeHooks.java:226)


This happens when a falling raw stone block is converted to a cobble block. This simple check on getMetaForState appears to resolve it. Not the most elegant fix. But it works.