### PR TITLE
Fix multiple issues with item stacks in small vessels

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/container/ContainerSmallVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/container/ContainerSmallVessel.java
@@ -5,13 +5,20 @@
 
 package net.dries007.tfc.objects.container;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.inventory.Slot;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 
+import net.dries007.tfc.api.capability.food.CapabilityFood;
+import net.dries007.tfc.api.capability.food.FoodTrait;
+import net.dries007.tfc.api.capability.food.IFood;
 import net.dries007.tfc.objects.inventory.capability.ISlotCallback;
 import net.dries007.tfc.objects.inventory.slot.SlotCallback;
+
+import javax.annotation.Nonnull;
 
 public class ContainerSmallVessel extends ContainerItemStack implements ISlotCallback
 {
@@ -33,5 +40,80 @@ public class ContainerSmallVessel extends ContainerItemStack implements ISlotCal
             addSlotToContainer(new SlotCallback(inventory, 2, 71, 41, callback));
             addSlotToContainer(new SlotCallback(inventory, 3, 89, 41, callback));
         }
+    }
+
+    /**
+     * Copied from ContainerItemStack, but modified to change preserved trait
+     */
+    @Override
+    @Nonnull
+    public ItemStack transferStackInSlot(EntityPlayer player, int index)
+    {
+        // Slot that was clicked
+        Slot slot = inventorySlots.get(index);
+
+        ItemStack itemstack;
+
+        if (slot == null || !slot.getHasStack())
+            return ItemStack.EMPTY;
+
+        if (index == itemIndex)
+            return ItemStack.EMPTY;
+
+        ItemStack itemstack1 = slot.getStack();
+        itemstack = itemstack1.copy();
+
+        // Begin custom transfer code here
+        int containerSlots = inventorySlots.size() - player.inventory.mainInventory.size(); // number of slots in the container
+        if (index < containerSlots)
+        {
+            // Transfer out of the container
+
+            // Player shift-clicked item out of vessel. Shift-clicks ignore the
+            // returned stack from ItemSmallVessel.extractItem, so the preserved
+            // trait of food items need to be updated here. Unset the preserved
+            // trait of this stack
+            IFood cap = itemstack1.getCapability(CapabilityFood.CAPABILITY, null);
+            if (cap != null)
+            {
+                CapabilityFood.removeTrait(cap, FoodTrait.PRESERVED);
+            }
+
+            if (!this.mergeItemStack(itemstack1, containerSlots, inventorySlots.size(), true))
+            {
+                // Set the preserved trait again; items failed to transfer
+                IFood capFail = itemstack1.getCapability(CapabilityFood.CAPABILITY, null);
+                if (capFail != null)
+                {
+                    CapabilityFood.applyTrait(capFail, FoodTrait.PRESERVED);
+                }
+
+                // Don't transfer anything
+                return ItemStack.EMPTY;
+            }
+        }
+        // Transfer into the container
+        else
+        {
+            if (!this.mergeItemStack(itemstack1, 0, containerSlots, false))
+            {
+                return ItemStack.EMPTY;
+            }
+        }
+
+        if (itemstack1.getCount() == 0)
+        {
+            slot.putStack(ItemStack.EMPTY);
+        }
+        else
+        {
+            slot.onSlotChanged();
+        }
+        if (itemstack1.getCount() == itemstack.getCount())
+        {
+            return ItemStack.EMPTY;
+        }
+        slot.onTake(player, itemstack1);
+        return itemstack;
     }
 }

