### PR TITLE
Mini Groundcover rework

### DIFF
--- a/resources/assets.py
+++ b/resources/assets.py
@@ -37,19 +37,25 @@ def generate(rm: ResourceManager):
             elif block_type == 'loose':
                 # One block state and multiple models for the block
                 block = rm.blockstate('rock/loose/%s' % rock, variants={
-                    'facing=east,count=1': {'model': 'tfc:block/rock/pebble/%s' % rock, 'y': 90},
-                    'facing=north,count=1': {'model': 'tfc:block/rock/pebble/%s' % rock},
-                    'facing=south,count=1': {'model': 'tfc:block/rock/pebble/%s' % rock, 'y': 180},
-                    'facing=west,count=1': {'model': 'tfc:block/rock/pebble/%s' % rock, 'y': 270},
-                    'facing=east,count=2': {'model': 'tfc:block/rock/rubble/%s' % rock, 'y': 90},
-                    'facing=north,count=2': {'model': 'tfc:block/rock/rubble/%s' % rock},
-                    'facing=south,count=2': {'model': 'tfc:block/rock/rubble/%s' % rock, 'y': 180},
-                    'facing=west,count=2': {'model': 'tfc:block/rock/rubble/%s' % rock, 'y': 270},
-                    'facing=east,count=3': {'model': 'tfc:block/rock/boulder/%s' % rock, 'y': 90},
-                    'facing=north,count=3': {'model': 'tfc:block/rock/boulder/%s' % rock},
-                    'facing=south,count=3': {'model': 'tfc:block/rock/boulder/%s' % rock, 'y': 180},
-                    'facing=west,count=3': {'model': 'tfc:block/rock/boulder/%s' % rock, 'y': 270},
-                })
+                    'count=1': [
+                        {'model': 'tfc:block/rock/pebble/%s' % rock, 'y': 90},
+                        {'model': 'tfc:block/rock/pebble/%s' % rock},
+                        {'model': 'tfc:block/rock/pebble/%s' % rock, 'y': 180},
+                        {'model': 'tfc:block/rock/pebble/%s' % rock, 'y': 270}
+                    ],
+                    'count=2': [
+                        {'model': 'tfc:block/rock/rubble/%s' % rock, 'y': 90},
+                        {'model': 'tfc:block/rock/rubble/%s' % rock},
+                        {'model': 'tfc:block/rock/rubble/%s' % rock, 'y': 180},
+                        {'model': 'tfc:block/rock/rubble/%s' % rock, 'y': 270}
+                    ],
+                    'count=3': [
+                        {'model': 'tfc:block/rock/boulder/%s' % rock, 'y': 90},
+                        {'model': 'tfc:block/rock/boulder/%s' % rock},
+                        {'model': 'tfc:block/rock/boulder/%s' % rock, 'y': 180},
+                        {'model': 'tfc:block/rock/boulder/%s' % rock, 'y': 270}
+                    ]
+                }, use_default_model=False)
                 for loose_type in ('pebble', 'rubble', 'boulder'):
                     rm.block_model('tfc:rock/%s/%s' % (loose_type, rock), 'tfc:item/loose_rock/%s' % rock, parent='tfc:block/groundcover/%s' % loose_type)
 
@@ -128,12 +134,12 @@ def generate(rm: ResourceManager):
         for ore, ore_data in ORES.items():
             if ore_data.graded:
                 # Small Ores / Groundcover Blocks
-                block = rm.blockstate('tfc:ore/small_%s' % ore, variants={
-                    'facing=east': {'model': 'tfc:block/groundcover/%s' % ore, 'y': 90},
-                    'facing=north': {'model': 'tfc:block/groundcover/%s' % ore},
-                    'facing=south': {'model': 'tfc:block/groundcover/%s' % ore, 'y': 180},
-                    'facing=west': {'model': 'tfc:block/groundcover/%s' % ore, 'y': 270}
-                })
+                block = rm.blockstate('tfc:ore/small_%s' % ore, variants={"": [
+                    {'model': 'tfc:block/groundcover/%s' % ore, 'y': 90},
+                    {'model': 'tfc:block/groundcover/%s' % ore},
+                    {'model': 'tfc:block/groundcover/%s' % ore, 'y': 180},
+                    {'model': 'tfc:block/groundcover/%s' % ore, 'y': 270}
+                ]}, use_default_model=False)
                 block.with_lang(lang('small %s', ore))
                 block.with_block_loot('tfc:ore/small_%s' % ore)
                 block.with_tag('can_be_snow_piled')
@@ -211,12 +217,12 @@ def generate(rm: ResourceManager):
 
     # Groundcover
     for misc in MISC_GROUNDCOVER:
-        block = rm.blockstate(('groundcover', misc), variants={
-            'facing=east': {'model': 'tfc:block/groundcover/%s' % misc, 'y': 90},
-            'facing=north': {'model': 'tfc:block/groundcover/%s' % misc},
-            'facing=south': {'model': 'tfc:block/groundcover/%s' % misc, 'y': 180},
-            'facing=west': {'model': 'tfc:block/groundcover/%s' % misc, 'y': 270}
-        })
+        block = rm.blockstate(('groundcover', misc), variants={"": [
+            {'model': 'tfc:block/groundcover/%s' % misc, 'y': 90},
+            {'model': 'tfc:block/groundcover/%s' % misc},
+            {'model': 'tfc:block/groundcover/%s' % misc, 'y': 180},
+            {'model': 'tfc:block/groundcover/%s' % misc, 'y': 270}
+        ]}, use_default_model=False)
         block.with_lang(lang(misc))
         block.with_tag('can_be_snow_piled')
 
@@ -443,18 +449,18 @@ def generate(rm: ResourceManager):
 
         # Groundcover
         for variant in ('twig', 'fallen_leaves'):
-            block = rm.blockstate('wood/%s/%s' % (variant, wood), variants={
-                'facing=east': {'model': 'tfc:block/wood/%s/%s' % (variant, wood), 'y': 90},
-                'facing=north': {'model': 'tfc:block/wood/%s/%s' % (variant, wood)},
-                'facing=south': {'model': 'tfc:block/wood/%s/%s' % (variant, wood), 'y': 180},
-                'facing=west': {'model': 'tfc:block/wood/%s/%s' % (variant, wood), 'y': 270}
-            })
+            block = rm.blockstate('wood/%s/%s' % (variant, wood), variants={"": [
+                {'model': 'tfc:block/wood/%s/%s' % (variant, wood), 'y': 90},
+                {'model': 'tfc:block/wood/%s/%s' % (variant, wood)},
+                {'model': 'tfc:block/wood/%s/%s' % (variant, wood), 'y': 180},
+                {'model': 'tfc:block/wood/%s/%s' % (variant, wood), 'y': 270}
+            ]}, use_default_model=False)
             block.with_item_model()
             block.with_lang(lang('%s %s', wood, variant))
 
             if variant == 'twig':
                 block.with_block_model({'side': 'tfc:block/wood/log/%s' % wood, 'top': 'tfc:block/wood/log_top/%s' % wood}, parent='tfc:block/groundcover/%s' % variant)
