### PR TITLE
Fix Iron Blooms

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/items/ItemBloom.java
+++ b/src/main/java/net/dries007/tfc/objects/items/ItemBloom.java
@@ -72,7 +72,6 @@ public class ItemBloom extends ItemTFC implements IMetalItem
         if (cap instanceof IForgeableMeasurableMetal)
         {
             int amount = ((IForgeableMeasurableMetal) cap).getMetalAmount();
-            if (amount > 100) amount = 100;
             return amount;
         }
         return 0;


### PR DESCRIPTION
Iron Blooms would all melt down to 100mB of fluid if the input was higher than 100 units. Removed the line that was returning 100 instead of the appropriate value of metal.