### PR TITLE
Remove predators and huntables before chunk regen

### DIFF
--- a/src/main/java/net/dries007/tfc/ConfigTFC.java
+++ b/src/main/java/net/dries007/tfc/ConfigTFC.java
@@ -507,7 +507,7 @@ public final class ConfigTFC
 
             @Config.Comment("Minimum server tps to allow chunk regeneration in the spring")
             @Config.RangeInt(min = 0, max = 20)
-            @Config.LangKey("config." + MOD_ID + ".general.world.minRegenTps")
+            @Config.LangKey("config." + MOD_ID + ".general.world_regen.minRegenTps")
             public int minRegenTps = 16;
         }
 

--- a/src/main/java/net/dries007/tfc/util/WorldRegenHandler.java
+++ b/src/main/java/net/dries007/tfc/util/WorldRegenHandler.java
@@ -138,6 +138,7 @@ public class WorldRegenHandler
                         int worldZ = pos.z << 4;
                         BlockPos blockpos = new BlockPos(worldX, 0, worldZ);
                         Biome biome = event.world.getBiome(blockpos.add(16, 0, 16));
+                        removePredators(event.world, pos);
                         regenPredators(event.world, biome, worldX + 8, worldZ + 8, 16, 16, RANDOM);
 
                         // notably missing: berry bushes
@@ -148,6 +149,18 @@ public class WorldRegenHandler
                 }
             }
         }
+    }
+
+    private static void removePredators(World world, ChunkPos pos)
+    {
+        for (ClassInheritanceMultiMap<Entity> target : world.getChunk(pos.x, pos.z).getEntityLists())
+            target.forEach(entity -> {
+                if (entity instanceof IPredator || entity instanceof IHuntable)
+                {
+                    entity.setDropItemsWhenDead(false);
+                    entity.setDead();
+                }
+            });
     }
 
     private static void removeCropsAndMushrooms(World world, ChunkPos pos)

--- a/src/main/java/net/dries007/tfc/util/WorldRegenHandler.java
+++ b/src/main/java/net/dries007/tfc/util/WorldRegenHandler.java
@@ -155,7 +155,7 @@ public class WorldRegenHandler
     {
         for (ClassInheritanceMultiMap<Entity> target : world.getChunk(pos.x, pos.z).getEntityLists())
             target.forEach(entity -> {
-                if (entity instanceof IPredator || entity instanceof IHuntable)
+                if (entity instanceof IPredator || entity instanceof IHuntable && !entity.hasCustomName())
                 {
                     entity.setDropItemsWhenDead(false);
                     entity.setDead();


### PR DESCRIPTION
Prevents slow overpopulation in chunks loaded every year. Particularly the chunks immediately surrounding a players base. Chunks loaded enough to trigger regen but not frequently enough to get protected chunk status slowly become overpopulated with predators. 