### PR TITLE
Removing TEBellows reference from being passed through IBellowsConsumerBlock's methods

### DIFF
--- a/src/main/java/net/dries007/tfc/api/util/IBellowsConsumerBlock.java
+++ b/src/main/java/net/dries007/tfc/api/util/IBellowsConsumerBlock.java
@@ -24,16 +24,14 @@ public interface IBellowsConsumerBlock
     /**
      * standard handlers should check if they have been accessed by belows from a legal offset
      *
-     * @param te     bellows that query
      * @param offset that the bellows used to reach this block, NOT ROTATED accordingly!
      * @param facing direction the bellows output to
      * @return self-explanatory
      */
-    boolean canIntakeFrom(@Nonnull TEBellows te, @Nonnull Vec3i offset, @Nonnull EnumFacing facing);
+    boolean canIntakeFrom(@Nonnull Vec3i offset, @Nonnull EnumFacing facing);
 
     /**
-     * @param te        the bellows that give the air intake.
      * @param airAmount the amount of air that the bellows give. For reference, TFC bellows always give 200.
      */
-    void onAirIntake(@Nonnull TEBellows te, @Nonnull World world, @Nonnull BlockPos pos, int airAmount);
+    void onAirIntake(@Nonnull World world, @Nonnull BlockPos pos, int airAmount);
 }

--- a/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockBlastFurnace.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockBlastFurnace.java
@@ -182,13 +182,13 @@ public class BlockBlastFurnace extends Block implements IBellowsConsumerBlock, I
     }
 
     @Override
-    public boolean canIntakeFrom(@Nonnull TEBellows te, @Nonnull Vec3i offset, @Nonnull EnumFacing facing)
+    public boolean canIntakeFrom(@Nonnull Vec3i offset, @Nonnull EnumFacing facing)
     {
         return offset.equals(TEBellows.OFFSET_LEVEL);
     }
 
     @Override
-    public void onAirIntake(@Nonnull TEBellows te, @Nonnull World world, @Nonnull BlockPos pos, int airAmount)
+    public void onAirIntake(@Nonnull World world, @Nonnull BlockPos pos, int airAmount)
     {
         TEBlastFurnace teBlastFurnace = Helpers.getTE(world, pos, TEBlastFurnace.class);
         if (teBlastFurnace != null)

--- a/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockCharcoalForge.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockCharcoalForge.java
@@ -108,13 +108,13 @@ public class BlockCharcoalForge extends Block implements IBellowsConsumerBlock, 
     }
 
     @Override
-    public boolean canIntakeFrom(TEBellows te, Vec3i offset, EnumFacing facing)
+    public boolean canIntakeFrom(Vec3i offset, EnumFacing facing)
     {
         return offset.equals(TEBellows.OFFSET_INSET);
     }
 
     @Override
-    public void onAirIntake(TEBellows te, World world, BlockPos pos, int airAmount)
+    public void onAirIntake(World world, BlockPos pos, int airAmount)
     {
         TECharcoalForge teForge = Helpers.getTE(world, pos, TECharcoalForge.class);
         if (teForge != null)

--- a/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockFirePit.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockFirePit.java
@@ -434,13 +434,13 @@ public class BlockFirePit extends Block implements IBellowsConsumerBlock, ILight
     }
 
     @Override
-    public boolean canIntakeFrom(TEBellows te, Vec3i offset, EnumFacing facing)
+    public boolean canIntakeFrom(Vec3i offset, EnumFacing facing)
     {
         return offset.equals(TEBellows.OFFSET_LEVEL);
     }
 
     @Override
-    public void onAirIntake(TEBellows te, World world, BlockPos pos, int airAmount)
+    public void onAirIntake(World world, BlockPos pos, int airAmount)
     {
         TEFirePit teFirePit = Helpers.getTE(world, pos, TEFirePit.class);
         if (teFirePit != null)

--- a/src/main/java/net/dries007/tfc/objects/te/TEBellows.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEBellows.java
@@ -98,9 +98,9 @@ public class TEBellows extends TEBase
                 .offset(direction, offset.getX())
                 .offset(direction.rotateY(), offset.getZ());
             Block block = world.getBlockState(posx).getBlock();
-            if (block instanceof IBellowsConsumerBlock && ((IBellowsConsumerBlock) block).canIntakeFrom(this, offset, direction))
+            if (block instanceof IBellowsConsumerBlock && ((IBellowsConsumerBlock) block).canIntakeFrom(offset, direction))
             {
-                ((IBellowsConsumerBlock) block).onAirIntake(this, world, posx, BELLOWS_AIR);
+                ((IBellowsConsumerBlock) block).onAirIntake(world, posx, BELLOWS_AIR);
                 if (world.isRemote)
                 {
                     posx = pos.offset(direction);


### PR DESCRIPTION
1. Nothing you can really get from `TEBellows` besides` TileEntity`, `TEBase` stuff. Even then, you can `BlockPos#offset` using the Vec3i passed through back to do whatever you want.
2. Only thing you can really get from `TEBellows` is a client side `getHeight` which isn't even available in the callback (server-side only).