### PR TITLE
Fix some minor issues with WAILA/TOP 

### DIFF
--- a/src/main/java/net/dries007/tfc/compat/waila/interfaces/HwylaBlockInterface.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/interfaces/HwylaBlockInterface.java
@@ -30,18 +30,20 @@ public class HwylaBlockInterface implements IWailaDataProvider, IWailaPlugin
         this.internal = internal;
     }
 
-
     @Override
     public void register(IWailaRegistrar registrar)
     {
         // Register providers accordingly to each implementation
         for (Class<?> clazz : internal.getLookupClass())
         {
-            registrar.registerBodyProvider(this, clazz);
             if (TileEntity.class.isAssignableFrom(clazz))
             {
                 // Register to update NBT data on all tile entities.
                 registrar.registerNBTProvider(this, clazz);
+            }
+            if (internal.appendBody())
+            {
+                registrar.registerBodyProvider(this, clazz);
             }
             if (internal.overrideTitle())
             {

--- a/src/main/java/net/dries007/tfc/compat/waila/interfaces/HwylaBlockInterface.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/interfaces/HwylaBlockInterface.java
@@ -80,7 +80,11 @@ public class HwylaBlockInterface implements IWailaDataProvider, IWailaPlugin
     @Override
     public List<String> getWailaBody(ItemStack itemStack, List<String> currentTooltip, IWailaDataAccessor accessor, IWailaConfigHandler config)
     {
-        currentTooltip.addAll(internal.getTooltip(accessor.getWorld(), accessor.getPosition(), accessor.getNBTData()));
+        List<String> body = internal.getTooltip(accessor.getWorld(), accessor.getPosition(), accessor.getNBTData());
+        if (!body.isEmpty())
+        {
+            currentTooltip.addAll(internal.getTooltip(accessor.getWorld(), accessor.getPosition(), accessor.getNBTData()));
+        }
         return currentTooltip;
     }
 

--- a/src/main/java/net/dries007/tfc/compat/waila/interfaces/IWailaBlock.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/interfaces/IWailaBlock.java
@@ -76,6 +76,16 @@ public interface IWailaBlock
     }
 
     /**
+     * Allows getTooltip to be queried and appended to the body of the Hwyla tooltip
+     *
+     * @return true if you wish to append to the Hwyla tooltip
+     */
+    default boolean appendBody()
+    {
+        return true;
+    }
+
+    /**
      * Overrides this to tell Hwyla and TOP to override the default stack (eg: The icon that is shown when you're looking at something).
      *
      * @return true if you wish to override the stack icon of the block you're looking at

--- a/src/main/java/net/dries007/tfc/compat/waila/interfaces/IWailaBlock.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/interfaces/IWailaBlock.java
@@ -5,6 +5,7 @@
 
 package net.dries007.tfc.compat.waila.interfaces;
 
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -27,7 +28,10 @@ public interface IWailaBlock
      * @return a List containing tooltips to write on the panel's body
      */
     @Nonnull
-    List<String> getTooltip(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull NBTTagCompound nbt);
+    default List<String> getTooltip(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull NBTTagCompound nbt)
+    {
+        return Collections.emptyList();
+    }
 
     /**
      * Overrides the title (default to the name of the block looked upon)

--- a/src/main/java/net/dries007/tfc/compat/waila/interfaces/TOPBlockInterface.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/interfaces/TOPBlockInterface.java
@@ -52,10 +52,13 @@ public class TOPBlockInterface implements IProbeInfoProvider, IBlockDisplayOverr
             nbt = tileEntity.writeToNBT(nbt);
         }
 
-        List<String> tooltip = internal.getTooltip(world, hitData.getPos(), nbt);
-        for (String string : tooltip)
+        if (internal.appendBody())
         {
-            info.horizontal(info.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER)).text(string);
+            List<String> tooltip = internal.getTooltip(world, hitData.getPos(), nbt);
+            for (String string : tooltip)
+            {
+                info.horizontal(info.defaultLayoutStyle().alignment(ElementAlignment.ALIGN_CENTER)).text(string);
+            }
         }
     }
 

--- a/src/main/java/net/dries007/tfc/compat/waila/providers/OreProvider.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/providers/OreProvider.java
@@ -5,7 +5,6 @@
 
 package net.dries007.tfc.compat.waila.providers;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -14,10 +13,8 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 
-import net.dries007.tfc.api.types.Ore;
 import net.dries007.tfc.compat.waila.interfaces.IWailaBlock;
 import net.dries007.tfc.objects.blocks.stone.BlockOreTFC;
 import net.dries007.tfc.objects.items.metal.ItemOreTFC;
@@ -29,16 +26,7 @@ public class OreProvider implements IWailaBlock
     @Override
     public List<String> getTooltip(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull NBTTagCompound nbt)
     {
-        List<String> currentTooltip = new ArrayList<>();
-        IBlockState state = world.getBlockState(pos);
-        if (state.getBlock() instanceof BlockOreTFC)
-        {
-            BlockOreTFC b = (BlockOreTFC) state.getBlock();
-            Ore.Grade grade = state.getValue(BlockOreTFC.GRADE);
-            ItemStack stack = ItemOreTFC.get(b.ore, grade, 1);
-            currentTooltip.add(new TextComponentTranslation("waila.tfc.ore_drop", new TextComponentTranslation(stack.getTranslationKey() + ".name").getFormattedText()).getFormattedText());
-        }
-        return currentTooltip;
+        return Collections.emptyList();
     }
 
     @Nonnull
@@ -59,5 +47,17 @@ public class OreProvider implements IWailaBlock
     public List<Class<?>> getLookupClass()
     {
         return Collections.singletonList(BlockOreTFC.class);
+    }
+
+    @Override
+    public boolean appendBody()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean overrideIcon()
+    {
+        return true;
     }
 }

--- a/src/main/java/net/dries007/tfc/compat/waila/providers/OreProvider.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/providers/OreProvider.java
@@ -24,13 +24,6 @@ public class OreProvider implements IWailaBlock
 
     @Nonnull
     @Override
-    public List<String> getTooltip(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull NBTTagCompound nbt)
-    {
-        return Collections.emptyList();
-    }
-
-    @Nonnull
-    @Override
     public ItemStack getIcon(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull NBTTagCompound nbt)
     {
         IBlockState state = world.getBlockState(pos);


### PR DESCRIPTION
-Fixes OreProvider not showing drop's ItemStack model as intended.

- (UP FOR DEBATE): removal of `OreProvider#getTooltip` as it is redundant, for the title of it already mentions what the ore is/contains.

+API addition `appendBody`: denotes if the particular IWailaBlock impl should have its `getTooltip` queried on showing tooltip.