### PR TITLE
Prospector's Pick events

### DIFF
--- a/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
+++ b/src/main/java/net/dries007/tfc/TerraFirmaCraft.java
@@ -130,6 +130,7 @@ public final class TerraFirmaCraft
         network.registerMessage(new PacketFoodStatsReplace.Handler(), PacketFoodStatsReplace.class, ++id, Side.CLIENT);
         network.registerMessage(new PacketPlayerDataUpdate.Handler(), PacketPlayerDataUpdate.class, ++id, Side.CLIENT);
         network.registerMessage(new PacketSpawnTFCParticle.Handler(), PacketSpawnTFCParticle.class, ++id, Side.CLIENT);
+        network.registerMessage(new PacketProspectResult.Handler(), PacketProspectResult.class, ++id, Side.CLIENT);
 
         EntitiesTFC.preInit();
         JsonConfigRegistry.INSTANCE.preInit(event.getModConfigurationDirectory());

--- a/src/main/java/net/dries007/tfc/api/events/ProspectEvent.java
+++ b/src/main/java/net/dries007/tfc/api/events/ProspectEvent.java
@@ -1,6 +1,7 @@
 package net.dries007.tfc.api.events;
 
 import net.dries007.tfc.objects.items.metal.ItemProspectorPick.ProspectResult.Type;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -12,16 +13,21 @@ import net.minecraftforge.fml.relauncher.Side;
  * Carries all the data relative to the result displayed to the player.
  * One of the two subclasses will be used according to the logical side.
  */