--- a/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
@@ -410,6 +410,7 @@ public class ItemSmallVessel extends ItemPottery
         @Override
         public void setStackInSlot(int slot, @Nonnull ItemStack stack)
         {
+            TerraFirmaCraft.getLog().info("setStackInSlot(slot = {}, stack = {})", slot, stack);
             IFood cap = stack.getCapability(CapabilityFood.CAPABILITY, null);
             if (cap != null)
             {
@@ -422,6 +423,7 @@ public class ItemSmallVessel extends ItemPottery
         @Override
         public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate)
         {
+            TerraFirmaCraft.getLog().info("insertItem(slot = {}, stack = {}, simulate = {})", slot, stack, simulate);
             if (!simulate)
             {
                 IFood cap = stack.getCapability(CapabilityFood.CAPABILITY, null);
@@ -437,12 +439,25 @@ public class ItemSmallVessel extends ItemPottery
         @Nonnull
         public ItemStack extractItem(int slot, int amount, boolean simulate)
         {
-            IFood cap = getStackInSlot(slot).getCapability(CapabilityFood.CAPABILITY, null);
+            TerraFirmaCraft.getLog().info("extractItem(slot = {}, amount = {}, simulate = {})", slot, amount, simulate);
+            ItemStack slotStack = getStackInSlot(slot);
+            boolean makesCopy = (amount != slotStack.getCount());
+            IFood cap = slotStack.getCapability(CapabilityFood.CAPABILITY, null);
             if (cap != null)
             {
                 CapabilityFood.removeTrait(cap, FoodTrait.PRESERVED);
             }
-            return super.extractItem(slot, amount, simulate);
+            ItemStack outStack = super.extractItem(slot, amount, simulate);
+            if (!simulate && makesCopy)
+            {
+                TerraFirmaCraft.getLog().info("Re-applied trait (workaround done)");
+                IFood capAfter = getStackInSlot(slot).getCapability(CapabilityFood.CAPABILITY, null);
+                if (capAfter != null)
+                {
+                    CapabilityFood.applyTrait(capAfter, FoodTrait.PRESERVED);
+                }
+            }
+            return outStack;
         }
 
         @Override
@@ -521,6 +536,7 @@ public class ItemSmallVessel extends ItemPottery
         @Override
         public void beforePutStack(SlotCallback slot, @Nonnull ItemStack stack)
         {
+            TerraFirmaCraft.getLog().info("beforePutStack(slot = {}, stack = {})", slot, stack);
             IFood cap = slot.getStack().getCapability(CapabilityFood.CAPABILITY, null);
             if (cap != null)
             {

--- a/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ceramics/ItemSmallVessel.java
@@ -410,7 +410,6 @@ public class ItemSmallVessel extends ItemPottery
         @Override
         public void setStackInSlot(int slot, @Nonnull ItemStack stack)
         {
-            TerraFirmaCraft.getLog().info("setStackInSlot(slot = {}, stack = {})", slot, stack);
             IFood cap = stack.getCapability(CapabilityFood.CAPABILITY, null);
             if (cap != null)
             {
@@ -423,7 +422,6 @@ public class ItemSmallVessel extends ItemPottery
         @Override
         public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate)
         {
-            TerraFirmaCraft.getLog().info("insertItem(slot = {}, stack = {}, simulate = {})", slot, stack, simulate);
             if (!simulate)
             {
                 IFood cap = stack.getCapability(CapabilityFood.CAPABILITY, null);
@@ -439,25 +437,13 @@ public class ItemSmallVessel extends ItemPottery
         @Nonnull
         public ItemStack extractItem(int slot, int amount, boolean simulate)
         {
-            TerraFirmaCraft.getLog().info("extractItem(slot = {}, amount = {}, simulate = {})", slot, amount, simulate);
-            ItemStack slotStack = getStackInSlot(slot);
-            boolean makesCopy = (amount != slotStack.getCount());
-            IFood cap = slotStack.getCapability(CapabilityFood.CAPABILITY, null);
+            ItemStack stack = super.extractItem(slot, amount, simulate).copy();
+            IFood cap = stack.getCapability(CapabilityFood.CAPABILITY, null);
             if (cap != null)
             {
                 CapabilityFood.removeTrait(cap, FoodTrait.PRESERVED);
             }
-            ItemStack outStack = super.extractItem(slot, amount, simulate);
-            if (!simulate && makesCopy)
-            {
-                TerraFirmaCraft.getLog().info("Re-applied trait (workaround done)");
-                IFood capAfter = getStackInSlot(slot).getCapability(CapabilityFood.CAPABILITY, null);
-                if (capAfter != null)
-                {
-                    CapabilityFood.applyTrait(capAfter, FoodTrait.PRESERVED);
-                }
-            }
-            return outStack;
+            return stack;
         }
 
         @Override
@@ -536,7 +522,6 @@ public class ItemSmallVessel extends ItemPottery
         @Override
         public void beforePutStack(SlotCallback slot, @Nonnull ItemStack stack)
         {
-            TerraFirmaCraft.getLog().info("beforePutStack(slot = {}, stack = {})", slot, stack);
             IFood cap = slot.getStack().getCapability(CapabilityFood.CAPABILITY, null);
             if (cap != null)
             {


### PR DESCRIPTION
- Fixes bug where splitting a stack inside a small vessel would remove the preserved trait from the half that remained in the vessel.
- Fixes bug where trying to repeatedly shift click an item into a full vessel would create a desync issue that showed food inside the vessel as not preserved. Reopening the vessel would show that they are actually preserved.
- Fixes bug where trying to move a food item from the vessel into a full inventory with shift-click would make the food in the vessel lose the preserved trait. This one was not a desync issue; the item would actually stop being preserved

This may fix #1282.

These issues were happening because calling extractItem doesn't necessarily mean that the item has been successfully moved out of the vessel and extractItem was always removing the preserved trait from the item stack in the vessel no matter what. Instead, this fix creates a copy of the item stack being removed and removes the preserved trait from the copy instead of the original stack in the vessel. This way, if moving fails, the original item stack doesn't stop being preserved

Doing just the fix above breaks shift-clicking items out of vessels; they don't stop being preserved because shift-clicking doesn't care about the return value of extractItem, it gets the value directly from the slot. To solve this issue, transferStackInSlot is overridden so that items being shift-clicked out of the inventory have their preserved trait removed