### PR TITLE
Added correct item ore OreDict names. `ore|Size|Material` as opposed to `ore|Material|Size`

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemOreTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemOreTFC.java
@@ -68,9 +68,11 @@ public class ItemOreTFC extends ItemTFC implements IMetalItem
             {
                 //noinspection ConstantConditions
                 OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", ore.getMetal().getRegistryName().getPath(), grade);
+                OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", grade, ore.getMetal().getRegistryName().getPath());
                 if (ore.getMetal() == Metal.WROUGHT_IRON && ConfigTFC.General.MISC.dictionaryIron)
                 {
                     OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", "iron", grade);
+                    OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", grade, "iron");
                 }
             }
         }

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemOreTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemOreTFC.java
@@ -67,8 +67,9 @@ public class ItemOreTFC extends ItemTFC implements IMetalItem
             for (Ore.Grade grade : Ore.Grade.values())
             {
                 //noinspection ConstantConditions
-                OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", ore.getMetal().getRegistryName().getPath(), grade);
-                OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", grade, ore.getMetal().getRegistryName().getPath());
+                String name = ore.getMetal().getRegistryName().getPath();
+                OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", name, grade);
+                OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", grade, name);
                 if (ore.getMetal() == Metal.WROUGHT_IRON && ConfigTFC.General.MISC.dictionaryIron)
                 {
                     OreDictionaryHelper.registerMeta(this, grade.getMeta(), "ore", "iron", grade);

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemSmallOre.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemSmallOre.java
@@ -59,15 +59,18 @@ public class ItemSmallOre extends ItemTFC implements IMetalItem
         {
             //noinspection ConstantConditions
             OreDictionaryHelper.register(this, "ore", ore.getMetal().getRegistryName().getPath(), "small");
+            OreDictionaryHelper.register(this, "ore", "small", ore.getMetal().getRegistryName().getPath());
             if (ore.getMetal() == Metal.WROUGHT_IRON && ConfigTFC.General.MISC.dictionaryIron)
             {
                 OreDictionaryHelper.register(this, "ore", "iron", "small");
+                OreDictionaryHelper.register(this, "ore", "small", "iron");
             }
         }
         else
         {
             //noinspection ConstantConditions
             OreDictionaryHelper.register(this, "ore", ore.getRegistryName().getPath(), "small");
+            OreDictionaryHelper.register(this, "ore", "small", ore.getRegistryName().getPath());
         }
     }
 

--- a/src/main/java/net/dries007/tfc/objects/items/metal/ItemSmallOre.java
+++ b/src/main/java/net/dries007/tfc/objects/items/metal/ItemSmallOre.java
@@ -58,8 +58,9 @@ public class ItemSmallOre extends ItemTFC implements IMetalItem
         if (ore.getMetal() != null)
         {
             //noinspection ConstantConditions
-            OreDictionaryHelper.register(this, "ore", ore.getMetal().getRegistryName().getPath(), "small");
-            OreDictionaryHelper.register(this, "ore", "small", ore.getMetal().getRegistryName().getPath());
+            String name = ore.getMetal().getRegistryName().getPath();
+            OreDictionaryHelper.register(this, "ore", name, "small");
+            OreDictionaryHelper.register(this, "ore", "small", name);
             if (ore.getMetal() == Metal.WROUGHT_IRON && ConfigTFC.General.MISC.dictionaryIron)
             {
                 OreDictionaryHelper.register(this, "ore", "iron", "small");
@@ -69,8 +70,9 @@ public class ItemSmallOre extends ItemTFC implements IMetalItem
         else
         {
             //noinspection ConstantConditions
-            OreDictionaryHelper.register(this, "ore", ore.getRegistryName().getPath(), "small");
-            OreDictionaryHelper.register(this, "ore", "small", ore.getRegistryName().getPath());
+            String name = ore.getMetal().getRegistryName().getPath();
+            OreDictionaryHelper.register(this, "ore", name, "small");
+            OreDictionaryHelper.register(this, "ore", "small", name);
         }
     }
 


### PR DESCRIPTION
- Old naming still exists to protect existing modpacks from breaking altogether.