### PR TITLE
Query tool classes to determine if item should be on the tool rack

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/te/TEToolRack.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEToolRack.java
@@ -37,7 +37,7 @@ public class TEToolRack extends TEBase
             return false;
         }
         Item item = stack.getItem();
-        return item instanceof ItemMetalTool || item instanceof ItemTool || item instanceof ItemBow || item instanceof ItemHoe || item instanceof ItemSword || item instanceof ItemFireStarter || item instanceof ItemFlintAndSteel || OreDictionaryHelper.doesStackMatchOre(stack, "tool");
+        return item instanceof ItemMetalTool || item instanceof ItemTool || item instanceof ItemBow || item instanceof ItemHoe || item instanceof ItemSword || item instanceof ItemFireStarter || item instanceof ItemFlintAndSteel || !item.getToolClasses(stack).isEmpty();
     }
 
     private final NonNullList<ItemStack> items = NonNullList.withSize(4, ItemStack.EMPTY);

--- a/src/main/java/net/dries007/tfc/objects/te/TEToolRack.java
+++ b/src/main/java/net/dries007/tfc/objects/te/TEToolRack.java
@@ -37,7 +37,7 @@ public class TEToolRack extends TEBase
             return false;
         }
         Item item = stack.getItem();
-        return item instanceof ItemMetalTool || item instanceof ItemTool || item instanceof ItemBow || item instanceof ItemHoe || item instanceof ItemSword || item instanceof ItemFireStarter || item instanceof ItemFlintAndSteel || !item.getToolClasses(stack).isEmpty();
+        return item instanceof ItemMetalTool || item instanceof ItemTool || item instanceof ItemBow || item instanceof ItemHoe || item instanceof ItemSword || item instanceof ItemFireStarter || item instanceof ItemFlintAndSteel || !item.getToolClasses(stack).isEmpty() || OreDictionaryHelper.doesStackMatchOre(stack, "tool");
     }
 
     private final NonNullList<ItemStack> items = NonNullList.withSize(4, ItemStack.EMPTY);


### PR DESCRIPTION
- Better way of determining if an item is a tool than checking for an oredict name `tool` as its not the correct convention.