### PR TITLE
Count all logs of same type when looking at log pile

### DIFF
--- a/src/main/java/net/dries007/tfc/compat/waila/HwylaPluginTFC.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/HwylaPluginTFC.java
@@ -34,6 +34,7 @@ public class HwylaPluginTFC implements IWailaPlugin
         new HwylaBlockInterface(new InfoProvider()),
         new HwylaBlockInterface(new TreeProvider()),
         new HwylaBlockInterface(new IngotPileProvider()),
+        new HwylaBlockInterface(new LogPileProvider()),
         new HwylaBlockInterface(new QuernProvider())
     );
 

--- a/src/main/java/net/dries007/tfc/compat/waila/TOPPlugin.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/TOPPlugin.java
@@ -32,6 +32,7 @@ public class TOPPlugin implements Function<ITheOneProbe, Void>
         new TOPBlockInterface(new InfoProvider()),
         new TOPBlockInterface(new TreeProvider()),
         new TOPBlockInterface(new IngotPileProvider()),
+        new TOPBlockInterface(new LogPileProvider()),
         new TOPBlockInterface(new QuernProvider())
     );
 

--- a/src/main/java/net/dries007/tfc/compat/waila/providers/LogPileProvider.java
+++ b/src/main/java/net/dries007/tfc/compat/waila/providers/LogPileProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Work under Copyright. Licensed under the EUPL.
+ * See the project README.md and LICENSE.txt for more information.
+ */
+
+package net.dries007.tfc.compat.waila.providers;
+
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+
+import net.dries007.tfc.compat.waila.interfaces.IWailaBlock;
+import net.dries007.tfc.objects.te.TELogPile;
+import net.dries007.tfc.util.Helpers;
+
+public class LogPileProvider implements IWailaBlock
+{
+
+    @Nonnull
+    @Override
+    public ItemStack getIcon(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull NBTTagCompound nbt)
+    {
+        TELogPile logPile = Helpers.getTE(world, pos, TELogPile.class);
+        if (logPile != null)
+        {
+            IItemHandler inventory = logPile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
+            ItemStack icon = ItemStack.EMPTY;
+            for (int i = 0; i < inventory.getSlots(); i++)
+            {
+                ItemStack slotStack = inventory.getStackInSlot(i);
+                if (!slotStack.isEmpty())
+                {
+                    if(icon.isEmpty()) {
+                        icon = slotStack.copy();
+                    }
+                    else if(slotStack.isItemEqual(icon)) {
+                        icon.grow(slotStack.getCount());
+                    }
+                }
+            }
+
+            return icon;
+        }
+        return ItemStack.EMPTY;
+    }
+
+    @Nonnull
+    @Override
+    public List<Class<?>> getLookupClass()
+    {
+        return Collections.singletonList(TELogPile.class);
+    }
+
+    @Override
+    public boolean appendBody()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean overrideIcon()
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Currently log piles only show the contents of the first slot in the HWYLA/TOP tooltip, meaning they will show a maximum of 4. This will allow them to show a full count.

For log piles with multiple types of wood, only a count of logs matching the first slot is shown, any other logs in the other slots are not reflected in the tooltip. I'm not sure how else to handle this since `IWailaBlock` only supports a single ItemStack for the icon.