-public abstract class ProspectEvent extends Event {
+public abstract class ProspectEvent extends Event
+{
 
-    public static class Server extends ProspectEvent {
-        public Server(EntityPlayer player, BlockPos pos, Type type, ItemStack vein){
+    public static class Server extends ProspectEvent
+    {
+        public Server(EntityPlayer player, BlockPos pos, Type type, ItemStack vein)
+        {
             super(Side.SERVER, player, pos, type, vein);
         }
     }
 
-    public static class Client extends ProspectEvent {
-        public Client(EntityPlayer player, BlockPos pos, Type type, ItemStack vein){
+    public static class Client extends ProspectEvent
+    {
+        public Client(EntityPlayer player, BlockPos pos, Type type, ItemStack vein)
+        {
             super(Side.CLIENT, player, pos, type, vein);
         }
     }
@@ -32,7 +38,8 @@ public abstract class ProspectEvent extends Event {
     private Type type;
     private ItemStack vein;
 
-    protected ProspectEvent(Side side, EntityPlayer player, BlockPos pos, Type type, ItemStack vein){
+    protected ProspectEvent(Side side, EntityPlayer player, BlockPos pos, Type type, ItemStack vein)
+    {
         this.side = side;
         this.player = player;
         this.pos = pos;
@@ -40,23 +47,28 @@ public abstract class ProspectEvent extends Event {
         this.vein = vein;
     }
 
-    public Side getSide(){
+    public Side getSide()
+    {
         return side;
     }
 
-    public EntityPlayer getPlayer(){
+    public EntityPlayer getPlayer()
+    {
         return player;
     }
 
-    public BlockPos getBlockPos(){
+    public BlockPos getBlockPos()
+    {
         return pos;
     }
 
-    public Type getResultType(){
+    public Type getResultType()
+    {
         return type;
     }
 
-    public ItemStack getVein(){
+    public ItemStack getVein()
+    {
         return vein;
     }
 }

--- a/src/main/java/net/dries007/tfc/api/events/ProspectEvent.java
+++ b/src/main/java/net/dries007/tfc/api/events/ProspectEvent.java
@@ -1,8 +1,10 @@
 package net.dries007.tfc.api.events;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.relauncher.Side;
 
 /**
  * Event fired when the Prospector's Pickaxe is used.
@@ -12,14 +14,14 @@ import net.minecraftforge.fml.common.eventhandler.Event;
 public abstract class ProspectEvent extends Event {
 
     public static class Server extends ProspectEvent {
-        public Server(EntityPlayer player, BlockPos pos, ResultType type, String ore, double score){
-            super(player, pos, type, ore, score);
+        public Server(EntityPlayer player, BlockPos pos, ResultType type, ItemStack vein){
+            super(Side.SERVER, player, pos, type, vein);
         }
     }
 
     public static class Client extends ProspectEvent {
-        public Client(EntityPlayer player, BlockPos pos, ResultType type, String ore, double score){
-            super(player, pos, type, ore, score);
+        public Client(EntityPlayer player, BlockPos pos, ResultType type, ItemStack vein){
+            super(Side.CLIENT, player, pos, type, vein);
         }
     }
 
@@ -33,24 +35,49 @@ public abstract class ProspectEvent extends Event {
         FOUND      ("tfc.propick.found"),         // right click on block
         NOTHING    ("tfc.propick.found_nothing"); // nothing interesting here
 
+        private static final ResultType[] VALUES = values();
         public final String translation;
 
         ResultType(String translation){
             this.translation = translation;
         }
+
+        public static ResultType valueOf(int ordinal){
+            return VALUES[ordinal];
+        }
     }
 
-    public final EntityPlayer player;
-    public final BlockPos pos;
-    public final ResultType type;
-    public final String ore;
-    public final double score;
+    private Side side;
+    private EntityPlayer player;
+    private BlockPos pos;
+    private ResultType type;
+    private ItemStack vein;
 
-    public ProspectEvent(EntityPlayer player, BlockPos pos, ResultType type, String ore, double score){
+    protected ProspectEvent(Side side, EntityPlayer player, BlockPos pos, ResultType type, ItemStack vein){
+        this.side = side;
         this.player = player;
         this.pos = pos;
         this.type = type;
-        this.ore = ore;
-        this.score = score;
+        this.vein = vein;
+    }
+
+    public Side getSide(){
+        return side;
+    }
+
+    public EntityPlayer getPlayer(){
+        return player;
+    }
+
+    public BlockPos getBlockPos(){
+        return pos;
+    }
+
+    public ResultType getResultType(){
+        return type;
+    }
+
+    public ItemStack getVein(){
+        return vein;
     }
 }

--- a/src/main/java/net/dries007/tfc/api/events/ProspectEvent.java
+++ b/src/main/java/net/dries007/tfc/api/events/ProspectEvent.java
@@ -1,0 +1,56 @@
+package net.dries007.tfc.api.events;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+/**
+ * Event fired when the Prospector's Pickaxe is used.
+ * Carries all the data relative to the result displayed to the player.
+ * One of the two subclasses will be used according to the logical side.
+ */
+public abstract class ProspectEvent extends Event {
+
+    public static class Server extends ProspectEvent {
+        public Server(EntityPlayer player, BlockPos pos, ResultType type, String ore, double score){
+            super(player, pos, type, ore, score);
+        }
+    }
+
+    public static class Client extends ProspectEvent {
+        public Client(EntityPlayer player, BlockPos pos, ResultType type, String ore, double score){
+            super(player, pos, type, ore, score);
+        }
+    }
+
+    public enum ResultType {
+        VERY_LARGE ("tfc.propick.found_very_large"),
+        LARGE      ("tfc.propick.found_large"),
+        MEDIUM     ("tfc.propick.found_medium"),
+        SMALL      ("tfc.propick.found_small"),
+        TRACES     ("tfc.propick.found_traces"),
+
+        FOUND      ("tfc.propick.found"),         // right click on block
+        NOTHING    ("tfc.propick.found_nothing"); // nothing interesting here
+
+        public final String translation;
+
+        ResultType(String translation){
+            this.translation = translation;
+        }
+    }
+
+    public final EntityPlayer player;
+    public final BlockPos pos;
+    public final ResultType type;
+    public final String ore;
+    public final double score;
+
+    public ProspectEvent(EntityPlayer player, BlockPos pos, ResultType type, String ore, double score){
+        this.player = player;
+        this.pos = pos;
+        this.type = type;
+        this.ore = ore;
+        this.score = score;
+    }
+}

--- a/src/main/java/net/dries007/tfc/api/events/ProspectEvent.java
+++ b/src/main/java/net/dries007/tfc/api/events/ProspectEvent.java
@@ -1,5 +1,6 @@
 package net.dries007.tfc.api.events;
 
+import net.dries007.tfc.objects.items.metal.ItemProspectorPick.ProspectResult.Type;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -14,46 +15,24 @@ import net.minecraftforge.fml.relauncher.Side;
 public abstract class ProspectEvent extends Event {
 
     public static class Server extends ProspectEvent {
-        public Server(EntityPlayer player, BlockPos pos, ResultType type, ItemStack vein){
+        public Server(EntityPlayer player, BlockPos pos, Type type, ItemStack vein){
             super(Side.SERVER, player, pos, type, vein);
         }
     }
 
     public static class Client extends ProspectEvent {
-        public Client(EntityPlayer player, BlockPos pos, ResultType type, ItemStack vein){
+        public Client(EntityPlayer player, BlockPos pos, Type type, ItemStack vein){
             super(Side.CLIENT, player, pos, type, vein);
-        }
-    }
-
-    public enum ResultType {
-        VERY_LARGE ("tfc.propick.found_very_large"),
-        LARGE      ("tfc.propick.found_large"),
-        MEDIUM     ("tfc.propick.found_medium"),
-        SMALL      ("tfc.propick.found_small"),
-        TRACES     ("tfc.propick.found_traces"),
-
-        FOUND      ("tfc.propick.found"),         // right click on block
-        NOTHING    ("tfc.propick.found_nothing"); // nothing interesting here
-
-        private static final ResultType[] VALUES = values();
-        public final String translation;
-
-        ResultType(String translation){
-            this.translation = translation;
-        }
-
-        public static ResultType valueOf(int ordinal){
-            return VALUES[ordinal];
         }
     }
 
     private Side side;
     private EntityPlayer player;
     private BlockPos pos;
-    private ResultType type;
+    private Type type;
     private ItemStack vein;
 
-    protected ProspectEvent(Side side, EntityPlayer player, BlockPos pos, ResultType type, ItemStack vein){
+    protected ProspectEvent(Side side, EntityPlayer player, BlockPos pos, Type type, ItemStack vein){
         this.side = side;
         this.player = player;
         this.pos = pos;
@@ -73,7 +52,7 @@ public abstract class ProspectEvent extends Event {
         return pos;
     }
 
-    public ResultType getResultType(){
+    public Type getResultType(){
         return type;
     }
 

--- a/src/main/java/net/dries007/tfc/network/PacketProspectResult.java
+++ b/src/main/java/net/dries007/tfc/network/PacketProspectResult.java
@@ -5,6 +5,7 @@ import net.dries007.tfc.ConfigTFC;
 import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.api.events.ProspectEvent;
 import net.dries007.tfc.objects.items.metal.ItemProspectorPick.ProspectResult.Type;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;

--- a/src/main/java/net/dries007/tfc/network/PacketProspectResult.java
+++ b/src/main/java/net/dries007/tfc/network/PacketProspectResult.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import net.dries007.tfc.ConfigTFC;
 import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.api.events.ProspectEvent;
+import net.dries007.tfc.objects.items.metal.ItemProspectorPick.ProspectResult.Type;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -18,14 +19,14 @@ import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 public class PacketProspectResult implements IMessage
 {
     private BlockPos pos;
-    private ProspectEvent.ResultType type;
+    private Type type;
     private ItemStack vein;
 
     @SuppressWarnings("unused")
     @Deprecated
     public PacketProspectResult() {}
 
-    public PacketProspectResult(BlockPos pos, ProspectEvent.ResultType type, ItemStack vein)
+    public PacketProspectResult(BlockPos pos, Type type, ItemStack vein)
     {
         this.pos = pos;
         this.type = type;
@@ -36,9 +37,9 @@ public class PacketProspectResult implements IMessage
     public void fromBytes(ByteBuf buf)
     {
         pos = BlockPos.fromLong(buf.readLong());
-        type = ProspectEvent.ResultType.valueOf(buf.readByte());
+        type = Type.valueOf(buf.readByte());
 
-        if (type != ProspectEvent.ResultType.NOTHING)
+        if (type != Type.NOTHING)
         {
             vein = ByteBufUtils.readItemStack(buf);
         }
@@ -50,7 +51,7 @@ public class PacketProspectResult implements IMessage
         buf.writeLong(pos.toLong());
         buf.writeByte(type.ordinal());
 
-        if (type != ProspectEvent.ResultType.NOTHING)
+        if (type != Type.NOTHING)
         {
             ByteBufUtils.writeItemStack(buf, vein);
         }
@@ -66,7 +67,7 @@ public class PacketProspectResult implements IMessage
                 if (player != null)
                 {
                     ITextComponent text = new TextComponentTranslation(message.type.translation);
-                    if (message.type != ProspectEvent.ResultType.NOTHING)
+                    if (message.type != Type.NOTHING)
                     {
                         text.appendText(" ").appendSibling(new TextComponentTranslation(message.vein.getTranslationKey() + ".name"));
                     }

--- a/src/main/java/net/dries007/tfc/network/PacketProspectResult.java
+++ b/src/main/java/net/dries007/tfc/network/PacketProspectResult.java
@@ -5,6 +5,7 @@ import net.dries007.tfc.ConfigTFC;
 import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.api.events.ProspectEvent;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextComponentTranslation;
@@ -18,54 +19,40 @@ public class PacketProspectResult implements IMessage
 {
     private BlockPos pos;
     private ProspectEvent.ResultType type;
-    private String ore;
-    private double score;
+    private ItemStack vein;
 
     @SuppressWarnings("unused")
     @Deprecated
     public PacketProspectResult() {}
 
-    public PacketProspectResult(BlockPos pos, ProspectEvent.ResultType type, String ore, double score)
+    public PacketProspectResult(BlockPos pos, ProspectEvent.ResultType type, ItemStack vein)
     {
         this.pos = pos;
         this.type = type;
-        this.ore = ore;
-        this.score = score;
+        this.vein = vein;
     }
 
     @Override
     public void fromBytes(ByteBuf buf)
     {
-        int x = buf.readInt();
-        int y = buf.readInt();
-        int z = buf.readInt();
-        this.pos = new BlockPos(x, y, z);
-        this.type = ProspectEvent.ResultType.values()[buf.readByte()];
+        pos = BlockPos.fromLong(buf.readLong());
+        type = ProspectEvent.ResultType.valueOf(buf.readByte());
 
-        if (type == ProspectEvent.ResultType.NOTHING)
+        if (type != ProspectEvent.ResultType.NOTHING)
         {
-            this.ore = null;
-            this.score = 0.0D;
-        }
-        else
-        {
-            this.ore = ByteBufUtils.readUTF8String(buf);
-            this.score = buf.readDouble();
+            vein = ByteBufUtils.readItemStack(buf);
         }
     }
 
     @Override
     public void toBytes(ByteBuf buf)
     {
-        buf.writeInt(pos.getX());
-        buf.writeInt(pos.getY());
-        buf.writeInt(pos.getZ());
+        buf.writeLong(pos.toLong());
         buf.writeByte(type.ordinal());
 
         if (type != ProspectEvent.ResultType.NOTHING)
         {
-            ByteBufUtils.writeUTF8String(buf, ore);
-            buf.writeDouble(score);
+            ByteBufUtils.writeItemStack(buf, vein);
         }
     }
 
@@ -81,12 +68,12 @@ public class PacketProspectResult implements IMessage
                     ITextComponent text = new TextComponentTranslation(message.type.translation);
                     if (message.type != ProspectEvent.ResultType.NOTHING)
                     {
-                        text.appendText(" ").appendSibling(new TextComponentTranslation(message.ore + ".name"));
+                        text.appendText(" ").appendSibling(new TextComponentTranslation(message.vein.getTranslationKey() + ".name"));
                     }
                     player.sendStatusMessage(text, ConfigTFC.Client.TOOLTIP.propickOutputToActionBar);
                 }
 
-                ProspectEvent event = new ProspectEvent.Client(player, message.pos, message.type, message.ore, message.score);
+                ProspectEvent event = new ProspectEvent.Client(player, message.pos, message.type, message.vein);
                 MinecraftForge.EVENT_BUS.post(event);
             });
             return null;

--- a/src/main/java/net/dries007/tfc/network/PacketProspectResult.java
+++ b/src/main/java/net/dries007/tfc/network/PacketProspectResult.java
@@ -1,0 +1,95 @@
+package net.dries007.tfc.network;
+
+import io.netty.buffer.ByteBuf;
+import net.dries007.tfc.ConfigTFC;
+import net.dries007.tfc.TerraFirmaCraft;
+import net.dries007.tfc.api.events.ProspectEvent;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.network.ByteBufUtils;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+
+public class PacketProspectResult implements IMessage
+{
+    private BlockPos pos;
+    private ProspectEvent.ResultType type;
+    private String ore;
+    private double score;
+
+    @SuppressWarnings("unused")
+    @Deprecated
+    public PacketProspectResult() {}
+
+    public PacketProspectResult(BlockPos pos, ProspectEvent.ResultType type, String ore, double score)
+    {
+        this.pos = pos;
+        this.type = type;
+        this.ore = ore;
+        this.score = score;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf)
+    {
+        int x = buf.readInt();
+        int y = buf.readInt();
+        int z = buf.readInt();
+        this.pos = new BlockPos(x, y, z);
+        this.type = ProspectEvent.ResultType.values()[buf.readByte()];
+
+        if (type == ProspectEvent.ResultType.NOTHING)
+        {
+            this.ore = null;
+            this.score = 0.0D;
+        }
+        else
+        {
+            this.ore = ByteBufUtils.readUTF8String(buf);
+            this.score = buf.readDouble();
+        }
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf)
+    {
+        buf.writeInt(pos.getX());
+        buf.writeInt(pos.getY());
+        buf.writeInt(pos.getZ());
+        buf.writeByte(type.ordinal());
+
+        if (type != ProspectEvent.ResultType.NOTHING)
+        {
+            ByteBufUtils.writeUTF8String(buf, ore);
+            buf.writeDouble(score);
+        }
+    }
+
+    public static final class Handler implements IMessageHandler<PacketProspectResult, IMessage>
+    {
+        @Override
+        public IMessage onMessage(PacketProspectResult message, MessageContext ctx)
+        {
+            TerraFirmaCraft.getProxy().getThreadListener(ctx).addScheduledTask(() -> {
+                EntityPlayer player = TerraFirmaCraft.getProxy().getPlayer(ctx);
+                if (player != null)
+                {
+                    ITextComponent text = new TextComponentTranslation(message.type.translation);
+                    if (message.type != ProspectEvent.ResultType.NOTHING)
+                    {
+                        text.appendText(" ").appendSibling(new TextComponentTranslation(message.ore + ".name"));
+                    }
+                    player.sendStatusMessage(text, ConfigTFC.Client.TOOLTIP.propickOutputToActionBar);
+                }
+
+                ProspectEvent event = new ProspectEvent.Client(player, message.pos, message.type, message.ore, message.score);
+                MinecraftForge.EVENT_BUS.post(event);
+            });
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemProspectorPick.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemProspectorPick.java
@@ -78,7 +78,7 @@ public class ItemProspectorPick extends ItemMetalTool
                 if (!targetStack.isEmpty())
                 {
                     // Just clicked on an ore block
-                    event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.FOUND, targetStack);
+                    event = new ProspectEvent.Server(player, pos, ProspectResult.Type.FOUND, targetStack);
 
                     // Increment skill
                     if (skill != null)
@@ -89,7 +89,7 @@ public class ItemProspectorPick extends ItemMetalTool
                 else if (RANDOM.nextFloat() < falseNegativeChance)
                 {
                     // False negative
-                    event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.NOTHING, null);
+                    event = new ProspectEvent.Server(player, pos, ProspectResult.Type.NOTHING, null);
                 }
                 else
                 {
@@ -97,7 +97,7 @@ public class ItemProspectorPick extends ItemMetalTool
                     if (results.isEmpty())
                     {
                         // Found nothing
-                        event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.NOTHING, null);
+                        event = new ProspectEvent.Server(player, pos, ProspectResult.Type.NOTHING, null);
                     }
                     else
                     {
@@ -220,7 +220,7 @@ public class ItemProspectorPick extends ItemMetalTool
         }
     }
 
-    private static final class ProspectResult
+    public static final class ProspectResult
     {
         private final ItemStack ore;
         private double score;
@@ -231,27 +231,50 @@ public class ItemProspectorPick extends ItemMetalTool
             score = num;
         }
 
-        public ProspectEvent.ResultType getType()
+        public Type getType()
         {
             if (score < 10)
             {
-                return ProspectEvent.ResultType.TRACES;
+                return Type.TRACES;
             }
             else if (score < 20)
             {
-                return ProspectEvent.ResultType.SMALL;
+                return Type.SMALL;
             }
             else if (score < 40)
             {
-                return ProspectEvent.ResultType.MEDIUM;
+                return Type.MEDIUM;
             }
             else if (score < 80)
             {
-                return ProspectEvent.ResultType.LARGE;
+                return Type.LARGE;
             }
             else
             {
-                return ProspectEvent.ResultType.VERY_LARGE;
+                return Type.VERY_LARGE;
+            }
+        }
+
+        public enum Type
+        {
+            VERY_LARGE ("tfc.propick.found_very_large"),
+            LARGE      ("tfc.propick.found_large"),
+            MEDIUM     ("tfc.propick.found_medium"),
+            SMALL      ("tfc.propick.found_small"),
+            TRACES     ("tfc.propick.found_traces"),
+
+            FOUND      ("tfc.propick.found"),         // right click on block
+            NOTHING    ("tfc.propick.found_nothing"); // nothing interesting here
+
+            private static final Type[] VALUES = values();
+            public final String translation;
+
+            Type(String translation){
+                this.translation = translation;
+            }
+
+            public static Type valueOf(int ordinal){
+                return VALUES[ordinal];
             }
         }
     }

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemProspectorPick.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemProspectorPick.java
@@ -15,6 +15,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 import net.dries007.tfc.api.events.ProspectEvent;
 import net.dries007.tfc.network.PacketProspectResult;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.state.IBlockState;
@@ -35,6 +36,7 @@ import net.dries007.tfc.util.skills.ProspectingSkill;
 import net.dries007.tfc.util.skills.SkillType;
 import net.dries007.tfc.world.classic.worldgen.vein.VeinRegistry;
 import net.dries007.tfc.world.classic.worldgen.vein.VeinType;
+
 import net.minecraftforge.common.MinecraftForge;
 
 @ParametersAreNonnullByDefault
@@ -257,23 +259,25 @@ public class ItemProspectorPick extends ItemMetalTool
 
         public enum Type
         {
-            VERY_LARGE ("tfc.propick.found_very_large"),
-            LARGE      ("tfc.propick.found_large"),
-            MEDIUM     ("tfc.propick.found_medium"),
-            SMALL      ("tfc.propick.found_small"),
-            TRACES     ("tfc.propick.found_traces"),
+            VERY_LARGE("tfc.propick.found_very_large"),
+            LARGE("tfc.propick.found_large"),
+            MEDIUM("tfc.propick.found_medium"),
+            SMALL("tfc.propick.found_small"),
+            TRACES("tfc.propick.found_traces"),
 
-            FOUND      ("tfc.propick.found"),         // right click on block
-            NOTHING    ("tfc.propick.found_nothing"); // nothing interesting here
+            FOUND("tfc.propick.found"),         // right click on block
+            NOTHING("tfc.propick.found_nothing"); // nothing interesting here
 
             private static final Type[] VALUES = values();
             public final String translation;
 
-            Type(String translation){
+            Type(String translation)
+            {
                 this.translation = translation;
             }
 
-            public static Type valueOf(int ordinal){
+            public static Type valueOf(int ordinal)
+            {
                 return VALUES[ordinal];
             }
         }

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemProspectorPick.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemProspectorPick.java
@@ -78,7 +78,7 @@ public class ItemProspectorPick extends ItemMetalTool
                 if (!targetStack.isEmpty())
                 {
                     // Just clicked on an ore block
-                    event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.FOUND, targetStack.getTranslationKey(), 0);
+                    event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.FOUND, targetStack);
 
                     // Increment skill
                     if (skill != null)
@@ -89,7 +89,7 @@ public class ItemProspectorPick extends ItemMetalTool
                 else if (RANDOM.nextFloat() < falseNegativeChance)
                 {
                     // False negative
-                    event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.NOTHING, null, 0);
+                    event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.NOTHING, null);
                 }
                 else
                 {
@@ -97,36 +97,13 @@ public class ItemProspectorPick extends ItemMetalTool
                     if (results.isEmpty())
                     {
                         // Found nothing
-                        event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.NOTHING, null, 0);
+                        event = new ProspectEvent.Server(player, pos, ProspectEvent.ResultType.NOTHING, null);
                     }
                     else
                     {
                         // Found something
                         ProspectResult result = (ProspectResult) results.toArray()[RANDOM.nextInt(results.size())];
-                        ProspectEvent.ResultType type;
-
-                        if (result.score < 10)
-                        {
-                            type = ProspectEvent.ResultType.TRACES;
-                        }
-                        else if (result.score < 20)
-                        {
-                            type = ProspectEvent.ResultType.SMALL;
-                        }
-                        else if (result.score < 40)
-                        {
-                            type = ProspectEvent.ResultType.MEDIUM;
-                        }
-                        else if (result.score < 80)
-                        {
-                            type = ProspectEvent.ResultType.LARGE;
-                        }
-                        else
-                        {
-                            type = ProspectEvent.ResultType.VERY_LARGE;
-                        }
-
-                        event = new ProspectEvent.Server(player, pos, type, result.ore.getTranslationKey(), result.score);
+                        event = new ProspectEvent.Server(player, pos, result.getType(), result.ore);
 
                         if (ConfigTFC.General.DEBUG.enable)
                         {
@@ -139,7 +116,7 @@ public class ItemProspectorPick extends ItemMetalTool
                 }
 
                 MinecraftForge.EVENT_BUS.post(event);
-                PacketProspectResult packet = new PacketProspectResult(event.pos, event.type, event.ore, event.score);
+                PacketProspectResult packet = new PacketProspectResult(event.getBlockPos(), event.getResultType(), event.getVein());
                 TerraFirmaCraft.getNetwork().sendTo(packet, (EntityPlayerMP) player);
             }
             else
@@ -252,6 +229,30 @@ public class ItemProspectorPick extends ItemMetalTool
         {
             ore = itemStack;
             score = num;
+        }
+
+        public ProspectEvent.ResultType getType()
+        {
+            if (score < 10)
+            {
+                return ProspectEvent.ResultType.TRACES;
+            }
+            else if (score < 20)
+            {
+                return ProspectEvent.ResultType.SMALL;
+            }
+            else if (score < 40)
+            {
+                return ProspectEvent.ResultType.MEDIUM;
+            }
+            else if (score < 80)
+            {
+                return ProspectEvent.ResultType.LARGE;
+            }
+            else
+            {
+                return ProspectEvent.ResultType.VERY_LARGE;
+            }
         }
     }
 }


### PR DESCRIPTION
Add event (scoped by logical side) to fire with information regarding usage of Prospector's Pick.

Fixes inconsistency where on the dedicated server whatever config is set in `ConfigTFC.Client.TOOLTIP.propickOutputToActionBar` applies to all connected clients when players use the propick, regardless of what is configured on the client side.