### PR TITLE
Two addon compat edits

### DIFF
--- a/src/main/java/net/dries007/tfc/api/recipes/barrel/BarrelRecipeFoodPreservation.java
+++ b/src/main/java/net/dries007/tfc/api/recipes/barrel/BarrelRecipeFoodPreservation.java
@@ -32,7 +32,7 @@ public class BarrelRecipeFoodPreservation extends BarrelRecipe
     private final FoodTrait trait;
     private final String tooltipName;
 
-    private BarrelRecipeFoodPreservation(@Nonnull IIngredient<FluidStack> inputFluid, @Nonnull IIngredient<ItemStack> inputStack, FoodTrait trait, String tooltipName)
+    public BarrelRecipeFoodPreservation(@Nonnull IIngredient<FluidStack> inputFluid, @Nonnull IIngredient<ItemStack> inputStack, FoodTrait trait, String tooltipName)
     {
         super(inputFluid, inputStack, null, ItemStack.EMPTY, -1);
         this.trait = trait;

--- a/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockFruitTreeTrunk.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/agriculture/BlockFruitTreeTrunk.java
@@ -293,7 +293,7 @@ public class BlockFruitTreeTrunk extends Block
         super.neighborChanged(state, worldIn, pos, blockIn, fromPos);
         if (!(worldIn.getBlockState(pos.down()).getBlock() instanceof BlockFruitTreeTrunk) && !BlocksTFC.isGrowableSoil(worldIn.getBlockState(pos.down())))
         {
-            worldIn.destroyBlock(pos, false);
+            worldIn.destroyBlock(pos, true);
         }
     }
 
@@ -318,23 +318,23 @@ public class BlockFruitTreeTrunk extends Block
             Block branch = BlockFruitTreeBranch.get(tree);
             if (worldIn.getBlockState(pos.up()).getBlock() == this || worldIn.getBlockState(pos.up()).getBlock() == branch)
             {
-                worldIn.destroyBlock(pos.up(), false);
+                worldIn.destroyBlock(pos.up(), true);
             }
             if (worldIn.getBlockState(pos.north()).getBlock() == branch)
             {
-                worldIn.destroyBlock(pos.up(), false);
+                worldIn.destroyBlock(pos.up(), true);
             }
             if (worldIn.getBlockState(pos.south()).getBlock() == branch)
             {
-                worldIn.destroyBlock(pos.up(), false);
+                worldIn.destroyBlock(pos.up(), true);
             }
             if (worldIn.getBlockState(pos.west()).getBlock() == branch)
             {
-                worldIn.destroyBlock(pos.up(), false);
+                worldIn.destroyBlock(pos.up(), true);
             }
             if (worldIn.getBlockState(pos.east()).getBlock() == branch)
             {
-                worldIn.destroyBlock(pos.up(), false);
+                worldIn.destroyBlock(pos.up(), true);
             }
         }
     }


### PR DESCRIPTION
- let fruit tree logs drop their block, even though they don't have one (so that the harvesting event can be fired)
- make BarrelRecipeFoodPreservation constructor public for use with non-vinegar fluids