### PR TITLE
API tweak - MultiBlock private field access

### DIFF
--- a/src/main/java/net/dries007/tfc/util/MultiBlock.java
+++ b/src/main/java/net/dries007/tfc/util/MultiBlock.java
@@ -20,7 +20,7 @@ import net.minecraft.world.level.block.state.BlockState;
 
 public class MultiBlock implements BiPredicate<LevelAccessor, BlockPos>
 {
-    private final List<BiPredicate<LevelAccessor, BlockPos>> conditions;
+    protected final List<BiPredicate<LevelAccessor, BlockPos>> conditions;
 
     public MultiBlock()
     {


### PR DESCRIPTION
Changed MultiBlock.conditions access from private to protected, so the class can be extended