### PR TITLE
Fixes #1658

### DIFF
--- a/src/main/java/net/dries007/tfc/api/recipes/barrel/BarrelRecipeFoodTraits.java
+++ b/src/main/java/net/dries007/tfc/api/recipes/barrel/BarrelRecipeFoodTraits.java
@@ -57,13 +57,17 @@ public class BarrelRecipeFoodTraits extends BarrelRecipe
     @Override
     public List<ItemStack> getOutputItem(FluidStack inputFluid, ItemStack inputStack)
     {
+        int multiplier = getMultiplier(inputFluid, inputStack);
         ItemStack stack = inputStack.copy();
+        stack.setCount(multiplier);
+
+        ItemStack remainder = Helpers.consumeItem(inputStack.copy(), multiplier);
         IFood food = stack.getCapability(CapabilityFood.CAPABILITY, null);
         if (food != null)
         {
             CapabilityFood.applyTrait(food, trait);
         }
-        return Helpers.listOf(stack);
+        return Helpers.listOf(stack, remainder);
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/net/dries007/tfc/objects/inventory/ingredient/IngredientItemFoodTrait.java
+++ b/src/main/java/net/dries007/tfc/objects/inventory/ingredient/IngredientItemFoodTrait.java
@@ -56,6 +56,12 @@ public class IngredientItemFoodTrait implements IIngredient<ItemStack>
         return innerIngredient.consume(input);
     }
 
+    @Override
+    public int getAmount()
+    {
+        return this.innerIngredient.getAmount();
+    }
+
     private boolean hasTrait(ItemStack stack)
     {
         IFood cap = stack.getCapability(CapabilityFood.CAPABILITY, null);


### PR DESCRIPTION
Fixes #1658. Before this PR food trait recipes did not require liquid per item in the stack, and consumed liquid like `min(stack size * required liquid, liquid amount in barrel)` and would always return the full stack with the trait. Meaning you could potentially brine a full stack of food using 125mb of brine.