### PR TITLE
Rewrite of WorldRegenHandler

### DIFF
--- a/src/main/java/net/dries007/tfc/util/RegenRocksSticks.java
+++ b/src/main/java/net/dries007/tfc/util/RegenRocksSticks.java
@@ -111,9 +111,7 @@ public class RegenRocksSticks implements IWorldGenerator
 
     private void generateRock(World world, BlockPos pos, @Nullable Vein vein, Rock rock)
     {
-        // Use air, so it doesn't replace other replaceable world gen
-        // This matches the check in BlockPlacedItemFlat for if the block can stay
-        // Also, only add on soil, since this is called by the world regen handler later
+
         if (isReplaceable(world, pos) && world.getBlockState(pos.down()).isSideSolid(world, pos.down(), EnumFacing.UP) && BlocksTFC.isSoil(world.getBlockState(pos.down())))
         {
             world.setBlockState(pos, BlocksTFC.PLACED_ITEM_FLAT.getDefaultState(), 2);
@@ -163,7 +161,7 @@ public class RegenRocksSticks implements IWorldGenerator
 
     private static Boolean isReplaceable(World world, BlockPos pos)
     {
-
+        //Modified to allow replacement of grass during spring regen
         Block test = world.getBlockState(pos).getBlock();
         if (test instanceof BlockShortGrassTFC || test instanceof BlockTallGrassTFC || test.isAir(world.getBlockState(pos), world, pos))
         {

--- a/src/main/java/net/dries007/tfc/util/RegenRocksSticks.java
+++ b/src/main/java/net/dries007/tfc/util/RegenRocksSticks.java
@@ -1,0 +1,202 @@
+package net.dries007.tfc.util;
+
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraftforge.fml.common.IWorldGenerator;
+
+import net.dries007.tfc.ConfigTFC;
+import net.dries007.tfc.api.types.Rock;
+import net.dries007.tfc.objects.blocks.BlocksTFC;
+import net.dries007.tfc.objects.blocks.plants.BlockShortGrassTFC;
+import net.dries007.tfc.objects.blocks.plants.BlockTallGrassTFC;
+import net.dries007.tfc.objects.items.rock.ItemRock;
+import net.dries007.tfc.objects.te.TEPlacedItemFlat;
+import net.dries007.tfc.world.classic.ChunkGenTFC;
+import net.dries007.tfc.world.classic.chunkdata.ChunkDataTFC;
+import net.dries007.tfc.world.classic.worldgen.vein.Vein;
+
+public class RegenRocksSticks implements IWorldGenerator
+{
+    private final boolean generateOres;
+    private double factor;
+
+    public RegenRocksSticks(boolean generateOres)
+    {
+        this.generateOres = generateOres;
+        factor = 1;
+    }
+
+    public void setFactor(double factor)
+    {
+        if (factor < 0) factor = 0;
+        if (factor > 1) factor = 1;
+        this.factor = factor;
+    }
+
+    @Override
+    public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider)
+    {
+        if (chunkGenerator instanceof ChunkGenTFC && world.provider.getDimension() == 0)
+        {
+            final BlockPos chunkBlockPos = new BlockPos(chunkX << 4, 0, chunkZ << 4);
+            final ChunkDataTFC baseChunkData = ChunkDataTFC.get(world, chunkBlockPos);
+
+            // Get the proper list of veins
+            Set<Vein> veins = new HashSet();
+            int xoff = chunkX * 16 + 8;
+            int zoff = chunkZ * 16 + 8;
+
+            if (generateOres)
+            {
+                // Grab 2x2 area
+                ChunkDataTFC[] chunkData = {
+                    baseChunkData, // This chunk
+                    ChunkDataTFC.get(world, chunkBlockPos.add(16, 0, 0)),
+                    ChunkDataTFC.get(world, chunkBlockPos.add(0, 0, 16)),
+                    ChunkDataTFC.get(world, chunkBlockPos.add(16, 0, 16))
+                };
+                if (!chunkData[0].isInitialized())
+                {
+                    return;
+                }
+
+                // Default to 35 below the surface, like classic
+                int lowestYScan = Math.max(10, world.getTopSolidOrLiquidBlock(chunkBlockPos).getY() - ConfigTFC.General.WORLD.looseRockScan);
+
+                for (ChunkDataTFC data : chunkData)
+                {
+                    veins.addAll(data.getGeneratedVeins());
+                }
+
+
+
+                if (!veins.isEmpty())
+                {
+                    veins.removeIf(v -> {
+                        if (v.getType() == null || !v.getType().hasLooseRocks() || v.getHighestY() < lowestYScan)
+                        {
+                            return true;
+                        }
+                        return false;
+                    });
+                }
+            }
+
+            for (int i = 0; i < ConfigTFC.General.WORLD.looseRocksFrequency * factor; i++)
+            {
+                BlockPos pos = new BlockPos(
+                    xoff + random.nextInt(16),
+                    0,
+                    zoff + random.nextInt(16)
+                );
+                Rock rock = baseChunkData.getRock1(pos);
+                generateRock(world, pos.up(world.getTopSolidOrLiquidBlock(pos).getY()), getRandomVein(veins, pos, random), rock);
+            }
+        }
+    }
+
+    private void generateRock(World world, BlockPos pos, @Nullable Vein vein, Rock rock)
+    {
+        // Use air, so it doesn't replace other replaceable world gen
+        // This matches the check in BlockPlacedItemFlat for if the block can stay
+        // Also, only add on soil, since this is called by the world regen handler later
+        if (isReplaceable(world, pos) && world.getBlockState(pos.down()).isSideSolid(world, pos.down(), EnumFacing.UP) && BlocksTFC.isSoil(world.getBlockState(pos.down())))
+        {
+            world.setBlockState(pos, BlocksTFC.PLACED_ITEM_FLAT.getDefaultState(), 2);
+            TEPlacedItemFlat tile = Helpers.getTE(world, pos, TEPlacedItemFlat.class);
+            if (tile != null)
+            {
+                ItemStack stack = ItemStack.EMPTY;
+                if (vein != null && vein.getType() != null)
+                {
+                    if (ConfigTFC.General.WORLD.enableLooseOres)
+                    {
+                        stack = vein.getType().getLooseRockItem();
+                    }
+                }
+                if (stack.isEmpty())
+                {
+                    if (ConfigTFC.General.WORLD.enableLooseRocks)
+                    {
+                        stack = ItemRock.get(rock, 1);
+                    }
+                }
+                if (!stack.isEmpty())
+                {
+                    tile.setStack(stack);
+                }
+            }
+        }
+    }
+
+    @Nullable
+    private Vein getRandomVein(Set<Vein> veins, BlockPos pos, Random rand)
+    {
+        if (!veins.isEmpty() && rand.nextDouble() < 0.4)
+        {
+            Optional<Vein> vein = veins.stream().findAny();
+            if (!veins.isEmpty())
+            {
+                Vein veintarget = vein.get();
+                if (veintarget.inRange(pos.getX(), pos.getZ(), 8))
+                {
+                    return veintarget;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Boolean isReplaceable(World world, BlockPos pos)
+    {
+
+        Block test = world.getBlockState(pos).getBlock();
+        if (test instanceof BlockShortGrassTFC || test instanceof BlockTallGrassTFC || test.isAir(world.getBlockState(pos), world, pos))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    public static void generateLooseSticks(Random rand, int chunkX, int chunkZ, World world, int amount)
+    {
+        if (ConfigTFC.General.WORLD.enableLooseSticks)
+        {
+            for (int i = 0; i < amount; i++)
+            {
+                final int x = chunkX * 16 + rand.nextInt(16) + 8;
+                final int z = chunkZ * 16 + rand.nextInt(16) + 8;
+                final BlockPos pos = world.getTopSolidOrLiquidBlock(new BlockPos(x, 0, z));
+
+                // Use air, so it doesn't replace other replaceable world gen
+                // This matches the check in BlockPlacedItemFlat for if the block can stay
+                // Also, only add on soil, since this is called by the world regen handler later
+                IBlockState stateDown = world.getBlockState(pos.down());
+                if (isReplaceable(world, pos) && stateDown.isSideSolid(world, pos.down(), EnumFacing.UP) && BlocksTFC.isGround(stateDown))
+                {
+                    world.setBlockState(pos, BlocksTFC.PLACED_ITEM_FLAT.getDefaultState());
+                    TEPlacedItemFlat tile = (TEPlacedItemFlat) world.getTileEntity(pos);
+                    if (tile != null)
+                    {
+                        tile.setStack(new ItemStack(Items.STICK));
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/dries007/tfc/util/RegenWildCrops.java
+++ b/src/main/java/net/dries007/tfc/util/RegenWildCrops.java
@@ -1,0 +1,95 @@
+package net.dries007.tfc.util;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.IChunkProvider;
+import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraftforge.fml.common.IWorldGenerator;
+
+import net.dries007.tfc.ConfigTFC;
+import net.dries007.tfc.api.types.ICrop;
+import net.dries007.tfc.objects.blocks.BlocksTFC;
+import net.dries007.tfc.objects.blocks.agriculture.BlockCropTFC;
+import net.dries007.tfc.objects.blocks.plants.BlockShortGrassTFC;
+import net.dries007.tfc.objects.blocks.plants.BlockTallGrassTFC;
+import net.dries007.tfc.util.agriculture.Crop;
+import net.dries007.tfc.util.calendar.CalendarTFC;
+import net.dries007.tfc.util.climate.ClimateTFC;
+import net.dries007.tfc.world.classic.ChunkGenTFC;
+import net.dries007.tfc.world.classic.chunkdata.ChunkDataTFC;
+
+@ParametersAreNonnullByDefault
+public class RegenWildCrops implements IWorldGenerator
+{
+    private static final List<ICrop> CROPS = new ArrayList<>();
+
+    public static void register(ICrop bush)
+    {
+        CROPS.add(bush);
+    }
+
+    public RegenWildCrops(){
+        for (ICrop crop : Crop.values())
+        {
+            RegenWildCrops.register(crop);
+        }
+
+    }
+    @Override
+    public void generate(Random random, int chunkX, int chunkZ, World world, IChunkGenerator chunkGenerator, IChunkProvider chunkProvider)
+    {
+        if (chunkGenerator instanceof ChunkGenTFC && world.provider.getDimension() == 0 && CROPS.size() > 0 && ConfigTFC.General.FOOD.cropRarity > 0)
+        {
+            if (random.nextInt(ConfigTFC.General.FOOD.cropRarity) == 0)
+            {
+                // Guarantees crop generation if possible (easier to balance by config file while also making it random)
+                BlockPos chunkBlockPos = new BlockPos(chunkX << 4, 0, chunkZ << 4);
+
+                Collections.shuffle(CROPS);
+                float temperature = ClimateTFC.getAvgTemp(world, chunkBlockPos);
+                float rainfall = ChunkDataTFC.getRainfall(world, chunkBlockPos);
+
+                ICrop crop = CROPS.stream().filter(x -> x.isValidConditions(temperature, rainfall)).findFirst().orElse(null);
+                if (crop != null)
+                {
+                    BlockCropTFC cropBlock = BlockCropTFC.get(crop);
+                    int cropsInChunk = 3 + random.nextInt(5);
+                    for (int i = 0; i < cropsInChunk; i++)
+                    {
+                        final int x = (chunkX << 4) + random.nextInt(16) + 8;
+                        final int z = (chunkZ << 4) + random.nextInt(16) + 8;
+                        final BlockPos pos = world.getTopSolidOrLiquidBlock(new BlockPos(x, 0, z));
+                        if (isReplaceable(world, pos) && BlocksTFC.isSoil(world.getBlockState(pos.down())))
+                        {
+                            double yearProgress = CalendarTFC.CALENDAR_TIME.getMonthOfYear().ordinal() / 11.0;
+                            int maxStage = crop.getMaxStage();
+                            int growth = (int) (yearProgress * maxStage) + 3 - random.nextInt(2);
+                            if (growth > maxStage)
+                                growth = maxStage;
+                            world.setBlockState(pos, cropBlock.getDefaultState().withProperty(cropBlock.getStageProperty(), growth).withProperty(BlockCropTFC.WILD, true), 2);
+
+                        }
+                    }
+                }
+            }
+        }
+    }
+    private Boolean isReplaceable(World world, BlockPos pos)
+    {
+
+        Block test = world.getBlockState(pos).getBlock();
+        if (test instanceof BlockShortGrassTFC || test instanceof BlockTallGrassTFC || test.isAir(world.getBlockState(pos), world, pos))
+        {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/net/dries007/tfc/util/RegenWildCrops.java
+++ b/src/main/java/net/dries007/tfc/util/RegenWildCrops.java
@@ -84,7 +84,7 @@ public class RegenWildCrops implements IWorldGenerator
     }
     private Boolean isReplaceable(World world, BlockPos pos)
     {
-
+        //Modified to allow replacement of grass during spring regen
         Block test = world.getBlockState(pos).getBlock();
         if (test instanceof BlockShortGrassTFC || test instanceof BlockTallGrassTFC || test.isAir(world.getBlockState(pos), world, pos))
         {

--- a/src/main/java/net/dries007/tfc/util/ServerUtils.java
+++ b/src/main/java/net/dries007/tfc/util/ServerUtils.java
@@ -1,0 +1,22 @@
+package net.dries007.tfc.util;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import static com.google.common.math.DoubleMath.mean;
+
+public class ServerUtils
+{
+    public ServerUtils() {}
+
+    public double getTPS(World world, int dimId)
+    {
+        double worldTickTime = (double) mean((long[]) world.getMinecraftServer().worldTickTimes.get(dimId)) * 1.0E-6D;
+        return Math.min(1000.0D / worldTickTime, 20.0D);
+
+    }
+
+    public static boolean isSurvivalOrAdventure(EntityPlayer player) {
+        return !player.isSpectator() && !player.isCreative();
+    }
+}

--- a/src/main/java/net/dries007/tfc/util/ServerUtils.java
+++ b/src/main/java/net/dries007/tfc/util/ServerUtils.java
@@ -15,8 +15,4 @@ public class ServerUtils
         return Math.min(1000.0D / worldTickTime, 20.0D);
 
     }
-
-    public static boolean isSurvivalOrAdventure(EntityPlayer player) {
-        return !player.isSpectator() && !player.isCreative();
-    }
 }

--- a/src/main/java/net/dries007/tfc/util/WorldRegenHandler.java
+++ b/src/main/java/net/dries007/tfc/util/WorldRegenHandler.java
@@ -5,57 +5,88 @@
 
 package net.dries007.tfc.util;
 
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.IEntityLivingData;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.tileentity.MobSpawnerBaseLogic;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ClassInheritanceMultiMap;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.ChunkProviderServer;
 import net.minecraft.world.gen.IChunkGenerator;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.event.world.ChunkDataEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 import net.dries007.tfc.ConfigTFC;
+import net.dries007.tfc.api.registries.TFCRegistries;
+import net.dries007.tfc.api.types.*;
+import net.dries007.tfc.objects.blocks.agriculture.BlockCropDead;
+import net.dries007.tfc.objects.blocks.plants.BlockMushroomTFC;
+import net.dries007.tfc.objects.blocks.stone.BlockRockVariant;
+import net.dries007.tfc.objects.items.ItemSeedsTFC;
+import net.dries007.tfc.objects.te.TECropBase;
+import net.dries007.tfc.objects.te.TEPlacedItemFlat;
+import net.dries007.tfc.types.DefaultPlants;
 import net.dries007.tfc.util.calendar.CalendarTFC;
 import net.dries007.tfc.util.calendar.ICalendar;
 import net.dries007.tfc.util.calendar.Month;
+import net.dries007.tfc.util.climate.ClimateTFC;
 import net.dries007.tfc.world.classic.chunkdata.ChunkDataTFC;
 import net.dries007.tfc.world.classic.worldgen.*;
 
 import static net.dries007.tfc.TerraFirmaCraft.MOD_ID;
+import static net.dries007.tfc.objects.blocks.agriculture.BlockCropTFC.WILD;
 
 /**
  * Seasonally regenerates rocks, sticks, snow, plants, crops and bushes.
  */
-@Mod.EventBusSubscriber(modid = MOD_ID)
-public final class WorldRegenHandler
-{
-    private static final WorldGenLooseRocks ROCKS_GEN = new WorldGenLooseRocks(false);
-    private static final WorldGenSnowIce SNOW_GEN = new WorldGenSnowIce();
-    private static final WorldGenWildCrops CROPS_GEN = new WorldGenWildCrops();
-    private static final WorldGenBerryBushes BUSH_GEN = new WorldGenBerryBushes();
 
+@SuppressWarnings({"unused", "WeakerAccess"})
+@Mod.EventBusSubscriber(modid = MOD_ID)
+public class WorldRegenHandler
+{
+
+    private static final RegenRocksSticks ROCKS_GEN = new RegenRocksSticks(true);
+    private static final RegenWildCrops CROPS_GEN = new RegenWildCrops();
+    private static final WorldGenBerryBushes BUSH_GEN = new WorldGenBerryBushes();
+    public static final WorldGenPlantTFC PLANT_GEN = new WorldGenPlantTFC();
     private static final Random RANDOM = new Random();
     private static final List<ChunkPos> POSITIONS = new LinkedList<>();
+
 
     @SubscribeEvent
     public static void onChunkLoad(ChunkDataEvent.Load event)
     {
-        // This is disabled for now, as it was causing runaway regeneration of stuff (after multiple attempts to fix it), and potential performance issues
-        // This needs some proper design work on how it is going to operate
-        // todo: fix this
-        /*if (event.getWorld().provider.getDimension() == 0)
+
+        ChunkDataTFC chunkDataTFC = ChunkDataTFC.get(event.getChunk());
+
+
+        //stick/rock/crop/mushroom/other? regen
+        if (event.getWorld().provider.getDimension() == 0 &&  chunkDataTFC.isInitialized() && POSITIONS.size() < 1000)
         {
-            ChunkDataTFC chunkDataTFC = ChunkDataTFC.get(event.getChunk());
-            if (chunkDataTFC.isInitialized() && !chunkDataTFC.isSpawnProtected() && (chunkDataTFC.getLastUpdateYear() > CalendarTFC.CALENDAR_TIME.getTotalYears() || CalendarTFC.PLAYER_TIME.getTicks() - chunkDataTFC.getLastUpdateTick() > 6 * ICalendar.TICKS_IN_DAY))
+            //Only run this in the early months of each year
+            if (CalendarTFC.CALENDAR_TIME.getMonthOfYear().isWithin(Month.APRIL, Month.JULY) && !chunkDataTFC.isSpawnProtected() && CalendarTFC.CALENDAR_TIME.getTotalYears() > chunkDataTFC.getLastUpdateYear())
             {
-                //POSITIONS.add(event.getChunk().getPos());
+                POSITIONS.add(event.getChunk().getPos());
             }
-        }*/
+        }
     }
 
     @SubscribeEvent
@@ -65,50 +96,265 @@ public final class WorldRegenHandler
         {
             if (!POSITIONS.isEmpty())
             {
-                ChunkPos pos = POSITIONS.remove(0);
-                ChunkDataTFC chunkDataTFC = ChunkDataTFC.get(event.world, pos.getBlock(0, 0, 0));
-
-                IChunkProvider chunkProvider = event.world.getChunkProvider();
-                IChunkGenerator chunkGenerator = ((ChunkProviderServer) chunkProvider).chunkGenerator;
-
-                // If past the update time, then run some regeneration of natural resources
-                long updateDelta = CalendarTFC.PLAYER_TIME.getTicks() - chunkDataTFC.getLastUpdateTick();
-                if (updateDelta > ConfigTFC.General.WORLD_REGEN.minimumTime * ICalendar.TICKS_IN_DAY && !chunkDataTFC.isSpawnProtected())
+                ServerUtils su = new ServerUtils();
+                double tps = su.getTPS(event.world, 0);
+                if (tps > 16)
                 {
-                    float regenerationModifier = MathHelper.clamp((float) updateDelta / (4 * ConfigTFC.General.WORLD_REGEN.minimumTime * ICalendar.TICKS_IN_DAY), 0, 1);
+                    ChunkPos pos = POSITIONS.remove(0);
+                    Chunk chunk = event.world.getChunk(pos.x, pos.z);
+                    BlockPos blockPos = pos.getBlock(0, 0, 0);
+                    ChunkDataTFC chunkDataTFC = ChunkDataTFC.get(event.world, pos.getBlock(0, 0, 0));
+                    IChunkProvider chunkProvider = event.world.getChunkProvider();
+                    IChunkGenerator chunkGenerator = ((ChunkProviderServer) chunkProvider).chunkGenerator;
 
-                    // Loose rocks - factors in time since last update
-                    if (ConfigTFC.General.WORLD_REGEN.sticksRocksModifier > 0)
+
+                    if (CalendarTFC.CALENDAR_TIME.getMonthOfYear().isWithin(Month.APRIL, Month.JULY) && !chunkDataTFC.isSpawnProtected() && CalendarTFC.CALENDAR_TIME.getTotalYears() > chunkDataTFC.getLastUpdateYear())
                     {
-                        double rockModifier = ConfigTFC.General.WORLD_REGEN.sticksRocksModifier * regenerationModifier;
-                        ROCKS_GEN.setFactor(rockModifier);
-                        ROCKS_GEN.generate(RANDOM, pos.x, pos.z, event.world, chunkGenerator, chunkProvider);
+                        if (ConfigTFC.General.WORLD_REGEN.sticksRocksModifier > 0)
+                        {
+                            //Nuke any rocks and sticks in chunk.
+                            removeAllPlacedItems(event.world, pos);
+                            List<Tree> trees = chunkDataTFC.getValidTrees();
+                            double rockModifier = ConfigTFC.General.WORLD_REGEN.sticksRocksModifier;
+                            ROCKS_GEN.generate(RANDOM, pos.x, pos.z, event.world, chunkGenerator, chunkProvider);
 
-                        int stickDensity = (int) (rockModifier * (1 + (int) (3f * chunkDataTFC.getFloraDensity())));
-                        WorldGenTrees.generateLooseSticks(RANDOM, pos.x, pos.z, event.world, stickDensity);
-                    }
+                            final float density = chunkDataTFC.getFloraDensity();
+                            int stickDensity = 3 + (int) (4f * density + 1.5f * trees.size() * rockModifier);
+                            if (trees.isEmpty())
+                            {
+                                stickDensity = 1 + (int) (1.5f * density * rockModifier);
+                            }
+                            RegenRocksSticks.generateLooseSticks(RANDOM, pos.x, pos.z, event.world, stickDensity);
+                        }
 
-                    chunkDataTFC.resetLastUpdateTick();
-                }
+                        //Nuke crops/mushrooms/dead crops (not sure the latter is working.
+                        removeAllSurfaceCrap(event.world, pos);
+                        removeSeedbags(event.world, pos);
 
-                // Plants + crops. Only runs once (maximum) each year
-                if (CalendarTFC.CALENDAR_TIME.getMonthOfYear().isWithin(Month.APRIL, Month.JULY) && !chunkDataTFC.isSpawnProtected() && CalendarTFC.CALENDAR_TIME.getTotalYears() > chunkDataTFC.getLastUpdateYear())
-                {
-                    if (RANDOM.nextInt(20) == 0)
-                    {
+                        float avgTemperature = ClimateTFC.getAvgTemp(event.world, blockPos);
+                        float rainfall = ChunkDataTFC.getRainfall(event.world, blockPos);
+                        float floraDensity = chunkDataTFC.getFloraDensity(); // Use for various plant based decoration (tall grass, those vanilla jungle shrub things, etc.)
+                        float floraDiversity = chunkDataTFC.getFloraDiversity();
+                        Plant plant = TFCRegistries.PLANTS.getValue(DefaultPlants.PORCINI);
+                        PLANT_GEN.setGeneratedPlant(plant);
+                        int mushroomCount = 3;
+                        for (float i = RANDOM.nextInt(Math.round(mushroomCount / floraDiversity)); i < (1 + floraDensity) * 5; i++)
+                        {
+                            BlockPos blockMushroomPos = event.world.getHeight(blockPos.add(RANDOM.nextInt(16) + 8, 0, RANDOM.nextInt(16) + 8));
+                            PLANT_GEN.generate(event.world, RANDOM, blockMushroomPos);
+                        }
                         CROPS_GEN.generate(RANDOM, pos.x, pos.z, event.world, chunkGenerator, chunkProvider);
+                        int worldX = pos.x << 4;
+                        int worldZ = pos.z << 4;
+                        BlockPos blockpos = new BlockPos(worldX, 0, worldZ);
+                        Biome biome = event.world.getBiome(blockpos.add(16, 0, 16));
+                        regenPredators(event.world, biome, worldX + 8, worldZ + 8, 16, 16, RANDOM);
+
+                        //Should nuke any bushes in the chunk. For now we just leave the bushes alone.
+                        //BUSH_GEN.generate(RANDOM, pos.x, pos.z, event.world, chunkGenerator, chunkProvider);
+                        chunkDataTFC.resetLastUpdateYear();
+
+
                     }
-                    BUSH_GEN.generate(RANDOM, pos.x, pos.z, event.world, chunkGenerator, chunkProvider);
+                    chunk.markDirty();
+                    ((ChunkProviderServer) chunkProvider).queueUnload(chunk);
 
-                    chunkDataTFC.resetLastUpdateYear();
                 }
-
-                // Update snow / ice from large calendar changes
-                if (updateDelta > ICalendar.TICKS_IN_DAY * 4)
+                else //TPS too low. Just remove it and move on. Or do we leave it?
                 {
-                    SNOW_GEN.generate(RANDOM, pos.x, pos.z, event.world, chunkGenerator, chunkProvider);
+                    ChunkPos pos = POSITIONS.remove(0);
                 }
             }
         }
+
+    }
+
+    private static void removeAllSurfaceCrap(World world, ChunkPos pos)
+    {
+        ArrayList<BlockPos> removals = new ArrayList<>();
+
+        int xX;
+        int zZ;
+        for (xX = 0; xX < 16; ++xX)
+        {
+            for (zZ = 0; zZ < 16; ++zZ)
+            {
+                BlockPos topBlock = world.getTopSolidOrLiquidBlock(pos.getBlock(xX, 0, zZ));
+                //If I'm not completely missing the point, then we have the top block for each in a chunk. Which is apparently not the top solid block ffs.
+                IBlockState blockstate = world.getBlockState(topBlock);
+                Block block = blockstate.getBlock();
+                if (!blockstate.getMaterial().isLiquid())
+                {
+                    if (block instanceof BlockCropDead || block instanceof BlockMushroomTFC)
+                    {
+                        IBlockState soil = world.getBlockState(topBlock.down());
+                        if (soil.getBlock() instanceof BlockRockVariant){
+                            BlockRockVariant soilRock = (BlockRockVariant) soil.getBlock();
+                            //Stop removing dead crops from farmland please!
+                            if (soilRock.getType() != Rock.Type.FARMLAND){
+                                removals.add(topBlock);
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+        //Remove all the crops
+        Map<BlockPos, TileEntity> teTargets = world.getChunk(pos.x, pos.z).getTileEntityMap();
+
+        if (!teTargets.isEmpty())
+        {
+            for (Map.Entry<BlockPos, TileEntity> entry : teTargets.entrySet())
+            {
+                if (entry.getValue() instanceof TECropBase)
+                {
+                    IBlockState bs = world.getBlockState(entry.getKey());
+                    boolean isWild = bs.getValue(WILD);
+                    if (isWild){
+                        removals.add(entry.getKey());
+                    }
+
+                }
+            }
+        }
+        if (!removals.isEmpty())
+        {
+
+            for (BlockPos remove : removals)
+            {
+                world.removeTileEntity(remove);
+                world.setBlockToAir(remove);
+            }
+        }
+    }
+
+
+    private static void removeSeedbags(World world, ChunkPos pos)
+    {
+        ClassInheritanceMultiMap<Entity>[] targets = world.getChunk(pos.x, pos.z).getEntityLists();
+        ArrayList<Entity> removals = new ArrayList<>();
+        if (targets.length > 0)
+        {
+
+
+            //we gots some entities. Now let's see if any of them are the target
+            for (int i = 0; i < targets.length; i++)
+            {
+                for (Entity select : targets[i])
+                {
+                    if (select instanceof EntityItem)
+                    {
+                        if (((EntityItem) select).getItem().getItem() instanceof ItemSeedsTFC)
+                        {
+                            //mark for destruction
+                            removals.add(select);
+                        }
+                    }
+
+                }
+            }
+            if (!removals.isEmpty())
+            {
+                for (Entity remove : removals)
+                {
+                    world.removeEntity(remove);
+                }
+
+            }
+
+
+        }
+    }
+
+    private static void removeAllPlacedItems(World world, ChunkPos pos)
+    {
+        Map<BlockPos, TileEntity> teTargets = world.getChunk(pos.x, pos.z).getTileEntityMap();
+        ArrayList<BlockPos> removals =  new ArrayList<>();
+
+        if (!teTargets.isEmpty())
+        {
+            for (Map.Entry<BlockPos, TileEntity> entry : teTargets.entrySet())
+            {
+                if (entry.getValue() instanceof TEPlacedItemFlat)
+                {
+                    removals.add(entry.getKey());
+                }
+            }
+        }
+        if (!removals.isEmpty())
+        {
+            for (BlockPos remove : removals)
+            {
+                world.removeTileEntity(remove);
+                world.setBlockToAir(remove);
+            }
+        }
+    }
+
+
+    public static void regenPredators(World worldIn, Biome biomeIn, int centerX, int centerZ, int diameterX, int diameterZ, Random randomIn) {
+        BlockPos chunkBlockPos = new BlockPos(centerX, 0, centerZ);
+        float temperature = ClimateTFC.getAvgTemp(worldIn, chunkBlockPos);
+        float rainfall = ChunkDataTFC.getRainfall(worldIn, chunkBlockPos);
+        float floraDensity = ChunkDataTFC.getFloraDensity(worldIn, chunkBlockPos);
+        float floraDiversity = ChunkDataTFC.getFloraDiversity(worldIn, chunkBlockPos);
+        ForgeRegistries.ENTITIES.getValuesCollection().stream().filter((x) -> {
+            if (ICreatureTFC.class.isAssignableFrom(x.getEntityClass())) {
+                Entity ent = x.newInstance(worldIn);
+                if (ent instanceof IPredator || ent instanceof IHuntable) {
+                    int weight = ((ICreatureTFC)ent).getSpawnWeight(biomeIn, temperature, rainfall, floraDensity, floraDiversity);
+                    return weight > 0 && randomIn.nextInt(weight) == 0;
+                }
+            }
+
+            return false;
+        }).findAny().ifPresent((entityEntry) -> {
+            doGroupSpawning(entityEntry, worldIn, centerX, centerZ, diameterX, diameterZ, randomIn);
+        });
+    }
+
+    private static void doGroupSpawning(EntityEntry entityEntry, World worldIn, int centerX, int centerZ, int diameterX, int diameterZ, Random randomIn) {
+        List<EntityLiving> group = new ArrayList();
+        EntityLiving creature = (EntityLiving)entityEntry.newInstance(worldIn);
+        if (creature instanceof ICreatureTFC) {
+            ICreatureTFC creatureTFC = (ICreatureTFC)creature;
+            int fallback = 5;
+            int individuals = Math.max(1, creatureTFC.getMinGroupSize()) + randomIn.nextInt(creatureTFC.getMaxGroupSize() - Math.max(0, creatureTFC.getMinGroupSize() - 1));
+
+            while(individuals > 0) {
+                int j = centerX + randomIn.nextInt(diameterX);
+                int k = centerZ + randomIn.nextInt(diameterZ);
+                BlockPos blockpos = worldIn.getTopSolidOrLiquidBlock(new BlockPos(j, 0, k));
+                creature.setLocationAndAngles((double)((float)j + 0.5F), (double)blockpos.getY(), (double)((float)k + 0.5F), randomIn.nextFloat() * 360.0F, 0.0F);
+                if (creature.getCanSpawnHere()) {
+                    if (ForgeEventFactory.canEntitySpawn(creature, worldIn, (float)j + 0.5F, (float)blockpos.getY(), (float)k + 0.5F, (MobSpawnerBaseLogic)null) == Event.Result.DENY) {
+                        --fallback;
+                        if (fallback > 0) {
+                            continue;
+                        }
+                        break;
+                    } else {
+                        fallback = 5;
+                        worldIn.spawnEntity(creature);
+                        group.add(creature);
+                        creature.onInitialSpawn(worldIn.getDifficultyForLocation(new BlockPos(creature)), (IEntityLivingData)null);
+                        --individuals;
+                        if (individuals > 0) {
+                            creature = (EntityLiving)entityEntry.newInstance(worldIn);
+                            creatureTFC = (ICreatureTFC)creature;
+                        }
+                    }
+                } else {
+                    --fallback;
+                    if (fallback <= 0) {
+                        break;
+                    }
+                }
+            }
+
+            creatureTFC.getGroupingRules().accept(group, randomIn);
+        }
     }
 }
+


### PR DESCRIPTION
Strips chunk of crops/dead crops/seed bags/rocks/sticks/nuggets before regen to prevent excess in chunk
- Regens nuggets/rocks/sticks
- Regens mushrooms
- Regens crops
- Regens predators and huntables
- Only executes if server tps > 16 to prevent excessive lag in spring regen
- Uses modified rock and crop gen to allow replacing grass in target location