### PR TITLE
Optimized pre-definition of ItemSizeHandlers

### DIFF
--- a/src/main/java/net/dries007/tfc/api/capability/size/CapabilityItemSize.java
+++ b/src/main/java/net/dries007/tfc/api/capability/size/CapabilityItemSize.java
@@ -36,20 +36,20 @@ public final class CapabilityItemSize
     public static void preInit()
     {
         // Register the capability
-        CapabilityManager.INSTANCE.register(IItemSize.class, new DumbStorage<>(), ItemSizeHandler::new);
+        CapabilityManager.INSTANCE.register(IItemSize.class, new DumbStorage<>(), ItemSizeHandler::getDefault);
     }
 
     public static void init()
     {
         // Add hardcoded size values for vanilla items
-        CUSTOM_ITEMS.put(IIngredient.of(Items.COAL), () -> new ItemSizeHandler(Size.SMALL, Weight.LIGHT, true)); // Store anywhere stacksize = 32
+        CUSTOM_ITEMS.put(IIngredient.of(Items.COAL), () -> ItemSizeHandler.get(Size.SMALL, Weight.LIGHT, true)); // Store anywhere stacksize = 32
         CUSTOM_ITEMS.put(IIngredient.of(Items.STICK), ItemStickCapability::new); // Store anywhere stacksize = 64
-        CUSTOM_ITEMS.put(IIngredient.of(Items.CLAY_BALL), () -> new ItemSizeHandler(Size.SMALL, Weight.VERY_LIGHT, true)); // Store anywhere stacksize = 64
-        CUSTOM_ITEMS.put(IIngredient.of(Items.BED), () -> new ItemSizeHandler(Size.LARGE, Weight.VERY_HEAVY, false)); // Store only in chests stacksize = 1
-        CUSTOM_ITEMS.put(IIngredient.of(Items.MINECART), () -> new ItemSizeHandler(Size.LARGE, Weight.VERY_HEAVY, false)); // Store only in chests stacksize = 1
-        CUSTOM_ITEMS.put(IIngredient.of(Items.ARMOR_STAND), () -> new ItemSizeHandler(Size.LARGE, Weight.HEAVY, true)); // Store only in chests stacksize = 4
-        CUSTOM_ITEMS.put(IIngredient.of(Items.CAULDRON), () -> new ItemSizeHandler(Size.LARGE, Weight.LIGHT, true)); // Store only in chests stacksize = 32
-        CUSTOM_ITEMS.put(IIngredient.of(Blocks.TRIPWIRE_HOOK), () -> new ItemSizeHandler(Size.SMALL, Weight.VERY_LIGHT, true)); // Store anywhere stacksize = 64
+        CUSTOM_ITEMS.put(IIngredient.of(Items.CLAY_BALL), () -> ItemSizeHandler.get(Size.SMALL, Weight.VERY_LIGHT, true)); // Store anywhere stacksize = 64
+        CUSTOM_ITEMS.put(IIngredient.of(Items.BED), () -> ItemSizeHandler.get(Size.LARGE, Weight.VERY_HEAVY, false)); // Store only in chests stacksize = 1
+        CUSTOM_ITEMS.put(IIngredient.of(Items.MINECART), () -> ItemSizeHandler.get(Size.LARGE, Weight.VERY_HEAVY, false)); // Store only in chests stacksize = 1
+        CUSTOM_ITEMS.put(IIngredient.of(Items.ARMOR_STAND), () -> ItemSizeHandler.get(Size.LARGE, Weight.HEAVY, true)); // Store only in chests stacksize = 4
+        CUSTOM_ITEMS.put(IIngredient.of(Items.CAULDRON), () -> ItemSizeHandler.get(Size.LARGE, Weight.LIGHT, true)); // Store only in chests stacksize = 32
+        CUSTOM_ITEMS.put(IIngredient.of(Blocks.TRIPWIRE_HOOK), () -> ItemSizeHandler.get(Size.SMALL, Weight.VERY_LIGHT, true)); // Store anywhere stacksize = 64
     }
 
     /**
@@ -107,23 +107,23 @@ public final class CapabilityItemSize
         Item item = stack.getItem();
         if (item instanceof ItemTool || item instanceof ItemSword)
         {
-            return new ItemSizeHandler(Size.LARGE, Weight.MEDIUM, true); // Stored only in chests, stacksize should be limited to 1 since it is a tool
+            return ItemSizeHandler.get(Size.LARGE, Weight.MEDIUM, true); // Stored only in chests, stacksize should be limited to 1 since it is a tool
         }
         else if (item instanceof ItemArmor)
         {
-            return new ItemSizeHandler(Size.LARGE, Weight.VERY_HEAVY, true); // Stored only in chests and stacksize = 1
+            return ItemSizeHandler.get(Size.LARGE, Weight.VERY_HEAVY, true); // Stored only in chests and stacksize = 1
         }
         else if (item instanceof ItemBlock && ((ItemBlock) item).getBlock() instanceof BlockLadder)
         {
-            return new ItemSizeHandler(Size.SMALL, Weight.VERY_LIGHT, true); // Fits small vessels and stacksize = 64
+            return ItemSizeHandler.get(Size.SMALL, Weight.VERY_LIGHT, true); // Fits small vessels and stacksize = 64
         }
         else if (item instanceof ItemBlock)
         {
-            return new ItemSizeHandler(Size.SMALL, Weight.LIGHT, true); // Fits small vessels and stacksize = 32
+            return ItemSizeHandler.get(Size.SMALL, Weight.LIGHT, true); // Fits small vessels and stacksize = 32
         }
         else
         {
-            return new ItemSizeHandler(Size.VERY_SMALL, Weight.VERY_LIGHT, true); // Stored anywhere and stacksize = 64
+            return ItemSizeHandler.get(Size.VERY_SMALL, Weight.VERY_LIGHT, true); // Stored anywhere and stacksize = 64
         }
     }
 }

--- a/src/main/java/net/dries007/tfc/compat/crafttweaker/CTItemRegistry.java
+++ b/src/main/java/net/dries007/tfc/compat/crafttweaker/CTItemRegistry.java
@@ -60,7 +60,7 @@ public class CTItemRegistry
                 @Override
                 public void apply()
                 {
-                    CapabilityItemSize.CUSTOM_ITEMS.put(inputIngredient, () -> new ItemSizeHandler(size, weight, true));
+                    CapabilityItemSize.CUSTOM_ITEMS.put(inputIngredient, () -> ItemSizeHandler.get(size, weight, true));
                 }
 
                 @Override

--- a/src/main/java/net/dries007/tfc/objects/items/itemblock/ItemBlockTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/itemblock/ItemBlockTFC.java
@@ -23,7 +23,7 @@ public class ItemBlockTFC extends ItemBlock implements IItemSize
 
     public ItemBlockTFC(Block block)
     {
-        this(block, block instanceof IItemSize ? (IItemSize) block : ItemSizeHandler.get(Size.SMALL, Weight.LIGHT, true));
+        this(block, block instanceof IItemSize ? (IItemSize) block : ItemSizeHandler.getDefault());
     }
 
     public ItemBlockTFC(Block block, IItemSize size)

--- a/src/main/java/net/dries007/tfc/objects/items/itemblock/ItemBlockTFC.java
+++ b/src/main/java/net/dries007/tfc/objects/items/itemblock/ItemBlockTFC.java
@@ -13,6 +13,7 @@ import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 
 import net.dries007.tfc.api.capability.size.IItemSize;
+import net.dries007.tfc.api.capability.size.ItemSizeHandler;
 import net.dries007.tfc.api.capability.size.Size;
 import net.dries007.tfc.api.capability.size.Weight;
 
@@ -22,10 +23,10 @@ public class ItemBlockTFC extends ItemBlock implements IItemSize
 
     public ItemBlockTFC(Block block)
     {
-        this(block, block instanceof IItemSize ? (IItemSize) block : null);
+        this(block, block instanceof IItemSize ? (IItemSize) block : ItemSizeHandler.get(Size.SMALL, Weight.LIGHT, true));
     }
 
-    public ItemBlockTFC(Block block, @Nullable IItemSize size)
+    public ItemBlockTFC(Block block, IItemSize size)
     {
         super(block);
 
@@ -36,20 +37,20 @@ public class ItemBlockTFC extends ItemBlock implements IItemSize
     @Override
     public Size getSize(@Nonnull ItemStack stack)
     {
-        return size != null ? size.getSize(stack) : Size.SMALL; // Stored everywhere
+        return size.getSize(stack);
     }
 
     @Nonnull
     @Override
     public Weight getWeight(@Nonnull ItemStack stack)
     {
-        return size != null ? size.getWeight(stack) : Weight.LIGHT; // Stacksize = 32
+        return size.getWeight(stack);
     }
 
     @Override
     public boolean canStack(@Nonnull ItemStack stack)
     {
-        return size == null || size.canStack(stack);
+        return size.canStack(stack);
     }
 
     /**
@@ -58,6 +59,6 @@ public class ItemBlockTFC extends ItemBlock implements IItemSize
     @Override
     public int getItemStackLimit(ItemStack stack)
     {
-        return getStackSize(stack);
+        return getWeight(stack).stackSize;
     }
 }


### PR DESCRIPTION
- A normal TFC dev env normally gets you

- `11,612 | 272.16 KB | net.dries007.tfc.api.capability.size.ItemSizeHandler`
- Which is 11k~ instances of `ItemSizeHandler` at about 272K RAM usage

After this commit:

- `8 | 192 bytes | net.dries007.tfc.api.capability.size.ItemSizeHandler`
- Which is 8 instances of `ItemSizeHandler` at around 192B

- This was only doable because the object holds 3 defined fields, 2 enum values and 1 boolean. The backing cache `EnumMap<Size, EnumMap<Weight, ItemSizeHandler[]>>` also is pretty efficient thanks to Java. This will obviously not work for custom `IItemSize` implementations, which is fine.