-                block.with_block_loot('minecraft:stick')
+                block.with_block_loot('tfc:wood/twig/%s' % wood)
             elif variant == 'fallen_leaves':
                 block.with_block_model('tfc:block/wood/leaves/%s' % wood, parent='tfc:block/groundcover/%s' % variant)
                 block.with_block_loot('tfc:wood/%s/%s' % (variant, wood))

--- a/resources/world_gen.py
+++ b/resources/world_gen.py
@@ -418,27 +418,27 @@ def generate(rm: ResourceManager):
     raw = ['tfc:rock/raw/%s' % rock for rock in ROCKS.keys()]
     grass = ['tfc:grass/%s' % soil for soil in SOIL_BLOCK_VARIANTS]
 
-    rm.feature('driftwood', wg.configure_decorated(simple_patch_feature('tfc:groundcover/driftwood[facing=north,fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(6), 'minecraft:square', decorate_climate(-10, 50, 200, 500)))
-    rm.feature('clam', wg.configure_decorated(simple_patch_feature('tfc:groundcover/clam[facing=north,fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(6), 'minecraft:square', decorate_climate(-50, 22, 10, 450)))
-    rm.feature('mollusk', wg.configure_decorated(simple_patch_feature('tfc:groundcover/mollusk[facing=north,fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(6), 'minecraft:square', decorate_climate(-10, 30, 150, 500)))
-    rm.feature('mussel', wg.configure_decorated(simple_patch_feature('tfc:groundcover/mussel[facing=north,fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(6), 'minecraft:square', decorate_climate(10, 50, 100, 500)))
+    rm.feature('driftwood', wg.configure_decorated(simple_patch_feature('tfc:groundcover/driftwood[fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(6), 'minecraft:square', decorate_climate(-10, 50, 200, 500)))
+    rm.feature('clam', wg.configure_decorated(simple_patch_feature('tfc:groundcover/clam[fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(6), 'minecraft:square', decorate_climate(-50, 22, 10, 450)))
+    rm.feature('mollusk', wg.configure_decorated(simple_patch_feature('tfc:groundcover/mollusk[fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(6), 'minecraft:square', decorate_climate(-10, 30, 150, 500)))
+    rm.feature('mussel', wg.configure_decorated(simple_patch_feature('tfc:groundcover/mussel[fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(6), 'minecraft:square', decorate_climate(10, 50, 100, 500)))
 
-    rm.feature('sticks_shore', wg.configure_decorated(simple_patch_feature('tfc:groundcover/stick[facing=north,fluid=empty]', 1, 15, 25, sand + gravel, True), decorate_chance(2), 'minecraft:square', decorate_climate(-50, 50, 100, 500)))
-    rm.feature('seaweed', wg.configure_decorated(simple_patch_feature('tfc:groundcover/seaweed[facing=north,fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(5), 'minecraft:square', decorate_climate(-20, 50, 150, 500)))
+    rm.feature('sticks_shore', wg.configure_decorated(simple_patch_feature('tfc:groundcover/stick[fluid=empty]', 1, 15, 25, sand + gravel, True), decorate_chance(2), 'minecraft:square', decorate_climate(-50, 50, 100, 500)))
+    rm.feature('seaweed', wg.configure_decorated(simple_patch_feature('tfc:groundcover/seaweed[fluid=empty]', 1, 15, 10, sand + gravel, True), decorate_chance(5), 'minecraft:square', decorate_climate(-20, 50, 150, 500)))
 
     # Forest Only
-    rm.feature('sticks_forest', wg.configure_decorated(simple_patch_feature('tfc:groundcover/stick[facing=north,fluid=empty]', 1, 15, 20), decorate_chance(3), 'minecraft:square', decorate_climate(-20, 50, 70, 500, True)))
-    rm.feature('pinecone', wg.configure_decorated(simple_patch_feature('tfc:groundcover/pinecone[facing=north,fluid=empty]', 1, 15, 10), decorate_chance(5), 'minecraft:square', decorate_climate(-5, 33, 200, 500, True)))
-    rm.feature('podzol', wg.configure_decorated(simple_patch_feature('tfc:groundcover/podzol[facing=north,fluid=empty]', 1, 5, 100), decorate_chance(5), 'minecraft:square', decorate_climate(8, 20, 180, 420, True, fuzzy=True)))
-    rm.feature('salt_lick', wg.configure_decorated(simple_patch_feature('tfc:groundcover/salt_lick[facing=north,fluid=empty]', 1, 5, 100, raw), decorate_chance(110), 'minecraft:square', decorate_climate(5, 33, 100, 500, True)))
-    rm.feature('dead_grass', wg.configure_decorated(simple_patch_feature('tfc:groundcover/dead_grass[facing=north,fluid=empty]', 1, 5, 100, grass), decorate_chance(70), 'minecraft:square', decorate_climate(10, 20, 0, 150, True, fuzzy=True)))
+    rm.feature('sticks_forest', wg.configure_decorated(simple_patch_feature('tfc:groundcover/stick[fluid=empty]', 1, 15, 20), decorate_chance(3), 'minecraft:square', decorate_climate(-20, 50, 70, 500, True)))
+    rm.feature('pinecone', wg.configure_decorated(simple_patch_feature('tfc:groundcover/pinecone[fluid=empty]', 1, 15, 10), decorate_chance(5), 'minecraft:square', decorate_climate(-5, 33, 200, 500, True)))
+    rm.feature('podzol', wg.configure_decorated(simple_patch_feature('tfc:groundcover/podzol[fluid=empty]', 1, 5, 100), decorate_chance(5), 'minecraft:square', decorate_climate(8, 20, 180, 420, True, fuzzy=True)))
+    rm.feature('salt_lick', wg.configure_decorated(simple_patch_feature('tfc:groundcover/salt_lick[fluid=empty]', 1, 5, 100, raw), decorate_chance(110), 'minecraft:square', decorate_climate(5, 33, 100, 500, True)))
+    rm.feature('dead_grass', wg.configure_decorated(simple_patch_feature('tfc:groundcover/dead_grass[fluid=empty]', 1, 5, 100, grass), decorate_chance(70), 'minecraft:square', decorate_climate(10, 20, 0, 150, True, fuzzy=True)))
 
     # Loose Rocks - Both Surface + Underground
     rm.feature('surface_loose_rocks', wg.configure_decorated(wg.configure('tfc:loose_rock'), decorate_count(6), 'minecraft:square', 'minecraft:top_solid_heightmap'))
 
     # Underground decoration
     rm.feature('underground_loose_rocks', wg.configure_decorated(wg.configure('tfc:loose_rock'), decorate_carving_mask(0.05, 12, 90)))
-    rm.feature('underground_guano', wg.configure_decorated(cave_patch_feature('tfc:groundcover/guano[facing=north,fluid=empty]', 5, 5, 60), decorate_chance(3), 'minecraft:square', decorate_range(80, 130)))
+    rm.feature('underground_guano', wg.configure_decorated(cave_patch_feature('tfc:groundcover/guano[fluid=empty]', 5, 5, 60), decorate_chance(3), 'minecraft:square', decorate_range(80, 130)))
 
     # Carvers
     rm.carver('cave', wg.configure('tfc:cave', {'probability': 0.1}))
@@ -588,11 +588,11 @@ def plant_feature(block: str, vertical_spread: int, horizontal_spread: int, coun
 
 
 def simple_patch_feature(block: str, vertical_spread: int, horizontal_spread: int, count: int = None, whitelist: List[Any] = None, water_agnostic: bool = False):
-    return random_patch(wg.block_state(block), random_property_placer(block, 'facing'), vertical_spread, horizontal_spread, count, target='both' if water_agnostic else 'air', project='sea' if water_agnostic else 'land', whitelist=whitelist)
+    return random_patch(wg.block_state(block), {'type': 'minecraft:simple_block_placer'}, vertical_spread, horizontal_spread, count, target='both' if water_agnostic else 'air', project='sea' if water_agnostic else 'land', whitelist=whitelist)
 
 
 def cave_patch_feature(block: str, vertical_spread: int, horizontal_spread: int, count: Optional[int] = None) -> Dict[str, Any]:
-    return random_patch(wg.block_state(block), random_property_placer(block, 'facing'), vertical_spread, horizontal_spread, count, False, project=False, only_underground=True)
+    return random_patch(wg.block_state(block), {'type': 'minecraft:simple_block_placer'}, vertical_spread, horizontal_spread, count, False, project=False, only_underground=True)
 
 
 def random_patch(state_provider: Union[str, Dict[str, Any]], block_placer: Dict[str, Any], vertical_spread: int, horizontal_spread: int, count: int, use_density: bool = False, target: Union[Literal['air', 'water', 'both', 'emergent'], str] = 'air', project: Union[Literal['sea', 'land', False], str] = 'land', only_underground: bool = False, blacklist: Optional[List[str]] = None, whitelist: Optional[List[str]] = None) -> Dict[str, Any]:

--- a/src/main/java/net/dries007/tfc/common/blocks/GroundcoverBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/GroundcoverBlock.java
@@ -44,7 +44,6 @@ import net.dries007.tfc.common.fluids.IFluidLoggable;
 public class GroundcoverBlock extends Block implements IFluidLoggable
 {
     public static final FluidProperty FLUID = TFCBlockStateProperties.WATER;
-    public static final DirectionProperty FACING = HorizontalBlock.FACING;
 
     public static final VoxelShape FLAT = box(2.0D, 0.0D, 2.0D, 14.0D, 2.0D, 14.0D);
     public static final VoxelShape SMALL = box(5.0D, 0.0D, 5.0D, 11.0D, 2.0D, 11.0D);
@@ -77,7 +76,7 @@ public class GroundcoverBlock extends Block implements IFluidLoggable
         this.shape = shape;
         this.pickBlock = pickBlock;
 
-        registerDefaultState(getStateDefinition().any().setValue(getFluidProperty(), getFluidProperty().keyFor(Fluids.EMPTY)).setValue(FACING, Direction.EAST));
+        registerDefaultState(getStateDefinition().any().setValue(getFluidProperty(), getFluidProperty().keyFor(Fluids.EMPTY)));
     }
 
     @Nonnull
@@ -86,7 +85,7 @@ public class GroundcoverBlock extends Block implements IFluidLoggable
     {
         final FluidState fluidState = context.getLevel().getFluidState(context.getClickedPos());
 
-        BlockState state = defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite());
+        BlockState state = defaultBlockState();
         if (getFluidProperty().canContain(fluidState.getType()))
         {
             return state.setValue(getFluidProperty(), getFluidProperty().keyFor(fluidState.getType()));
@@ -97,7 +96,7 @@ public class GroundcoverBlock extends Block implements IFluidLoggable
     @Override
     protected void createBlockStateDefinition(StateContainer.Builder<Block, BlockState> builder)
     {
-        builder.add(FACING, getFluidProperty());
+        builder.add(getFluidProperty());
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/blocks/rock/LooseRockBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/rock/LooseRockBlock.java
@@ -6,16 +6,12 @@
 
 package net.dries007.tfc.common.blocks.rock;
 
-import javax.annotation.Nonnull;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.state.IntegerProperty;
 import net.minecraft.state.StateContainer;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
 import net.minecraft.util.math.BlockPos;
@@ -25,9 +21,6 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-import net.minecraft.world.server.ServerWorld;
-
-import net.minecraftforge.items.ItemHandlerHelper;
 
 import net.dries007.tfc.common.blocks.GroundcoverBlock;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;

--- a/src/main/java/net/dries007/tfc/util/InteractionManager.java
+++ b/src/main/java/net/dries007/tfc/util/InteractionManager.java
@@ -14,10 +14,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-import javax.annotation.Nullable;
 
 import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
 import net.minecraft.block.SoundType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.*;

--- a/src/main/java/net/dries007/tfc/world/feature/LooseRockFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/LooseRockFeature.java
@@ -50,7 +50,7 @@ public class LooseRockFeature extends Feature<NoFeatureConfig>
 
         if (state != null && state.canSurvive(worldIn, pos))
         {
-            setBlock(worldIn, pos, state.setValue(TFCBlockStateProperties.COUNT_1_3, 1 + rand.nextInt(2)).setValue(HorizontalBlock.FACING, Direction.Plane.HORIZONTAL.getRandomDirection(rand)));
+            setBlock(worldIn, pos, state.setValue(TFCBlockStateProperties.COUNT_1_3, 1 + rand.nextInt(2)));
             return true;
         }
         return false;

--- a/src/main/java/net/dries007/tfc/world/feature/tree/ForestFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/tree/ForestFeature.java
@@ -170,9 +170,7 @@ public class ForestFeature extends Feature<ForestConfig>
                 mutablePos.setY(worldIn.getHeight(Heightmap.Type.OCEAN_FLOOR, mutablePos.getX(), mutablePos.getZ()));
                 if ((worldIn.isEmptyBlock(mutablePos) || worldIn.isWaterAt(mutablePos)) && worldIn.getBlockState(mutablePos.below()).isFaceSturdy(worldIn, mutablePos, Direction.UP))
                 {
-                    setBlock(worldIn, mutablePos, setState
-                        .setValue(TFCBlockStateProperties.WATER, TFCBlockStateProperties.WATER.keyFor(worldIn.getFluidState(mutablePos).getType()))
-                        .setValue(HorizontalBlock.FACING, Direction.Plane.HORIZONTAL.getRandomDirection(random)));
+                    setBlock(worldIn, mutablePos, setState.setValue(TFCBlockStateProperties.WATER, TFCBlockStateProperties.WATER.keyFor(worldIn.getFluidState(mutablePos).getType())));
                 }
             }
         }

--- a/src/main/java/net/dries007/tfc/world/feature/vein/VeinFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/vein/VeinFeature.java
@@ -100,8 +100,7 @@ public abstract class VeinFeature<C extends VeinConfig, V extends Vein> extends 
                         final BlockState state = indicator.getStateToGenerate(random);
                         if (stateAt.isAir() && state.canSurvive(world, mutablePos))
                         {
-                            // todo: this is dangerous directly setting the facing property. can this be just random from the indicator json?
-                            world.setBlock(mutablePos, state.setValue(HorizontalBlock.FACING, Direction.Plane.HORIZONTAL.getRandomDirection(random)), 3);
+                            world.setBlock(mutablePos, state, 3);
                             //world.setBlock(mutablePos.above(20), Blocks.GOLD_BLOCK.defaultBlockState(), 3);
                         }
                     }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/bone.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/bone.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/bone",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/bone"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/bone",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/bone",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/bone",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/bone"
+      },
+      {
+        "model": "tfc:block/groundcover/bone",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/bone",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/clam.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/clam.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/clam",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/clam"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/clam",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/clam",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/clam",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/clam"
+      },
+      {
+        "model": "tfc:block/groundcover/clam",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/clam",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/dead_grass.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/dead_grass.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/dead_grass",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/dead_grass"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/dead_grass",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/dead_grass",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/dead_grass",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/dead_grass"
+      },
+      {
+        "model": "tfc:block/groundcover/dead_grass",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/dead_grass",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/driftwood.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/driftwood.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/driftwood",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/driftwood"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/driftwood",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/driftwood",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/driftwood",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/driftwood"
+      },
+      {
+        "model": "tfc:block/groundcover/driftwood",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/driftwood",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/feather.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/feather.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/feather",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/feather"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/feather",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/feather",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/feather",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/feather"
+      },
+      {
+        "model": "tfc:block/groundcover/feather",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/feather",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/flint.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/flint.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/flint",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/flint"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/flint",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/flint",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/flint",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/flint"
+      },
+      {
+        "model": "tfc:block/groundcover/flint",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/flint",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/guano.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/guano.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/guano",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/guano"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/guano",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/guano",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/guano",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/guano"
+      },
+      {
+        "model": "tfc:block/groundcover/guano",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/guano",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/mollusk.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/mollusk.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/mollusk",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/mollusk"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/mollusk",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/mollusk",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/mollusk",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/mollusk"
+      },
+      {
+        "model": "tfc:block/groundcover/mollusk",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/mollusk",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/mussel.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/mussel.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/mussel",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/mussel"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/mussel",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/mussel",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/mussel",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/mussel"
+      },
+      {
+        "model": "tfc:block/groundcover/mussel",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/mussel",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/pinecone.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/pinecone.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/pinecone",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/pinecone"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/pinecone",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/pinecone",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/pinecone",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/pinecone"
+      },
+      {
+        "model": "tfc:block/groundcover/pinecone",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/pinecone",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/podzol.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/podzol.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/podzol",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/podzol"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/podzol",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/podzol",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/podzol",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/podzol"
+      },
+      {
+        "model": "tfc:block/groundcover/podzol",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/podzol",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/rotten_flesh.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/rotten_flesh.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/rotten_flesh",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/rotten_flesh"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/rotten_flesh",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/rotten_flesh",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/rotten_flesh",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/rotten_flesh"
+      },
+      {
+        "model": "tfc:block/groundcover/rotten_flesh",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/rotten_flesh",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/salt_lick.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/salt_lick.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/salt_lick",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/salt_lick"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/salt_lick",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/salt_lick",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/salt_lick",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/salt_lick"
+      },
+      {
+        "model": "tfc:block/groundcover/salt_lick",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/salt_lick",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/seaweed.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/seaweed.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/seaweed",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/seaweed"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/seaweed",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/seaweed",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/seaweed",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/seaweed"
+      },
+      {
+        "model": "tfc:block/groundcover/seaweed",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/seaweed",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/groundcover/stick.json
+++ b/src/main/resources/assets/tfc/blockstates/groundcover/stick.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/stick",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/stick"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/stick",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/stick",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/stick",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/stick"
+      },
+      {
+        "model": "tfc:block/groundcover/stick",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/stick",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_bismuthinite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_bismuthinite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/bismuthinite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/bismuthinite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/bismuthinite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/bismuthinite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/bismuthinite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/bismuthinite"
+      },
+      {
+        "model": "tfc:block/groundcover/bismuthinite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/bismuthinite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_cassiterite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_cassiterite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/cassiterite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/cassiterite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/cassiterite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/cassiterite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/cassiterite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/cassiterite"
+      },
+      {
+        "model": "tfc:block/groundcover/cassiterite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/cassiterite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_garnierite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_garnierite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/garnierite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/garnierite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/garnierite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/garnierite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/garnierite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/garnierite"
+      },
+      {
+        "model": "tfc:block/groundcover/garnierite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/garnierite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_hematite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_hematite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/hematite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/hematite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/hematite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/hematite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/hematite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/hematite"
+      },
+      {
+        "model": "tfc:block/groundcover/hematite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/hematite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_limonite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_limonite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/limonite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/limonite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/limonite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/limonite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/limonite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/limonite"
+      },
+      {
+        "model": "tfc:block/groundcover/limonite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/limonite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_magnetite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_magnetite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/magnetite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/magnetite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/magnetite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/magnetite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/magnetite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/magnetite"
+      },
+      {
+        "model": "tfc:block/groundcover/magnetite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/magnetite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_malachite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_malachite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/malachite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/malachite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/malachite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/malachite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/malachite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/malachite"
+      },
+      {
+        "model": "tfc:block/groundcover/malachite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/malachite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_native_copper.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_native_copper.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/native_copper",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/native_copper"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/native_copper",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/native_copper",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/native_copper",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/native_copper"
+      },
+      {
+        "model": "tfc:block/groundcover/native_copper",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/native_copper",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_native_gold.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_native_gold.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/native_gold",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/native_gold"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/native_gold",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/native_gold",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/native_gold",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/native_gold"
+      },
+      {
+        "model": "tfc:block/groundcover/native_gold",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/native_gold",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_native_silver.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_native_silver.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/native_silver",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/native_silver"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/native_silver",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/native_silver",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/native_silver",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/native_silver"
+      },
+      {
+        "model": "tfc:block/groundcover/native_silver",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/native_silver",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_sphalerite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_sphalerite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/sphalerite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/sphalerite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/sphalerite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/sphalerite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/sphalerite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/sphalerite"
+      },
+      {
+        "model": "tfc:block/groundcover/sphalerite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/sphalerite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/ore/small_tetrahedrite.json
+++ b/src/main/resources/assets/tfc/blockstates/ore/small_tetrahedrite.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/groundcover/tetrahedrite",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/groundcover/tetrahedrite"
-    },
-    "facing=south": {
-      "model": "tfc:block/groundcover/tetrahedrite",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/groundcover/tetrahedrite",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/groundcover/tetrahedrite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/groundcover/tetrahedrite"
+      },
+      {
+        "model": "tfc:block/groundcover/tetrahedrite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/groundcover/tetrahedrite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/andesite.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/andesite.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/andesite",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/andesite"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/andesite",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/andesite",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/andesite",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/andesite"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/andesite",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/andesite",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/andesite",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/andesite"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/andesite",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/andesite",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/andesite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/andesite"
+      },
+      {
+        "model": "tfc:block/rock/pebble/andesite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/andesite",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/andesite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/andesite"
+      },
+      {
+        "model": "tfc:block/rock/rubble/andesite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/andesite",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/andesite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/andesite"
+      },
+      {
+        "model": "tfc:block/rock/boulder/andesite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/andesite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/basalt.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/basalt.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/basalt",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/basalt"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/basalt",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/basalt",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/basalt",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/basalt"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/basalt",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/basalt",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/basalt",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/basalt"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/basalt",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/basalt",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/basalt",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/basalt"
+      },
+      {
+        "model": "tfc:block/rock/pebble/basalt",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/basalt",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/basalt",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/basalt"
+      },
+      {
+        "model": "tfc:block/rock/rubble/basalt",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/basalt",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/basalt",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/basalt"
+      },
+      {
+        "model": "tfc:block/rock/boulder/basalt",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/basalt",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/chalk.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/chalk.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/chalk",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/chalk"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/chalk",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/chalk",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/chalk",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/chalk"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/chalk",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/chalk",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/chalk",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/chalk"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/chalk",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/chalk",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/chalk",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/chalk"
+      },
+      {
+        "model": "tfc:block/rock/pebble/chalk",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/chalk",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/chalk",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/chalk"
+      },
+      {
+        "model": "tfc:block/rock/rubble/chalk",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/chalk",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/chalk",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/chalk"
+      },
+      {
+        "model": "tfc:block/rock/boulder/chalk",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/chalk",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/chert.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/chert.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/chert",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/chert"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/chert",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/chert",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/chert",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/chert"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/chert",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/chert",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/chert",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/chert"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/chert",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/chert",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/chert",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/chert"
+      },
+      {
+        "model": "tfc:block/rock/pebble/chert",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/chert",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/chert",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/chert"
+      },
+      {
+        "model": "tfc:block/rock/rubble/chert",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/chert",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/chert",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/chert"
+      },
+      {
+        "model": "tfc:block/rock/boulder/chert",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/chert",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/claystone.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/claystone.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/claystone",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/claystone"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/claystone",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/claystone",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/claystone",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/claystone"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/claystone",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/claystone",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/claystone",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/claystone"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/claystone",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/claystone",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/claystone",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/claystone"
+      },
+      {
+        "model": "tfc:block/rock/pebble/claystone",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/claystone",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/claystone",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/claystone"
+      },
+      {
+        "model": "tfc:block/rock/rubble/claystone",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/claystone",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/claystone",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/claystone"
+      },
+      {
+        "model": "tfc:block/rock/boulder/claystone",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/claystone",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/conglomerate.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/conglomerate.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/conglomerate",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/conglomerate"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/conglomerate",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/conglomerate",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/conglomerate",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/conglomerate"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/conglomerate",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/conglomerate",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/conglomerate",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/conglomerate"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/conglomerate",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/conglomerate",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/conglomerate",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/conglomerate"
+      },
+      {
+        "model": "tfc:block/rock/pebble/conglomerate",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/conglomerate",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/conglomerate",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/conglomerate"
+      },
+      {
+        "model": "tfc:block/rock/rubble/conglomerate",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/conglomerate",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/conglomerate",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/conglomerate"
+      },
+      {
+        "model": "tfc:block/rock/boulder/conglomerate",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/conglomerate",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/dacite.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/dacite.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/dacite",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/dacite"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/dacite",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/dacite",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/dacite",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/dacite"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/dacite",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/dacite",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/dacite",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/dacite"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/dacite",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/dacite",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/dacite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/dacite"
+      },
+      {
+        "model": "tfc:block/rock/pebble/dacite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/dacite",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/dacite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/dacite"
+      },
+      {
+        "model": "tfc:block/rock/rubble/dacite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/dacite",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/dacite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/dacite"
+      },
+      {
+        "model": "tfc:block/rock/boulder/dacite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/dacite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/diorite.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/diorite.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/diorite",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/diorite"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/diorite",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/diorite",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/diorite",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/diorite"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/diorite",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/diorite",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/diorite",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/diorite"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/diorite",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/diorite",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/diorite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/diorite"
+      },
+      {
+        "model": "tfc:block/rock/pebble/diorite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/diorite",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/diorite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/diorite"
+      },
+      {
+        "model": "tfc:block/rock/rubble/diorite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/diorite",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/diorite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/diorite"
+      },
+      {
+        "model": "tfc:block/rock/boulder/diorite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/diorite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/dolomite.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/dolomite.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/dolomite",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/dolomite"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/dolomite",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/dolomite",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/dolomite",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/dolomite"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/dolomite",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/dolomite",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/dolomite",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/dolomite"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/dolomite",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/dolomite",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/dolomite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/dolomite"
+      },
+      {
+        "model": "tfc:block/rock/pebble/dolomite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/dolomite",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/dolomite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/dolomite"
+      },
+      {
+        "model": "tfc:block/rock/rubble/dolomite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/dolomite",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/dolomite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/dolomite"
+      },
+      {
+        "model": "tfc:block/rock/boulder/dolomite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/dolomite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/gabbro.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/gabbro.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/gabbro",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/gabbro"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/gabbro",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/gabbro",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/gabbro",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/gabbro"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/gabbro",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/gabbro",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/gabbro",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/gabbro"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/gabbro",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/gabbro",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/gabbro",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/gabbro"
+      },
+      {
+        "model": "tfc:block/rock/pebble/gabbro",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/gabbro",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/gabbro",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/gabbro"
+      },
+      {
+        "model": "tfc:block/rock/rubble/gabbro",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/gabbro",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/gabbro",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/gabbro"
+      },
+      {
+        "model": "tfc:block/rock/boulder/gabbro",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/gabbro",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/gneiss.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/gneiss.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/gneiss",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/gneiss"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/gneiss",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/gneiss",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/gneiss",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/gneiss"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/gneiss",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/gneiss",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/gneiss",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/gneiss"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/gneiss",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/gneiss",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/gneiss",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/gneiss"
+      },
+      {
+        "model": "tfc:block/rock/pebble/gneiss",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/gneiss",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/gneiss",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/gneiss"
+      },
+      {
+        "model": "tfc:block/rock/rubble/gneiss",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/gneiss",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/gneiss",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/gneiss"
+      },
+      {
+        "model": "tfc:block/rock/boulder/gneiss",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/gneiss",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/granite.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/granite.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/granite",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/granite"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/granite",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/granite",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/granite",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/granite"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/granite",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/granite",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/granite",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/granite"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/granite",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/granite",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/granite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/granite"
+      },
+      {
+        "model": "tfc:block/rock/pebble/granite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/granite",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/granite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/granite"
+      },
+      {
+        "model": "tfc:block/rock/rubble/granite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/granite",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/granite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/granite"
+      },
+      {
+        "model": "tfc:block/rock/boulder/granite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/granite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/limestone.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/limestone.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/limestone",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/limestone"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/limestone",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/limestone",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/limestone",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/limestone"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/limestone",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/limestone",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/limestone",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/limestone"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/limestone",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/limestone",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/limestone",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/limestone"
+      },
+      {
+        "model": "tfc:block/rock/pebble/limestone",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/limestone",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/limestone",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/limestone"
+      },
+      {
+        "model": "tfc:block/rock/rubble/limestone",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/limestone",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/limestone",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/limestone"
+      },
+      {
+        "model": "tfc:block/rock/boulder/limestone",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/limestone",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/marble.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/marble.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/marble",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/marble"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/marble",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/marble",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/marble",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/marble"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/marble",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/marble",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/marble",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/marble"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/marble",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/marble",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/marble",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/marble"
+      },
+      {
+        "model": "tfc:block/rock/pebble/marble",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/marble",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/marble",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/marble"
+      },
+      {
+        "model": "tfc:block/rock/rubble/marble",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/marble",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/marble",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/marble"
+      },
+      {
+        "model": "tfc:block/rock/boulder/marble",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/marble",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/phyllite.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/phyllite.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/phyllite",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/phyllite"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/phyllite",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/phyllite",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/phyllite",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/phyllite"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/phyllite",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/phyllite",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/phyllite",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/phyllite"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/phyllite",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/phyllite",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/phyllite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/phyllite"
+      },
+      {
+        "model": "tfc:block/rock/pebble/phyllite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/phyllite",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/phyllite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/phyllite"
+      },
+      {
+        "model": "tfc:block/rock/rubble/phyllite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/phyllite",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/phyllite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/phyllite"
+      },
+      {
+        "model": "tfc:block/rock/boulder/phyllite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/phyllite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/quartzite.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/quartzite.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/quartzite",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/quartzite"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/quartzite",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/quartzite",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/quartzite",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/quartzite"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/quartzite",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/quartzite",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/quartzite",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/quartzite"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/quartzite",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/quartzite",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/quartzite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/quartzite"
+      },
+      {
+        "model": "tfc:block/rock/pebble/quartzite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/quartzite",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/quartzite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/quartzite"
+      },
+      {
+        "model": "tfc:block/rock/rubble/quartzite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/quartzite",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/quartzite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/quartzite"
+      },
+      {
+        "model": "tfc:block/rock/boulder/quartzite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/quartzite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/rhyolite.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/rhyolite.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/rhyolite",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/rhyolite"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/rhyolite",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/rhyolite",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/rhyolite",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/rhyolite"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/rhyolite",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/rhyolite",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/rhyolite",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/rhyolite"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/rhyolite",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/rhyolite",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/rhyolite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/rhyolite"
+      },
+      {
+        "model": "tfc:block/rock/pebble/rhyolite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/rhyolite",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/rhyolite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/rhyolite"
+      },
+      {
+        "model": "tfc:block/rock/rubble/rhyolite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/rhyolite",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/rhyolite",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/rhyolite"
+      },
+      {
+        "model": "tfc:block/rock/boulder/rhyolite",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/rhyolite",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/schist.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/schist.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/schist",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/schist"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/schist",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/schist",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/schist",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/schist"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/schist",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/schist",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/schist",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/schist"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/schist",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/schist",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/schist",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/schist"
+      },
+      {
+        "model": "tfc:block/rock/pebble/schist",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/schist",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/schist",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/schist"
+      },
+      {
+        "model": "tfc:block/rock/rubble/schist",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/schist",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/schist",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/schist"
+      },
+      {
+        "model": "tfc:block/rock/boulder/schist",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/schist",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/shale.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/shale.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/shale",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/shale"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/shale",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/shale",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/shale",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/shale"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/shale",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/shale",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/shale",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/shale"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/shale",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/shale",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/shale",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/shale"
+      },
+      {
+        "model": "tfc:block/rock/pebble/shale",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/shale",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/shale",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/shale"
+      },
+      {
+        "model": "tfc:block/rock/rubble/shale",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/shale",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/shale",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/shale"
+      },
+      {
+        "model": "tfc:block/rock/boulder/shale",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/shale",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/rock/loose/slate.json
+++ b/src/main/resources/assets/tfc/blockstates/rock/loose/slate.json
@@ -1,50 +1,56 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east,count=1": {
-      "model": "tfc:block/rock/pebble/slate",
-      "y": 90
-    },
-    "facing=north,count=1": {
-      "model": "tfc:block/rock/pebble/slate"
-    },
-    "facing=south,count=1": {
-      "model": "tfc:block/rock/pebble/slate",
-      "y": 180
-    },
-    "facing=west,count=1": {
-      "model": "tfc:block/rock/pebble/slate",
-      "y": 270
-    },
-    "facing=east,count=2": {
-      "model": "tfc:block/rock/rubble/slate",
-      "y": 90
-    },
-    "facing=north,count=2": {
-      "model": "tfc:block/rock/rubble/slate"
-    },
-    "facing=south,count=2": {
-      "model": "tfc:block/rock/rubble/slate",
-      "y": 180
-    },
-    "facing=west,count=2": {
-      "model": "tfc:block/rock/rubble/slate",
-      "y": 270
-    },
-    "facing=east,count=3": {
-      "model": "tfc:block/rock/boulder/slate",
-      "y": 90
-    },
-    "facing=north,count=3": {
-      "model": "tfc:block/rock/boulder/slate"
-    },
-    "facing=south,count=3": {
-      "model": "tfc:block/rock/boulder/slate",
-      "y": 180
-    },
-    "facing=west,count=3": {
-      "model": "tfc:block/rock/boulder/slate",
-      "y": 270
-    }
+    "count=1": [
+      {
+        "model": "tfc:block/rock/pebble/slate",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/pebble/slate"
+      },
+      {
+        "model": "tfc:block/rock/pebble/slate",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/pebble/slate",
+        "y": 270
+      }
+    ],
+    "count=2": [
+      {
+        "model": "tfc:block/rock/rubble/slate",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/rubble/slate"
+      },
+      {
+        "model": "tfc:block/rock/rubble/slate",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/rubble/slate",
+        "y": 270
+      }
+    ],
+    "count=3": [
+      {
+        "model": "tfc:block/rock/boulder/slate",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/rock/boulder/slate"
+      },
+      {
+        "model": "tfc:block/rock/boulder/slate",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/rock/boulder/slate",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/acacia.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/acacia.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/acacia",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/acacia"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/acacia",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/acacia",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/acacia",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/acacia"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/acacia",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/acacia",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/ash.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/ash.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/ash",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/ash"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/ash",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/ash",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/ash",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/ash"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/ash",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/ash",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/aspen.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/aspen.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/aspen",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/aspen"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/aspen",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/aspen",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/aspen",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/aspen"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/aspen",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/aspen",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/birch.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/birch.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/birch",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/birch"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/birch",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/birch",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/birch",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/birch"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/birch",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/birch",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/blackwood.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/blackwood.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/blackwood",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/blackwood"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/blackwood",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/blackwood",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/blackwood",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/blackwood"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/blackwood",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/blackwood",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/chestnut.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/chestnut.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/chestnut",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/chestnut"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/chestnut",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/chestnut",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/chestnut",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/chestnut"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/chestnut",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/chestnut",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/douglas_fir.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/douglas_fir.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/douglas_fir",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/douglas_fir"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/douglas_fir",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/douglas_fir",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/douglas_fir",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/douglas_fir"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/douglas_fir",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/douglas_fir",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/hickory.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/hickory.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/hickory",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/hickory"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/hickory",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/hickory",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/hickory",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/hickory"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/hickory",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/hickory",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/kapok.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/kapok.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/kapok",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/kapok"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/kapok",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/kapok",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/kapok",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/kapok"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/kapok",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/kapok",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/maple.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/maple.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/maple",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/maple"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/maple",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/maple",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/maple",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/maple"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/maple",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/maple",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/oak.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/oak.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/oak",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/oak"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/oak",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/oak",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/oak",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/oak"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/oak",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/oak",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/palm.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/palm.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/palm",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/palm"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/palm",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/palm",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/palm",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/palm"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/palm",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/palm",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/pine.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/pine.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/pine",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/pine"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/pine",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/pine",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/pine",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/pine"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/pine",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/pine",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/rosewood.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/rosewood.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/rosewood",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/rosewood"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/rosewood",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/rosewood",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/rosewood",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/rosewood"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/rosewood",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/rosewood",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/sequoia.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/sequoia.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/sequoia",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/sequoia"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/sequoia",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/sequoia",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/sequoia",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/sequoia"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/sequoia",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/sequoia",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/spruce.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/spruce.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/spruce",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/spruce"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/spruce",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/spruce",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/spruce",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/spruce"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/spruce",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/spruce",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/sycamore.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/sycamore.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/sycamore",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/sycamore"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/sycamore",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/sycamore",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/sycamore",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/sycamore"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/sycamore",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/sycamore",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/white_cedar.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/white_cedar.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/white_cedar",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/white_cedar"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/white_cedar",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/white_cedar",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/white_cedar",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/white_cedar"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/white_cedar",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/white_cedar",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/willow.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/fallen_leaves/willow.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/fallen_leaves/willow",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/fallen_leaves/willow"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/fallen_leaves/willow",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/fallen_leaves/willow",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/fallen_leaves/willow",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/willow"
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/willow",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/fallen_leaves/willow",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/acacia.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/acacia.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/acacia",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/acacia"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/acacia",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/acacia",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/acacia",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/acacia"
+      },
+      {
+        "model": "tfc:block/wood/twig/acacia",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/acacia",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/ash.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/ash.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/ash",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/ash"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/ash",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/ash",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/ash",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/ash"
+      },
+      {
+        "model": "tfc:block/wood/twig/ash",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/ash",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/aspen.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/aspen.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/aspen",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/aspen"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/aspen",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/aspen",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/aspen",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/aspen"
+      },
+      {
+        "model": "tfc:block/wood/twig/aspen",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/aspen",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/birch.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/birch.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/birch",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/birch"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/birch",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/birch",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/birch",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/birch"
+      },
+      {
+        "model": "tfc:block/wood/twig/birch",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/birch",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/blackwood.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/blackwood.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/blackwood",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/blackwood"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/blackwood",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/blackwood",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/blackwood",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/blackwood"
+      },
+      {
+        "model": "tfc:block/wood/twig/blackwood",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/blackwood",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/chestnut.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/chestnut.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/chestnut",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/chestnut"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/chestnut",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/chestnut",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/chestnut",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/chestnut"
+      },
+      {
+        "model": "tfc:block/wood/twig/chestnut",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/chestnut",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/douglas_fir.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/douglas_fir.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/douglas_fir",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/douglas_fir"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/douglas_fir",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/douglas_fir",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/douglas_fir",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/douglas_fir"
+      },
+      {
+        "model": "tfc:block/wood/twig/douglas_fir",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/douglas_fir",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/hickory.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/hickory.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/hickory",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/hickory"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/hickory",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/hickory",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/hickory",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/hickory"
+      },
+      {
+        "model": "tfc:block/wood/twig/hickory",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/hickory",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/kapok.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/kapok.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/kapok",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/kapok"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/kapok",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/kapok",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/kapok",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/kapok"
+      },
+      {
+        "model": "tfc:block/wood/twig/kapok",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/kapok",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/maple.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/maple.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/maple",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/maple"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/maple",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/maple",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/maple",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/maple"
+      },
+      {
+        "model": "tfc:block/wood/twig/maple",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/maple",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/oak.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/oak.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/oak",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/oak"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/oak",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/oak",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/oak",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/oak"
+      },
+      {
+        "model": "tfc:block/wood/twig/oak",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/oak",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/palm.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/palm.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/palm",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/palm"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/palm",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/palm",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/palm",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/palm"
+      },
+      {
+        "model": "tfc:block/wood/twig/palm",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/palm",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/pine.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/pine.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/pine",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/pine"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/pine",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/pine",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/pine",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/pine"
+      },
+      {
+        "model": "tfc:block/wood/twig/pine",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/pine",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/rosewood.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/rosewood.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/rosewood",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/rosewood"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/rosewood",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/rosewood",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/rosewood",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/rosewood"
+      },
+      {
+        "model": "tfc:block/wood/twig/rosewood",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/rosewood",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/sequoia.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/sequoia.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/sequoia",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/sequoia"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/sequoia",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/sequoia",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/sequoia",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/sequoia"
+      },
+      {
+        "model": "tfc:block/wood/twig/sequoia",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/sequoia",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/spruce.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/spruce.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/spruce",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/spruce"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/spruce",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/spruce",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/spruce",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/spruce"
+      },
+      {
+        "model": "tfc:block/wood/twig/spruce",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/spruce",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/sycamore.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/sycamore.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/sycamore",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/sycamore"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/sycamore",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/sycamore",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/sycamore",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/sycamore"
+      },
+      {
+        "model": "tfc:block/wood/twig/sycamore",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/sycamore",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/white_cedar.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/white_cedar.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/white_cedar",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/white_cedar"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/white_cedar",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/white_cedar",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/white_cedar",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/white_cedar"
+      },
+      {
+        "model": "tfc:block/wood/twig/white_cedar",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/white_cedar",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/assets/tfc/blockstates/wood/twig/willow.json
+++ b/src/main/resources/assets/tfc/blockstates/wood/twig/willow.json
@@ -1,20 +1,22 @@
 {
   "__comment__": "This file was automatically created by mcresources",
   "variants": {
-    "facing=east": {
-      "model": "tfc:block/wood/twig/willow",
-      "y": 90
-    },
-    "facing=north": {
-      "model": "tfc:block/wood/twig/willow"
-    },
-    "facing=south": {
-      "model": "tfc:block/wood/twig/willow",
-      "y": 180
-    },
-    "facing=west": {
-      "model": "tfc:block/wood/twig/willow",
-      "y": 270
-    }
+    "": [
+      {
+        "model": "tfc:block/wood/twig/willow",
+        "y": 90
+      },
+      {
+        "model": "tfc:block/wood/twig/willow"
+      },
+      {
+        "model": "tfc:block/wood/twig/willow",
+        "y": 180
+      },
+      {
+        "model": "tfc:block/wood/twig/willow",
+        "y": 270
+      }
+    ]
   }
 }

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/acacia.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/acacia.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/acacia"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/ash.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/ash.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/ash"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/aspen.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/aspen.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/aspen"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/birch.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/birch.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/birch"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/blackwood.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/blackwood.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/blackwood"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/chestnut.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/chestnut.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/chestnut"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/douglas_fir.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/douglas_fir.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/douglas_fir"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/hickory.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/hickory.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/hickory"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/kapok.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/kapok.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/kapok"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/maple.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/maple.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/maple"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/oak.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/oak.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/oak"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/palm.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/palm.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/palm"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/pine.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/pine.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/pine"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/rosewood.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/rosewood.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/rosewood"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/sequoia.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/sequoia.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/sequoia"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/spruce.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/spruce.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/spruce"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/sycamore.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/sycamore.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/sycamore"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/white_cedar.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/white_cedar.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/white_cedar"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/willow.json
+++ b/src/main/resources/data/tfc/loot_tables/blocks/wood/twig/willow.json
@@ -8,7 +8,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:stick"
+          "name": "tfc:wood/twig/willow"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/tfc/worldgen/configured_feature/clam.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/clam.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/clam",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/clam",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [
                   "tfc:sand/brown",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/dead_grass.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/dead_grass.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/dead_grass",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/dead_grass",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [
                   "tfc:grass/silt",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/driftwood.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/driftwood.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/driftwood",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/driftwood",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [
                   "tfc:sand/brown",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/mollusk.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/mollusk.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/mollusk",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/mollusk",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [
                   "tfc:sand/brown",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/mussel.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/mussel.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/mussel",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/mussel",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [
                   "tfc:sand/brown",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/pinecone.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/pinecone.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/pinecone",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/pinecone",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [],
                 "blacklist": [],

--- a/src/main/resources/data/tfc/worldgen/configured_feature/podzol.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/podzol.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/podzol",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/podzol",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [],
                 "blacklist": [],

--- a/src/main/resources/data/tfc/worldgen/configured_feature/salt_lick.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/salt_lick.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/salt_lick",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/salt_lick",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [
                   "tfc:rock/raw/chalk",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/seaweed.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/seaweed.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/seaweed",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/seaweed",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [
                   "tfc:sand/brown",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/sticks_forest.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/sticks_forest.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/stick",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/stick",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [],
                 "blacklist": [],

--- a/src/main/resources/data/tfc/worldgen/configured_feature/sticks_shore.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/sticks_shore.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/stick",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/stick",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [
                   "tfc:sand/brown",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/underground_guano.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/underground_guano.json
@@ -16,15 +16,12 @@
                   "state": {
                     "Name": "tfc:groundcover/guano",
                     "Properties": {
-                      "facing": "north",
                       "fluid": "empty"
                     }
                   }
                 },
                 "block_placer": {
-                  "type": "tfc:random_property",
-                  "block": "tfc:groundcover/guano",
-                  "property": "facing"
+                  "type": "minecraft:simple_block_placer"
                 },
                 "whitelist": [],
                 "blacklist": [],


### PR DESCRIPTION
The asset fixes are in the omnibus pr.

- twigs drop themselves (change? still need a crafting recipe adding PR for all this stuff)
- rock addition works now
- facing property removed (breaks worlds)