### PR TITLE
Fixed #1956 by implementing shield textures, animations and properties

### DIFF
--- a/src/main/java/net/dries007/tfc/client/ClientEventHandler.java
+++ b/src/main/java/net/dries007/tfc/client/ClientEventHandler.java
@@ -67,7 +67,6 @@ import net.dries007.tfc.common.items.TFCItems;
 import net.dries007.tfc.mixin.client.accessor.BiomeColorsAccessor;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.Metal;
-import net.minecraftforge.fml.loading.FMLEnvironment;
 
 import static net.dries007.tfc.common.blocks.wood.Wood.BlockType.*;
 

--- a/src/main/java/net/dries007/tfc/client/ClientEventHandler.java
+++ b/src/main/java/net/dries007/tfc/client/ClientEventHandler.java
@@ -67,6 +67,7 @@ import net.dries007.tfc.common.items.TFCItems;
 import net.dries007.tfc.mixin.client.accessor.BiomeColorsAccessor;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.Metal;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 
 import static net.dries007.tfc.common.blocks.wood.Wood.BlockType.*;
 
@@ -134,6 +135,19 @@ public final class ClientEventHandler
                             return entity instanceof Player player && TFCFishingRodItem.isThisTheHeldRod(player, stack) && player.fishing != null ? 1.0F : 0.0F;
                         }
                     });
+
+                    Item shield = TFCItems.METAL_ITEMS.get(metal).get(Metal.ItemType.SHIELD).get();
+                    //if (FMLEnvironment.dist.isClient()) {
+                    ItemProperties.register(shield, new ResourceLocation("blocking"), (stack, level, entity, unused) -> {
+                        if(entity == null)
+                        {
+                            return 0.0F;
+                        }else
+                        {
+                            return entity instanceof Player player && entity.isUsingItem() && entity.getUseItem() == stack ? 1.0f : 0.0f;
+                        }
+                    });
+                    //}
                 }
             }
 

--- a/src/main/java/net/dries007/tfc/common/items/TFCShieldItem.java
+++ b/src/main/java/net/dries007/tfc/common/items/TFCShieldItem.java
@@ -6,9 +6,12 @@
 
 package net.dries007.tfc.common.items;
 
+import net.minecraft.client.renderer.item.ItemProperties;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ShieldItem;
 import net.minecraft.world.item.Tier;
+import net.minecraftforge.fml.loading.FMLEnvironment;
 
 public class TFCShieldItem extends ShieldItem
 {
@@ -18,6 +21,9 @@ public class TFCShieldItem extends ShieldItem
     {
         super(builder.defaultDurability(tier.getUses()));
         this.tier = tier;
+        if (FMLEnvironment.dist.isClient()) {
+            ItemProperties.register(this, new ResourceLocation("blocking"), (stack, world, living, i) -> living != null && living.isUsingItem() && living.getUseItem() == stack ? 1.0f : 0.0f);
+        }
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/items/TFCShieldItem.java
+++ b/src/main/java/net/dries007/tfc/common/items/TFCShieldItem.java
@@ -6,12 +6,9 @@
 
 package net.dries007.tfc.common.items;
 
-import net.minecraft.client.renderer.item.ItemProperties;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.ShieldItem;
 import net.minecraft.world.item.Tier;
-import net.minecraftforge.fml.loading.FMLEnvironment;
 
 public class TFCShieldItem extends ShieldItem
 {
@@ -21,9 +18,6 @@ public class TFCShieldItem extends ShieldItem
     {
         super(builder.defaultDurability(tier.getUses()));
         this.tier = tier;
-        if (FMLEnvironment.dist.isClient()) {
-            ItemProperties.register(this, new ResourceLocation("blocking"), (stack, world, living, i) -> living != null && living.isUsingItem() && living.getUseItem() == stack ? 1.0f : 0.0f);
-        }
     }
 
     @Override

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze.json
@@ -1,7 +1,409 @@
 {
-  "__comment__": "This file was automatically created by mcresources",
-  "parent": "item/handheld",
+  "credit": "Made with Blockbench",
+  "gui_light": "front",
   "textures": {
-    "layer0": "tfc:item/metal/shield/bismuth_bronze_front"
-  }
+    "1": "tfc:item/metal/shield/bismuth_bronze_front",
+    "2": "tfc:item/metal/shield/bismuth_bronze_back",
+    "particle": "tfc:item/metal/shield/bismuth_bronze_front"
+  },
+  "elements": [
+    {
+      "name": "h",
+      "from": [7, 10, 8],
+      "to": [8, 11, 13],
+      "faces": {
+        "north": {"uv": [0, 0, 0, 0], "texture": "#texture"},
+        "east": {"uv": [6, 1, 11, 2], "texture": "#2"},
+        "south": {"uv": [14, 9, 15, 10], "texture": "#2"},
+        "west": {"uv": [6, 14, 11, 15], "texture": "#2"},
+        "up": {"uv": [14, 5, 15, 10], "texture": "#2"},
+        "down": {"uv": [1, 5, 2, 10], "texture": "#2"}
+      }
+    },
+    {
+      "name": "h",
+      "from": [7, 6, 12],
+      "to": [8, 10, 13],
+      "faces": {
+        "north": {"uv": [1, 7, 2, 11], "texture": "#2"},
+        "east": {"uv": [1, 7, 2, 11], "texture": "#2"},
+        "south": {"uv": [14, 5, 15, 9], "texture": "#2"},
+        "west": {"uv": [14, 7, 15, 11], "texture": "#2"}
+      }
+    },
+    {
+      "name": "h",
+      "from": [7, 5, 8],
+      "to": [8, 6, 13],
+      "faces": {
+        "east": {"uv": [6, 14, 11, 15], "texture": "#2"},
+        "south": {"uv": [5, 1, 6, 2], "texture": "#2"},
+        "west": {"uv": [6, 14, 11, 15], "texture": "#2"},
+        "up": {"uv": [14, 5, 15, 10], "texture": "#2"},
+        "down": {"uv": [1, 5, 2, 10], "texture": "#2"}
+      }
+    },
+    {
+      "name": "h",
+      "from": [6, 10, 7],
+      "to": [9, 11, 8],
+      "faces": {
+        "east": {"uv": [1, 5, 2, 6], "texture": "#2"},
+        "south": {"uv": [8, 14, 11, 15], "texture": "#2"},
+        "west": {"uv": [2, 3, 3, 4], "texture": "#2"},
+        "up": {"uv": [6, 14, 9, 15], "texture": "#2"},
+        "down": {"uv": [7, 1, 10, 2], "texture": "#2"}
+      }
+    },
+    {
+      "name": "h",
+      "from": [6, 5, 7],
+      "to": [9, 6, 8],
+      "faces": {
+        "east": {"uv": [3, 13, 4, 14], "texture": "#2"},
+        "south": {"uv": [5, 1, 8, 2], "texture": "#2"},
+        "west": {"uv": [10, 14, 11, 15], "texture": "#2"},
+        "up": {"uv": [9, 15, 6, 14], "texture": "#2"},
+        "down": {"uv": [11, 15, 8, 14], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f1",
+      "from": [6, 5, 6],
+      "to": [10, 11, 7],
+      "faces": {
+        "north": {"uv": [6, 5, 10, 11], "texture": "#1"},
+        "east": {"uv": [6, 5, 7, 11], "texture": "#1"},
+        "south": {"uv": [6, 5, 10, 11], "texture": "#2"},
+        "west": {"uv": [9, 5, 10, 11], "texture": "#1"},
+        "up": {"uv": [6, 5, 10, 6], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [6, 10, 10, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f1",
+      "from": [5, 6, 6],
+      "to": [6, 10, 7],
+      "faces": {
+        "north": {"uv": [10, 6, 11, 10], "texture": "#1"},
+        "south": {"uv": [5, 6, 6, 10], "texture": "#2"},
+        "west": {"uv": [10, 6, 11, 10], "texture": "#1"},
+        "up": {"uv": [9, 6, 10, 7], "texture": "#1"},
+        "down": {"uv": [9, 10, 10, 11], "texture": "#1"}
+      }
+    },
+    {
+      "name": "f1",
+      "from": [10, 6, 6],
+      "to": [11, 10, 7],
+      "faces": {
+        "north": {"uv": [5, 6, 6, 10], "texture": "#1"},
+        "east": {"uv": [5, 6, 6, 10], "texture": "#1"},
+        "south": {"uv": [10, 6, 11, 10], "texture": "#2"},
+        "west": {"uv": [0, 0, 0, 0], "texture": "#1"},
+        "up": {"uv": [5, 6, 6, 7], "texture": "#1"},
+        "down": {"uv": [5, 10, 6, 11], "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [10, 10, 7],
+      "to": [12, 12, 8],
+      "faces": {
+        "north": {"uv": [4, 4, 6, 6], "texture": "#1"},
+        "east": {"uv": [4, 4, 5, 6], "texture": "#1"},
+        "south": {"uv": [10, 4, 12, 6], "texture": "#2"},
+        "west": {"uv": [10, 4, 11, 6], "texture": "#2"},
+        "up": {"uv": [4, 4, 6, 5], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [10, 5, 12, 6], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [11, 5, 7],
+      "to": [13, 11, 8],
+      "faces": {
+        "north": {"uv": [3, 5, 5, 11], "texture": "#1"},
+        "east": {"uv": [3, 5, 4, 11], "texture": "#1"},
+        "south": {"uv": [11, 5, 13, 11], "texture": "#2"},
+        "west": {"uv": [10, 5, 11, 11], "texture": "#2"},
+        "up": {"uv": [3, 5, 5, 6], "texture": "#1"},
+        "down": {"uv": [3, 10, 5, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [10, 4, 7],
+      "to": [12, 6, 8],
+      "faces": {
+        "north": {"uv": [4, 10, 6, 12], "texture": "#1"},
+        "east": {"uv": [3, 9, 4, 11], "texture": "#1"},
+        "south": {"uv": [10, 10, 12, 12], "texture": "#2"},
+        "west": {"uv": [10, 10, 11, 12], "texture": "#2"},
+        "up": {"uv": [10, 10, 12, 11], "texture": "#2"},
+        "down": {"uv": [4, 11, 6, 12], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [5, 11, 7],
+      "to": [11, 13, 8],
+      "faces": {
+        "north": {"uv": [5, 3, 11, 5], "texture": "#1"},
+        "east": {"uv": [5, 3, 6, 5], "texture": "#1"},
+        "south": {"uv": [5, 3, 11, 5], "texture": "#2"},
+        "west": {"uv": [10, 3, 11, 5], "texture": "#1"},
+        "up": {"uv": [5, 3, 11, 4], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [5, 4, 11, 5], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [4, 10, 7],
+      "to": [6, 12, 8],
+      "faces": {
+        "north": {"uv": [10, 4, 12, 6], "texture": "#1"},
+        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
+        "south": {"uv": [4, 4, 6, 6], "texture": "#2"},
+        "west": {"uv": [11, 4, 12, 6], "texture": "#1"},
+        "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
+        "down": {"uv": [4, 5, 6, 6], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [3, 5, 7],
+      "to": [5, 11, 8],
+      "faces": {
+        "north": {"uv": [11, 5, 13, 11], "texture": "#1"},
+        "east": {"uv": [5, 5, 6, 11], "texture": "#2"},
+        "south": {"uv": [3, 5, 5, 11], "texture": "#2"},
+        "west": {"uv": [12, 5, 13, 11], "texture": "#1"},
+        "up": {"uv": [11, 5, 13, 6], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [11, 10, 13, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [4, 4, 7],
+      "to": [6, 6, 8],
+      "faces": {
+        "north": {"uv": [10, 10, 12, 12], "texture": "#1"},
+        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
+        "south": {"uv": [4, 10, 6, 12], "texture": "#2"},
+        "west": {"uv": [11, 10, 12, 12], "texture": "#1"},
+        "up": {"uv": [4, 10, 6, 11], "texture": "#2"},
+        "down": {"uv": [10, 11, 12, 12], "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [5, 3, 7],
+      "to": [11, 5, 8],
+      "faces": {
+        "north": {"uv": [5, 11, 11, 13], "texture": "#1"},
+        "east": {"uv": [5, 11, 6, 13], "texture": "#1"},
+        "south": {"uv": [5, 11, 11, 13], "texture": "#2"},
+        "west": {"uv": [10, 11, 11, 13], "texture": "#1"},
+        "up": {"uv": [5, 11, 11, 12], "texture": "#2"},
+        "down": {"uv": [5, 12, 11, 13], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [13, 5, 8],
+      "to": [15, 11, 9],
+      "faces": {
+        "north": {"uv": [1, 5, 3, 11], "texture": "#1"},
+        "east": {"uv": [1, 5, 2, 11], "texture": "#1"},
+        "south": {"uv": [13, 5, 15, 11], "texture": "#2"},
+        "west": {"uv": [13, 5, 14, 11], "texture": "#2"},
+        "up": {"uv": [1, 5, 3, 6], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [1, 10, 3, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [5, 1, 8],
+      "to": [11, 3, 9],
+      "faces": {
+        "north": {"uv": [5, 13, 11, 15], "texture": "#1"},
+        "east": {"uv": [5, 13, 6, 15], "texture": "#1"},
+        "south": {"uv": [5, 13, 11, 15], "texture": "#2"},
+        "west": {"uv": [10, 13, 11, 15], "texture": "#1"},
+        "up": {"uv": [5, 13, 11, 14], "texture": "#2"},
+        "down": {"uv": [5, 14, 11, 15], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [5, 13, 8],
+      "to": [11, 15, 9],
+      "faces": {
+        "north": {"uv": [5, 1, 11, 3], "texture": "#1"},
+        "east": {"uv": [5, 1, 6, 3], "texture": "#1"},
+        "south": {"uv": [5, 1, 11, 3], "texture": "#2"},
+        "west": {"uv": [10, 1, 11, 3], "texture": "#1"},
+        "up": {"uv": [5, 1, 11, 2], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [5, 2, 11, 3], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [1, 5, 8],
+      "to": [3, 11, 9],
+      "faces": {
+        "north": {"uv": [13, 5, 15, 11], "texture": "#1"},
+        "east": {"uv": [2, 5, 3, 11], "texture": "#2"},
+        "south": {"uv": [1, 5, 3, 11], "texture": "#2"},
+        "west": {"uv": [14, 5, 15, 11], "texture": "#1"},
+        "up": {"uv": [13, 5, 15, 6], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [13, 10, 15, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [11, 13, 8],
+      "to": [13, 14, 9],
+      "faces": {
+        "north": {"uv": [3, 2, 5, 3], "texture": "#1"},
+        "east": {"uv": [2, 4, 3, 5], "texture": "#1"},
+        "south": {"uv": [11, 2, 13, 3], "texture": "#2"},
+        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
+        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [11, 11, 8],
+      "to": [14, 13, 9],
+      "faces": {
+        "north": {"uv": [2, 3, 5, 5], "texture": "#1"},
+        "east": {"uv": [2, 3, 3, 5], "texture": "#1"},
+        "south": {"uv": [11, 3, 14, 5], "texture": "#2"},
+        "west": {"uv": [11, 3, 12, 5], "texture": "#2"},
+        "up": {"uv": [2, 3, 5, 4], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [11, 4, 14, 5], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [3, 13, 8],
+      "to": [5, 14, 9],
+      "faces": {
+        "north": {"uv": [11, 2, 13, 3], "texture": "#1"},
+        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
+        "south": {"uv": [3, 2, 5, 3], "texture": "#2"},
+        "west": {"uv": [13, 3, 14, 4], "texture": "#1"},
+        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [2, 11, 8],
+      "to": [5, 13, 9],
+      "faces": {
+        "north": {"uv": [11, 3, 14, 5], "texture": "#1"},
+        "east": {"uv": [4, 3, 5, 5], "texture": "#2"},
+        "south": {"uv": [2, 3, 5, 5], "texture": "#2"},
+        "west": {"uv": [13, 3, 14, 5], "texture": "#1"},
+        "up": {"uv": [13, 3, 14, 4], "texture": "#1"},
+        "down": {"uv": [2, 4, 5, 5], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [11, 2, 8],
+      "to": [13, 3, 9],
+      "faces": {
+        "north": {"uv": [3, 13, 5, 14], "texture": "#1"},
+        "east": {"uv": [2, 12, 3, 13], "texture": "#1"},
+        "south": {"uv": [11, 13, 13, 14], "texture": "#2"},
+        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
+        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
+        "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [11, 3, 8],
+      "to": [14, 5, 9],
+      "faces": {
+        "north": {"uv": [2, 11, 5, 13], "texture": "#1"},
+        "east": {"uv": [2, 11, 3, 13], "texture": "#1"},
+        "south": {"uv": [11, 11, 14, 13], "texture": "#2"},
+        "west": {"uv": [11, 11, 12, 13], "texture": "#2"},
+        "up": {"uv": [11, 11, 14, 12], "texture": "#2"},
+        "down": {"uv": [2, 12, 3, 13], "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [3, 2, 8],
+      "to": [5, 3, 9],
+      "faces": {
+        "north": {"uv": [11, 13, 13, 14], "texture": "#1"},
+        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
+        "south": {"uv": [3, 13, 5, 14], "texture": "#2"},
+        "west": {"uv": [12, 13, 13, 14], "texture": "#1"},
+        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
+        "down": {"uv": [11, 13, 13, 14], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [2, 3, 8],
+      "to": [5, 5, 9],
+      "faces": {
+        "north": {"uv": [11, 11, 14, 13], "texture": "#1"},
+        "east": {"uv": [4, 11, 5, 13], "texture": "#2"},
+        "south": {"uv": [2, 11, 5, 13], "texture": "#2"},
+        "west": {"uv": [13, 11, 14, 13], "texture": "#1"},
+        "up": {"uv": [2, 11, 5, 12], "texture": "#2"},
+        "down": {"uv": [13, 12, 14, 13], "texture": "#1"}
+      }
+    }
+  ],
+  "display": {
+    "thirdperson_righthand": {
+      "rotation": [0, -90, 0],
+      "translation": [2.3, -2, 5]
+    },
+    "thirdperson_lefthand": {
+      "rotation": [0, -90, 0],
+      "translation": [2.3, -2, 5]
+    },
+    "firstperson_righthand": {
+      "rotation": [0, -75, 15],
+      "translation": [4, -3, 0]
+    },
+    "firstperson_lefthand": {
+      "rotation": [0, -75, 15],
+      "translation": [4, -3, 0]
+    },
+    "ground": {
+      "translation": [0, 2, 0],
+      "scale": [0.5, 0.5, 0.5]
+    },
+    "gui": {
+      "rotation": [0, 180, 0]
+    },
+    "head": {
+      "translation": [0, 0, -7.56]
+    },
+    "fixed": {
+      "translation": [0, 0, -0.38],
+      "scale": [2, 2, 2]
+    }
+  },
+  "overrides": [
+        {
+            "predicate": {
+                "blocking": 1
+            },
+            "model": "tfc:item/metal/shield/bismuth_bronze_blocking"
+        }
+    ]
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze.json
@@ -12,7 +12,6 @@
       "from": [7, 10, 8],
       "to": [8, 11, 13],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#texture"},
         "east": {"uv": [6, 1, 11, 2], "texture": "#2"},
         "south": {"uv": [14, 9, 15, 10], "texture": "#2"},
         "west": {"uv": [6, 14, 11, 15], "texture": "#2"},

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze.json
@@ -163,7 +163,6 @@
       "to": [6, 12, 8],
       "faces": {
         "north": {"uv": [10, 4, 12, 6], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 4, 6, 6], "texture": "#2"},
         "west": {"uv": [11, 4, 12, 6], "texture": "#1"},
         "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
@@ -189,7 +188,6 @@
       "to": [6, 6, 8],
       "faces": {
         "north": {"uv": [10, 10, 12, 12], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 10, 6, 12], "texture": "#2"},
         "west": {"uv": [11, 10, 12, 12], "texture": "#1"},
         "up": {"uv": [4, 10, 6, 11], "texture": "#2"},
@@ -269,9 +267,7 @@
         "north": {"uv": [3, 2, 5, 3], "texture": "#1"},
         "east": {"uv": [2, 4, 3, 5], "texture": "#1"},
         "south": {"uv": [11, 2, 13, 3], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -293,11 +289,9 @@
       "to": [5, 14, 9],
       "faces": {
         "north": {"uv": [11, 2, 13, 3], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 2, 5, 3], "texture": "#2"},
         "west": {"uv": [13, 3, 14, 4], "texture": "#1"},
-        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -321,8 +315,6 @@
         "north": {"uv": [3, 13, 5, 14], "texture": "#1"},
         "east": {"uv": [2, 12, 3, 13], "texture": "#1"},
         "south": {"uv": [11, 13, 13, 14], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#1"}
       }
     },
@@ -345,10 +337,8 @@
       "to": [5, 3, 9],
       "faces": {
         "north": {"uv": [11, 13, 13, 14], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 13, 5, 14], "texture": "#2"},
         "west": {"uv": [12, 13, 13, 14], "texture": "#1"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [11, 13, 13, 14], "rotation": 180, "texture": "#1"}
       }
     },

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
@@ -2,9 +2,9 @@
   "credit": "Made with Blockbench",
   "gui_light": "front",
   "textures": {
-    "1": "tfc:item/metal/shield/black_bronze_front",
-    "2": "tfc:item/metal/shield/black_bronze_back",
-    "particle": "tfc:item/metal/shield/black_bronze_front"
+    "1": "tfc:item/metal/shield/bismuth_bronze_front",
+    "2": "tfc:item/metal/shield/bismuth_bronze_back",
+    "particle": "tfc:item/metal/shield/bismuth_bronze_front"
   },
   "elements": [
     {
@@ -376,12 +376,12 @@
       "translation": [2.3, -2, 5]
     },
     "firstperson_righthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "firstperson_lefthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "ground": {
       "translation": [0, 2, 0],
@@ -397,13 +397,5 @@
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
     }
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "blocking": 1
-      },
-      "model": "tfc:item/metal/shield/black_bronze_blocking"
-    }
-  ]
+  }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
@@ -12,7 +12,6 @@
       "from": [7, 10, 8],
       "to": [8, 11, 13],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#texture"},
         "east": {"uv": [6, 1, 11, 2], "texture": "#2"},
         "south": {"uv": [14, 9, 15, 10], "texture": "#2"},
         "west": {"uv": [6, 14, 11, 15], "texture": "#2"},

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
@@ -163,7 +163,6 @@
       "to": [6, 12, 8],
       "faces": {
         "north": {"uv": [10, 4, 12, 6], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 4, 6, 6], "texture": "#2"},
         "west": {"uv": [11, 4, 12, 6], "texture": "#1"},
         "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
@@ -189,7 +188,6 @@
       "to": [6, 6, 8],
       "faces": {
         "north": {"uv": [10, 10, 12, 12], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 10, 6, 12], "texture": "#2"},
         "west": {"uv": [11, 10, 12, 12], "texture": "#1"},
         "up": {"uv": [4, 10, 6, 11], "texture": "#2"},
@@ -269,9 +267,7 @@
         "north": {"uv": [3, 2, 5, 3], "texture": "#1"},
         "east": {"uv": [2, 4, 3, 5], "texture": "#1"},
         "south": {"uv": [11, 2, 13, 3], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -293,11 +289,9 @@
       "to": [5, 14, 9],
       "faces": {
         "north": {"uv": [11, 2, 13, 3], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 2, 5, 3], "texture": "#2"},
         "west": {"uv": [13, 3, 14, 4], "texture": "#1"},
-        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -321,8 +315,6 @@
         "north": {"uv": [3, 13, 5, 14], "texture": "#1"},
         "east": {"uv": [2, 12, 3, 13], "texture": "#1"},
         "south": {"uv": [11, 13, 13, 14], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#1"}
       }
     },
@@ -345,10 +337,8 @@
       "to": [5, 3, 9],
       "faces": {
         "north": {"uv": [11, 13, 13, 14], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 13, 5, 14], "texture": "#2"},
         "west": {"uv": [12, 13, 13, 14], "texture": "#1"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [11, 13, 13, 14], "rotation": 180, "texture": "#1"}
       }
     },

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze.json
@@ -12,7 +12,6 @@
       "from": [7, 10, 8],
       "to": [8, 11, 13],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#texture"},
         "east": {"uv": [6, 1, 11, 2], "texture": "#2"},
         "south": {"uv": [14, 9, 15, 10], "texture": "#2"},
         "west": {"uv": [6, 14, 11, 15], "texture": "#2"},

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze.json
@@ -163,7 +163,6 @@
       "to": [6, 12, 8],
       "faces": {
         "north": {"uv": [10, 4, 12, 6], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 4, 6, 6], "texture": "#2"},
         "west": {"uv": [11, 4, 12, 6], "texture": "#1"},
         "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
@@ -189,7 +188,6 @@
       "to": [6, 6, 8],
       "faces": {
         "north": {"uv": [10, 10, 12, 12], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 10, 6, 12], "texture": "#2"},
         "west": {"uv": [11, 10, 12, 12], "texture": "#1"},
         "up": {"uv": [4, 10, 6, 11], "texture": "#2"},
@@ -269,9 +267,7 @@
         "north": {"uv": [3, 2, 5, 3], "texture": "#1"},
         "east": {"uv": [2, 4, 3, 5], "texture": "#1"},
         "south": {"uv": [11, 2, 13, 3], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -293,11 +289,9 @@
       "to": [5, 14, 9],
       "faces": {
         "north": {"uv": [11, 2, 13, 3], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 2, 5, 3], "texture": "#2"},
         "west": {"uv": [13, 3, 14, 4], "texture": "#1"},
-        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -321,8 +315,6 @@
         "north": {"uv": [3, 13, 5, 14], "texture": "#1"},
         "east": {"uv": [2, 12, 3, 13], "texture": "#1"},
         "south": {"uv": [11, 13, 13, 14], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#1"}
       }
     },
@@ -345,10 +337,8 @@
       "to": [5, 3, 9],
       "faces": {
         "north": {"uv": [11, 13, 13, 14], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 13, 5, 14], "texture": "#2"},
         "west": {"uv": [12, 13, 13, 14], "texture": "#1"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [11, 13, 13, 14], "rotation": 180, "texture": "#1"}
       }
     },

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
@@ -376,12 +376,12 @@
       "translation": [2.3, -2, 5]
     },
     "firstperson_righthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "firstperson_lefthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "ground": {
       "translation": [0, 2, 0],
@@ -397,13 +397,5 @@
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
     }
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "blocking": 1
-      },
-      "model": "tfc:item/metal/shield/black_bronze_blocking"
-    }
-  ]
+  }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
@@ -12,7 +12,6 @@
       "from": [7, 10, 8],
       "to": [8, 11, 13],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#texture"},
         "east": {"uv": [6, 1, 11, 2], "texture": "#2"},
         "south": {"uv": [14, 9, 15, 10], "texture": "#2"},
         "west": {"uv": [6, 14, 11, 15], "texture": "#2"},

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
@@ -163,7 +163,6 @@
       "to": [6, 12, 8],
       "faces": {
         "north": {"uv": [10, 4, 12, 6], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 4, 6, 6], "texture": "#2"},
         "west": {"uv": [11, 4, 12, 6], "texture": "#1"},
         "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
@@ -189,7 +188,6 @@
       "to": [6, 6, 8],
       "faces": {
         "north": {"uv": [10, 10, 12, 12], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 10, 6, 12], "texture": "#2"},
         "west": {"uv": [11, 10, 12, 12], "texture": "#1"},
         "up": {"uv": [4, 10, 6, 11], "texture": "#2"},
@@ -269,9 +267,7 @@
         "north": {"uv": [3, 2, 5, 3], "texture": "#1"},
         "east": {"uv": [2, 4, 3, 5], "texture": "#1"},
         "south": {"uv": [11, 2, 13, 3], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -293,11 +289,9 @@
       "to": [5, 14, 9],
       "faces": {
         "north": {"uv": [11, 2, 13, 3], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 2, 5, 3], "texture": "#2"},
         "west": {"uv": [13, 3, 14, 4], "texture": "#1"},
-        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -321,8 +315,6 @@
         "north": {"uv": [3, 13, 5, 14], "texture": "#1"},
         "east": {"uv": [2, 12, 3, 13], "texture": "#1"},
         "south": {"uv": [11, 13, 13, 14], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#1"}
       }
     },
@@ -345,10 +337,8 @@
       "to": [5, 3, 9],
       "faces": {
         "north": {"uv": [11, 13, 13, 14], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 13, 5, 14], "texture": "#2"},
         "west": {"uv": [12, 13, 13, 14], "texture": "#1"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [11, 13, 13, 14], "rotation": 180, "texture": "#1"}
       }
     },

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_steel.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_steel.json
@@ -10,7 +10,6 @@
       "from": [6, 10, 8],
       "to": [7, 11, 11],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#missing"},
         "east": {"uv": [7, 12, 10, 13], "texture": "#2"},
         "south": {"uv": [12, 6, 13, 7], "texture": "#1"},
         "west": {"uv": [7, 12, 10, 13], "texture": "#2"},
@@ -22,7 +21,6 @@
       "from": [6, 5, 8],
       "to": [7, 6, 11],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#missing"},
         "east": {"uv": [7, 12, 10, 13], "texture": "#2"},
         "south": {"uv": [12, 6, 13, 7], "texture": "#1"},
         "west": {"uv": [7, 12, 10, 13], "texture": "#2"},
@@ -44,7 +42,6 @@
       "from": [5, 10, 7],
       "to": [8, 11, 8],
       "faces": {
-        "north": {"uv": [6, 0, 9, 1], "texture": "#missing"},
         "east": {"uv": [6, 3, 7, 4], "texture": "#2"},
         "south": {"uv": [6, 3, 9, 4], "texture": "#2"},
         "west": {"uv": [8, 3, 9, 4], "texture": "#2"},
@@ -56,7 +53,6 @@
       "from": [5, 5, 7],
       "to": [8, 6, 8],
       "faces": {
-        "north": {"uv": [6, 0, 9, 1], "texture": "#missing"},
         "east": {"uv": [6, 3, 7, 4], "texture": "#2"},
         "south": {"uv": [6, 3, 9, 4], "texture": "#2"},
         "west": {"uv": [8, 3, 9, 4], "texture": "#2"},
@@ -106,7 +102,6 @@
         "north": {"uv": [4, 4, 6, 12], "texture": "#1"},
         "east": {"uv": [4, 4, 5, 12], "texture": "#1"},
         "south": {"uv": [10, 4, 12, 12], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 8], "texture": "#missing"},
         "up": {"uv": [4, 4, 6, 5], "rotation": 180, "texture": "#1"},
         "down": {"uv": [4, 11, 6, 12], "rotation": 180, "texture": "#1"}
       }
@@ -117,7 +112,6 @@
       "to": [5, 12, 7],
       "faces": {
         "north": {"uv": [10, 4, 12, 12], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 8], "texture": "#missing"},
         "south": {"uv": [4, 4, 6, 12], "texture": "#2"},
         "west": {"uv": [11, 4, 12, 12], "texture": "#1"},
         "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
@@ -130,7 +124,6 @@
       "to": [3, 10, 7],
       "faces": {
         "north": {"uv": [12, 6, 13, 10], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "south": {"uv": [3, 6, 4, 10], "texture": "#2"},
         "west": {"uv": [12, 6, 13, 10], "texture": "#1"},
         "up": {"uv": [12, 6, 13, 7], "texture": "#1"},
@@ -145,7 +138,6 @@
         "north": {"uv": [3, 6, 4, 10], "texture": "#1"},
         "east": {"uv": [3, 6, 4, 10], "texture": "#1"},
         "south": {"uv": [12, 6, 13, 10], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [3, 6, 4, 7], "texture": "#1"},
         "down": {"uv": [3, 9, 4, 10], "texture": "#1"}
       }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_steel_blocking.json
@@ -10,7 +10,6 @@
       "from": [6, 10, 8],
       "to": [7, 11, 11],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#missing"},
         "east": {"uv": [7, 12, 10, 13], "texture": "#2"},
         "south": {"uv": [12, 6, 13, 7], "texture": "#1"},
         "west": {"uv": [7, 12, 10, 13], "texture": "#2"},
@@ -22,7 +21,6 @@
       "from": [6, 5, 8],
       "to": [7, 6, 11],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#missing"},
         "east": {"uv": [7, 12, 10, 13], "texture": "#2"},
         "south": {"uv": [12, 6, 13, 7], "texture": "#1"},
         "west": {"uv": [7, 12, 10, 13], "texture": "#2"},
@@ -44,7 +42,6 @@
       "from": [5, 10, 7],
       "to": [8, 11, 8],
       "faces": {
-        "north": {"uv": [6, 0, 9, 1], "texture": "#missing"},
         "east": {"uv": [6, 3, 7, 4], "texture": "#2"},
         "south": {"uv": [6, 3, 9, 4], "texture": "#2"},
         "west": {"uv": [8, 3, 9, 4], "texture": "#2"},
@@ -56,7 +53,6 @@
       "from": [5, 5, 7],
       "to": [8, 6, 8],
       "faces": {
-        "north": {"uv": [6, 0, 9, 1], "texture": "#missing"},
         "east": {"uv": [6, 3, 7, 4], "texture": "#2"},
         "south": {"uv": [6, 3, 9, 4], "texture": "#2"},
         "west": {"uv": [8, 3, 9, 4], "texture": "#2"},
@@ -106,7 +102,6 @@
         "north": {"uv": [4, 4, 6, 12], "texture": "#1"},
         "east": {"uv": [4, 4, 5, 12], "texture": "#1"},
         "south": {"uv": [10, 4, 12, 12], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 8], "texture": "#missing"},
         "up": {"uv": [4, 4, 6, 5], "rotation": 180, "texture": "#1"},
         "down": {"uv": [4, 11, 6, 12], "rotation": 180, "texture": "#1"}
       }
@@ -117,7 +112,6 @@
       "to": [5, 12, 7],
       "faces": {
         "north": {"uv": [10, 4, 12, 12], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 8], "texture": "#missing"},
         "south": {"uv": [4, 4, 6, 12], "texture": "#2"},
         "west": {"uv": [11, 4, 12, 12], "texture": "#1"},
         "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
@@ -130,7 +124,6 @@
       "to": [3, 10, 7],
       "faces": {
         "north": {"uv": [12, 6, 13, 10], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "south": {"uv": [3, 6, 4, 10], "texture": "#2"},
         "west": {"uv": [12, 6, 13, 10], "texture": "#1"},
         "up": {"uv": [12, 6, 13, 7], "texture": "#1"},
@@ -145,7 +138,6 @@
         "north": {"uv": [3, 6, 4, 10], "texture": "#1"},
         "east": {"uv": [3, 6, 4, 10], "texture": "#1"},
         "south": {"uv": [12, 6, 13, 10], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [3, 6, 4, 7], "texture": "#1"},
         "down": {"uv": [3, 9, 4, 10], "texture": "#1"}
       }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_steel_blocking.json
@@ -174,12 +174,12 @@
       "translation": [1.2, -2, 3]
     },
     "firstperson_righthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "firstperson_lefthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "ground": {
       "translation": [0, 2, 0],
@@ -195,13 +195,5 @@
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
     }
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "blocking": 1
-      },
-      "model": "tfc:item/metal/shield/black_steel_blocking"
-    }
-  ]
+  }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel.json
@@ -10,7 +10,6 @@
       "from": [7, 10, 8],
       "to": [8, 11, 13],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#missing"},
         "east": {"uv": [11.5, 15, 13.5, 15.5], "texture": "#0"},
         "south": {"uv": [11.5, 13, 12, 13.5], "texture": "#0"},
         "west": {"uv": [10.5, 15.5, 12.5, 16], "texture": "#0"},
@@ -22,7 +21,6 @@
       "from": [7, 6, 12],
       "to": [8, 10, 13],
       "faces": {
-        "north": {"uv": [14, 2.5, 15, 6.5], "texture": "#missing"},
         "east": {"uv": [10.5, 13, 12.5, 13.5], "rotation": 90, "texture": "#0"},
         "south": {"uv": [11, 13, 11.5, 15], "texture": "#0"},
         "west": {"uv": [11.5, 15, 13.5, 15.5], "rotation": 90, "texture": "#0"}
@@ -43,10 +41,8 @@
       "from": [6, 10, 7],
       "to": [9, 11, 8],
       "faces": {
-        "north": {"uv": [6, 0, 9, 1], "texture": "#missing"},
         "east": {"uv": [12, 13, 12.5, 13.5], "texture": "#0"},
         "south": {"uv": [11, 13, 12.5, 13.5], "texture": "#0"},
-        "west": {"uv": [1, 1, 2, 2], "texture": "#missing"},
         "up": {"uv": [11, 13, 12.5, 13.5], "texture": "#0"},
         "down": {"uv": [11, 13, 12.5, 13.5], "texture": "#0"}
       }
@@ -55,10 +51,8 @@
       "from": [6, 5, 7],
       "to": [9, 6, 8],
       "faces": {
-        "north": {"uv": [8, 0, 11, 1], "texture": "#missing"},
         "east": {"uv": [12.5, 13.5, 13, 14], "texture": "#0"},
         "south": {"uv": [10.5, 13, 12, 13.5], "texture": "#0"},
-        "west": {"uv": [3, 12, 4, 13], "texture": "#missing"},
         "up": {"uv": [13.5, 13.5, 12, 13], "texture": "#0"},
         "down": {"uv": [12, 15, 10.5, 14.5], "texture": "#0"}
       }
@@ -97,7 +91,6 @@
         "north": {"uv": [2, 3, 2.5, 5], "texture": "#0"},
         "east": {"uv": [2, 3, 2.5, 5], "texture": "#0"},
         "south": {"uv": [5.5, 11, 6, 13], "texture": "#0"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [2, 3, 2.5, 3.5], "texture": "#0"},
         "down": {"uv": [2, 4.5, 2.5, 5], "texture": "#0"}
       }
@@ -121,7 +114,6 @@
       "to": [5, 10, 8],
       "faces": {
         "north": {"uv": [5.5, 3, 6, 5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "south": {"uv": [2, 11, 2.5, 13], "texture": "#0"},
         "west": {"uv": [5.5, 3, 6, 5], "texture": "#0"},
         "up": {"uv": [5.5, 3, 6, 3.5], "texture": "#0"},
@@ -176,7 +168,6 @@
         "east": {"uv": [3, 13.5, 3.5, 15], "texture": "#0"},
         "south": {"uv": [3, 13.5, 3.5, 15], "texture": "#0"},
         "west": {"uv": [4.5, 5.5, 5, 7], "texture": "#0"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [4.5, 6.5, 5, 7], "texture": "#0"}
       }
     },
@@ -189,8 +180,7 @@
         "east": {"uv": [3, 9, 3.5, 10.5], "texture": "#0"},
         "south": {"uv": [3, 1, 3.5, 2.5], "texture": "#0"},
         "west": {"uv": [4.5, 1, 5, 2.5], "texture": "#0"},
-        "up": {"uv": [4.5, 1, 5, 1.5], "texture": "#0"},
-        "down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+        "up": {"uv": [4.5, 1, 5, 1.5], "texture": "#0"}
       }
     },
     {
@@ -199,8 +189,6 @@
       "to": [6, 9, 7],
       "faces": {
         "north": {"uv": [5, 3.5, 5.5, 4.5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-        "south": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "west": {"uv": [5, 3.5, 5.5, 4.5], "texture": "#0"},
         "up": {"uv": [5, 3.5, 5.5, 4], "texture": "#0"},
         "down": {"uv": [5, 4, 5.5, 4.5], "texture": "#0"}
@@ -214,7 +202,6 @@
         "north": {"uv": [3, 2.5, 3.5, 5.5], "texture": "#0"},
         "east": {"uv": [3, 2.5, 3.5, 5.5], "texture": "#0"},
         "south": {"uv": [4.5, 10.5, 5, 13.5], "texture": "#0"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [3, 2.5, 3.5, 3], "texture": "#0"},
         "down": {"uv": [3, 5, 3.5, 5.5], "texture": "#0"}
       }
@@ -226,8 +213,6 @@
       "faces": {
         "north": {"uv": [2.5, 3.5, 3, 4.5], "texture": "#0"},
         "east": {"uv": [2.5, 3.5, 3, 4.5], "texture": "#0"},
-        "south": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-        "west": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "up": {"uv": [2.5, 3.5, 3, 4], "texture": "#0"},
         "down": {"uv": [2.5, 4, 3, 4.5], "texture": "#0"}
       }
@@ -251,7 +236,6 @@
       "to": [7, 11, 7],
       "faces": {
         "north": {"uv": [4.5, 2.5, 5, 5.5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "south": {"uv": [3, 10.5, 3.5, 13.5], "texture": "#0"},
         "west": {"uv": [4.5, 2.5, 5, 5.5], "texture": "#0"},
         "up": {"uv": [4.5, 2.5, 5, 3], "texture": "#0"},
@@ -266,7 +250,6 @@
         "north": {"uv": [13.5, 1.5, 14, 4.5], "texture": "#0"},
         "east": {"uv": [13.5, 1.5, 14, 4.5], "texture": "#0"},
         "south": {"uv": [10, 9.5, 10.5, 12.5], "texture": "#0"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [13.5, 1.5, 14, 2], "texture": "#0"},
         "down": {"uv": [14.5, 3, 15, 3.5], "texture": "#0"}
       }
@@ -290,7 +273,6 @@
       "to": [3, 16, 9],
       "faces": {
         "north": {"uv": [14.5, 0.5, 15, 3.5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "south": {"uv": [9, 8.5, 9.5, 11.5], "texture": "#0"},
         "west": {"uv": [14.5, 0.5, 15, 3.5], "texture": "#0"},
         "up": {"uv": [14.5, 0.5, 15, 1], "texture": "#0"},
@@ -305,7 +287,6 @@
         "north": {"uv": [9, 0.5, 9.5, 3.5], "texture": "#0"},
         "east": {"uv": [9, 0.5, 9.5, 3.5], "texture": "#0"},
         "south": {"uv": [14.5, 8.5, 15, 11.5], "texture": "#0"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [9, 0.5, 9.5, 1], "texture": "#0"},
         "down": {"uv": [9, 3, 9.5, 3.5], "texture": "#0"}
       }
@@ -316,7 +297,6 @@
       "to": [12, 14, 9],
       "faces": {
         "north": {"uv": [10, 1.5, 10.5, 4.5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "south": {"uv": [13.5, 9.5, 14, 12.5], "texture": "#0"},
         "west": {"uv": [10, 1.5, 10.5, 4.5], "texture": "#0"},
         "up": {"uv": [10, 1.5, 10.5, 2], "texture": "#0"},

--- a/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel_blocking.json
@@ -10,7 +10,6 @@
       "from": [7, 10, 8],
       "to": [8, 11, 13],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#missing"},
         "east": {"uv": [11.5, 15, 13.5, 15.5], "texture": "#0"},
         "south": {"uv": [11.5, 13, 12, 13.5], "texture": "#0"},
         "west": {"uv": [10.5, 15.5, 12.5, 16], "texture": "#0"},
@@ -22,7 +21,6 @@
       "from": [7, 6, 12],
       "to": [8, 10, 13],
       "faces": {
-        "north": {"uv": [14, 2.5, 15, 6.5], "texture": "#missing"},
         "east": {"uv": [10.5, 13, 12.5, 13.5], "rotation": 90, "texture": "#0"},
         "south": {"uv": [11, 13, 11.5, 15], "texture": "#0"},
         "west": {"uv": [11.5, 15, 13.5, 15.5], "rotation": 90, "texture": "#0"}
@@ -43,10 +41,8 @@
       "from": [6, 10, 7],
       "to": [9, 11, 8],
       "faces": {
-        "north": {"uv": [6, 0, 9, 1], "texture": "#missing"},
         "east": {"uv": [12, 13, 12.5, 13.5], "texture": "#0"},
         "south": {"uv": [11, 13, 12.5, 13.5], "texture": "#0"},
-        "west": {"uv": [1, 1, 2, 2], "texture": "#missing"},
         "up": {"uv": [11, 13, 12.5, 13.5], "texture": "#0"},
         "down": {"uv": [11, 13, 12.5, 13.5], "texture": "#0"}
       }
@@ -55,10 +51,8 @@
       "from": [6, 5, 7],
       "to": [9, 6, 8],
       "faces": {
-        "north": {"uv": [8, 0, 11, 1], "texture": "#missing"},
         "east": {"uv": [12.5, 13.5, 13, 14], "texture": "#0"},
         "south": {"uv": [10.5, 13, 12, 13.5], "texture": "#0"},
-        "west": {"uv": [3, 12, 4, 13], "texture": "#missing"},
         "up": {"uv": [13.5, 13.5, 12, 13], "texture": "#0"},
         "down": {"uv": [12, 15, 10.5, 14.5], "texture": "#0"}
       }
@@ -97,7 +91,6 @@
         "north": {"uv": [2, 3, 2.5, 5], "texture": "#0"},
         "east": {"uv": [2, 3, 2.5, 5], "texture": "#0"},
         "south": {"uv": [5.5, 11, 6, 13], "texture": "#0"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [2, 3, 2.5, 3.5], "texture": "#0"},
         "down": {"uv": [2, 4.5, 2.5, 5], "texture": "#0"}
       }
@@ -121,7 +114,6 @@
       "to": [5, 10, 8],
       "faces": {
         "north": {"uv": [5.5, 3, 6, 5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "south": {"uv": [2, 11, 2.5, 13], "texture": "#0"},
         "west": {"uv": [5.5, 3, 6, 5], "texture": "#0"},
         "up": {"uv": [5.5, 3, 6, 3.5], "texture": "#0"},
@@ -176,7 +168,6 @@
         "east": {"uv": [3, 13.5, 3.5, 15], "texture": "#0"},
         "south": {"uv": [3, 13.5, 3.5, 15], "texture": "#0"},
         "west": {"uv": [4.5, 5.5, 5, 7], "texture": "#0"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [4.5, 6.5, 5, 7], "texture": "#0"}
       }
     },
@@ -189,8 +180,7 @@
         "east": {"uv": [3, 9, 3.5, 10.5], "texture": "#0"},
         "south": {"uv": [3, 1, 3.5, 2.5], "texture": "#0"},
         "west": {"uv": [4.5, 1, 5, 2.5], "texture": "#0"},
-        "up": {"uv": [4.5, 1, 5, 1.5], "texture": "#0"},
-        "down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+        "up": {"uv": [4.5, 1, 5, 1.5], "texture": "#0"}
       }
     },
     {
@@ -199,8 +189,6 @@
       "to": [6, 9, 7],
       "faces": {
         "north": {"uv": [5, 3.5, 5.5, 4.5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-        "south": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "west": {"uv": [5, 3.5, 5.5, 4.5], "texture": "#0"},
         "up": {"uv": [5, 3.5, 5.5, 4], "texture": "#0"},
         "down": {"uv": [5, 4, 5.5, 4.5], "texture": "#0"}
@@ -214,7 +202,6 @@
         "north": {"uv": [3, 2.5, 3.5, 5.5], "texture": "#0"},
         "east": {"uv": [3, 2.5, 3.5, 5.5], "texture": "#0"},
         "south": {"uv": [4.5, 10.5, 5, 13.5], "texture": "#0"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [3, 2.5, 3.5, 3], "texture": "#0"},
         "down": {"uv": [3, 5, 3.5, 5.5], "texture": "#0"}
       }
@@ -226,8 +213,6 @@
       "faces": {
         "north": {"uv": [2.5, 3.5, 3, 4.5], "texture": "#0"},
         "east": {"uv": [2.5, 3.5, 3, 4.5], "texture": "#0"},
-        "south": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-        "west": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "up": {"uv": [2.5, 3.5, 3, 4], "texture": "#0"},
         "down": {"uv": [2.5, 4, 3, 4.5], "texture": "#0"}
       }
@@ -251,7 +236,6 @@
       "to": [7, 11, 7],
       "faces": {
         "north": {"uv": [4.5, 2.5, 5, 5.5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "south": {"uv": [3, 10.5, 3.5, 13.5], "texture": "#0"},
         "west": {"uv": [4.5, 2.5, 5, 5.5], "texture": "#0"},
         "up": {"uv": [4.5, 2.5, 5, 3], "texture": "#0"},
@@ -266,7 +250,6 @@
         "north": {"uv": [13.5, 1.5, 14, 4.5], "texture": "#0"},
         "east": {"uv": [13.5, 1.5, 14, 4.5], "texture": "#0"},
         "south": {"uv": [10, 9.5, 10.5, 12.5], "texture": "#0"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [13.5, 1.5, 14, 2], "texture": "#0"},
         "down": {"uv": [14.5, 3, 15, 3.5], "texture": "#0"}
       }
@@ -290,7 +273,6 @@
       "to": [3, 16, 9],
       "faces": {
         "north": {"uv": [14.5, 0.5, 15, 3.5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "south": {"uv": [9, 8.5, 9.5, 11.5], "texture": "#0"},
         "west": {"uv": [14.5, 0.5, 15, 3.5], "texture": "#0"},
         "up": {"uv": [14.5, 0.5, 15, 1], "texture": "#0"},
@@ -305,7 +287,6 @@
         "north": {"uv": [9, 0.5, 9.5, 3.5], "texture": "#0"},
         "east": {"uv": [9, 0.5, 9.5, 3.5], "texture": "#0"},
         "south": {"uv": [14.5, 8.5, 15, 11.5], "texture": "#0"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [9, 0.5, 9.5, 1], "texture": "#0"},
         "down": {"uv": [9, 3, 9.5, 3.5], "texture": "#0"}
       }
@@ -316,7 +297,6 @@
       "to": [12, 14, 9],
       "faces": {
         "north": {"uv": [10, 1.5, 10.5, 4.5], "texture": "#0"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "south": {"uv": [13.5, 9.5, 14, 12.5], "texture": "#0"},
         "west": {"uv": [10, 1.5, 10.5, 4.5], "texture": "#0"},
         "up": {"uv": [10, 1.5, 10.5, 2], "texture": "#0"},

--- a/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel_blocking.json
@@ -347,12 +347,12 @@
       "translation": [3.3, -1.9, 3]
     },
     "firstperson_righthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "firstperson_lefthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "ground": {
       "translation": [0, 2, 0],
@@ -369,13 +369,5 @@
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
     }
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "blocking": 1
-      },
-      "model": "tfc:item/metal/shield/blue_steel_blocking"
-    }
-  ]
+  }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bronze.json
@@ -12,7 +12,6 @@
       "from": [7, 10, 8],
       "to": [8, 11, 13],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#texture"},
         "east": {"uv": [6, 1, 11, 2], "texture": "#2"},
         "south": {"uv": [14, 9, 15, 10], "texture": "#2"},
         "west": {"uv": [6, 14, 11, 15], "texture": "#2"},

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bronze.json
@@ -1,7 +1,409 @@
 {
-  "__comment__": "This file was automatically created by mcresources",
-  "parent": "item/handheld",
+  "credit": "Made with Blockbench",
+  "gui_light": "front",
   "textures": {
-    "layer0": "tfc:item/metal/shield/bronze_front"
-  }
+    "1": "tfc:item/metal/shield/bronze_front",
+    "2": "tfc:item/metal/shield/bronze_back",
+    "particle": "tfc:item/metal/shield/bronze_front"
+  },
+  "elements": [
+    {
+      "name": "h",
+      "from": [7, 10, 8],
+      "to": [8, 11, 13],
+      "faces": {
+        "north": {"uv": [0, 0, 0, 0], "texture": "#texture"},
+        "east": {"uv": [6, 1, 11, 2], "texture": "#2"},
+        "south": {"uv": [14, 9, 15, 10], "texture": "#2"},
+        "west": {"uv": [6, 14, 11, 15], "texture": "#2"},
+        "up": {"uv": [14, 5, 15, 10], "texture": "#2"},
+        "down": {"uv": [1, 5, 2, 10], "texture": "#2"}
+      }
+    },
+    {
+      "name": "h",
+      "from": [7, 6, 12],
+      "to": [8, 10, 13],
+      "faces": {
+        "north": {"uv": [1, 7, 2, 11], "texture": "#2"},
+        "east": {"uv": [1, 7, 2, 11], "texture": "#2"},
+        "south": {"uv": [14, 5, 15, 9], "texture": "#2"},
+        "west": {"uv": [14, 7, 15, 11], "texture": "#2"}
+      }
+    },
+    {
+      "name": "h",
+      "from": [7, 5, 8],
+      "to": [8, 6, 13],
+      "faces": {
+        "east": {"uv": [6, 14, 11, 15], "texture": "#2"},
+        "south": {"uv": [5, 1, 6, 2], "texture": "#2"},
+        "west": {"uv": [6, 14, 11, 15], "texture": "#2"},
+        "up": {"uv": [14, 5, 15, 10], "texture": "#2"},
+        "down": {"uv": [1, 5, 2, 10], "texture": "#2"}
+      }
+    },
+    {
+      "name": "h",
+      "from": [6, 10, 7],
+      "to": [9, 11, 8],
+      "faces": {
+        "east": {"uv": [1, 5, 2, 6], "texture": "#2"},
+        "south": {"uv": [8, 14, 11, 15], "texture": "#2"},
+        "west": {"uv": [2, 3, 3, 4], "texture": "#2"},
+        "up": {"uv": [6, 14, 9, 15], "texture": "#2"},
+        "down": {"uv": [7, 1, 10, 2], "texture": "#2"}
+      }
+    },
+    {
+      "name": "h",
+      "from": [6, 5, 7],
+      "to": [9, 6, 8],
+      "faces": {
+        "east": {"uv": [3, 13, 4, 14], "texture": "#2"},
+        "south": {"uv": [5, 1, 8, 2], "texture": "#2"},
+        "west": {"uv": [10, 14, 11, 15], "texture": "#2"},
+        "up": {"uv": [9, 15, 6, 14], "texture": "#2"},
+        "down": {"uv": [11, 15, 8, 14], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f1",
+      "from": [6, 5, 6],
+      "to": [10, 11, 7],
+      "faces": {
+        "north": {"uv": [6, 5, 10, 11], "texture": "#1"},
+        "east": {"uv": [6, 5, 7, 11], "texture": "#1"},
+        "south": {"uv": [6, 5, 10, 11], "texture": "#2"},
+        "west": {"uv": [9, 5, 10, 11], "texture": "#1"},
+        "up": {"uv": [6, 5, 10, 6], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [6, 10, 10, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f1",
+      "from": [5, 6, 6],
+      "to": [6, 10, 7],
+      "faces": {
+        "north": {"uv": [10, 6, 11, 10], "texture": "#1"},
+        "south": {"uv": [5, 6, 6, 10], "texture": "#2"},
+        "west": {"uv": [10, 6, 11, 10], "texture": "#1"},
+        "up": {"uv": [9, 6, 10, 7], "texture": "#1"},
+        "down": {"uv": [9, 10, 10, 11], "texture": "#1"}
+      }
+    },
+    {
+      "name": "f1",
+      "from": [10, 6, 6],
+      "to": [11, 10, 7],
+      "faces": {
+        "north": {"uv": [5, 6, 6, 10], "texture": "#1"},
+        "east": {"uv": [5, 6, 6, 10], "texture": "#1"},
+        "south": {"uv": [10, 6, 11, 10], "texture": "#2"},
+        "west": {"uv": [0, 0, 0, 0], "texture": "#1"},
+        "up": {"uv": [5, 6, 6, 7], "texture": "#1"},
+        "down": {"uv": [5, 10, 6, 11], "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [10, 10, 7],
+      "to": [12, 12, 8],
+      "faces": {
+        "north": {"uv": [4, 4, 6, 6], "texture": "#1"},
+        "east": {"uv": [4, 4, 5, 6], "texture": "#1"},
+        "south": {"uv": [10, 4, 12, 6], "texture": "#2"},
+        "west": {"uv": [10, 4, 11, 6], "texture": "#2"},
+        "up": {"uv": [4, 4, 6, 5], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [10, 5, 12, 6], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [11, 5, 7],
+      "to": [13, 11, 8],
+      "faces": {
+        "north": {"uv": [3, 5, 5, 11], "texture": "#1"},
+        "east": {"uv": [3, 5, 4, 11], "texture": "#1"},
+        "south": {"uv": [11, 5, 13, 11], "texture": "#2"},
+        "west": {"uv": [10, 5, 11, 11], "texture": "#2"},
+        "up": {"uv": [3, 5, 5, 6], "texture": "#1"},
+        "down": {"uv": [3, 10, 5, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [10, 4, 7],
+      "to": [12, 6, 8],
+      "faces": {
+        "north": {"uv": [4, 10, 6, 12], "texture": "#1"},
+        "east": {"uv": [3, 9, 4, 11], "texture": "#1"},
+        "south": {"uv": [10, 10, 12, 12], "texture": "#2"},
+        "west": {"uv": [10, 10, 11, 12], "texture": "#2"},
+        "up": {"uv": [10, 10, 12, 11], "texture": "#2"},
+        "down": {"uv": [4, 11, 6, 12], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [5, 11, 7],
+      "to": [11, 13, 8],
+      "faces": {
+        "north": {"uv": [5, 3, 11, 5], "texture": "#1"},
+        "east": {"uv": [5, 3, 6, 5], "texture": "#1"},
+        "south": {"uv": [5, 3, 11, 5], "texture": "#2"},
+        "west": {"uv": [10, 3, 11, 5], "texture": "#1"},
+        "up": {"uv": [5, 3, 11, 4], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [5, 4, 11, 5], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [4, 10, 7],
+      "to": [6, 12, 8],
+      "faces": {
+        "north": {"uv": [10, 4, 12, 6], "texture": "#1"},
+        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
+        "south": {"uv": [4, 4, 6, 6], "texture": "#2"},
+        "west": {"uv": [11, 4, 12, 6], "texture": "#1"},
+        "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
+        "down": {"uv": [4, 5, 6, 6], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [3, 5, 7],
+      "to": [5, 11, 8],
+      "faces": {
+        "north": {"uv": [11, 5, 13, 11], "texture": "#1"},
+        "east": {"uv": [5, 5, 6, 11], "texture": "#2"},
+        "south": {"uv": [3, 5, 5, 11], "texture": "#2"},
+        "west": {"uv": [12, 5, 13, 11], "texture": "#1"},
+        "up": {"uv": [11, 5, 13, 6], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [11, 10, 13, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [4, 4, 7],
+      "to": [6, 6, 8],
+      "faces": {
+        "north": {"uv": [10, 10, 12, 12], "texture": "#1"},
+        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
+        "south": {"uv": [4, 10, 6, 12], "texture": "#2"},
+        "west": {"uv": [11, 10, 12, 12], "texture": "#1"},
+        "up": {"uv": [4, 10, 6, 11], "texture": "#2"},
+        "down": {"uv": [10, 11, 12, 12], "texture": "#1"}
+      }
+    },
+    {
+      "name": "f2",
+      "from": [5, 3, 7],
+      "to": [11, 5, 8],
+      "faces": {
+        "north": {"uv": [5, 11, 11, 13], "texture": "#1"},
+        "east": {"uv": [5, 11, 6, 13], "texture": "#1"},
+        "south": {"uv": [5, 11, 11, 13], "texture": "#2"},
+        "west": {"uv": [10, 11, 11, 13], "texture": "#1"},
+        "up": {"uv": [5, 11, 11, 12], "texture": "#2"},
+        "down": {"uv": [5, 12, 11, 13], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [13, 5, 8],
+      "to": [15, 11, 9],
+      "faces": {
+        "north": {"uv": [1, 5, 3, 11], "texture": "#1"},
+        "east": {"uv": [1, 5, 2, 11], "texture": "#1"},
+        "south": {"uv": [13, 5, 15, 11], "texture": "#2"},
+        "west": {"uv": [13, 5, 14, 11], "texture": "#2"},
+        "up": {"uv": [1, 5, 3, 6], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [1, 10, 3, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [5, 1, 8],
+      "to": [11, 3, 9],
+      "faces": {
+        "north": {"uv": [5, 13, 11, 15], "texture": "#1"},
+        "east": {"uv": [5, 13, 6, 15], "texture": "#1"},
+        "south": {"uv": [5, 13, 11, 15], "texture": "#2"},
+        "west": {"uv": [10, 13, 11, 15], "texture": "#1"},
+        "up": {"uv": [5, 13, 11, 14], "texture": "#2"},
+        "down": {"uv": [5, 14, 11, 15], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [5, 13, 8],
+      "to": [11, 15, 9],
+      "faces": {
+        "north": {"uv": [5, 1, 11, 3], "texture": "#1"},
+        "east": {"uv": [5, 1, 6, 3], "texture": "#1"},
+        "south": {"uv": [5, 1, 11, 3], "texture": "#2"},
+        "west": {"uv": [10, 1, 11, 3], "texture": "#1"},
+        "up": {"uv": [5, 1, 11, 2], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [5, 2, 11, 3], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [1, 5, 8],
+      "to": [3, 11, 9],
+      "faces": {
+        "north": {"uv": [13, 5, 15, 11], "texture": "#1"},
+        "east": {"uv": [2, 5, 3, 11], "texture": "#2"},
+        "south": {"uv": [1, 5, 3, 11], "texture": "#2"},
+        "west": {"uv": [14, 5, 15, 11], "texture": "#1"},
+        "up": {"uv": [13, 5, 15, 6], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [13, 10, 15, 11], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [11, 13, 8],
+      "to": [13, 14, 9],
+      "faces": {
+        "north": {"uv": [3, 2, 5, 3], "texture": "#1"},
+        "east": {"uv": [2, 4, 3, 5], "texture": "#1"},
+        "south": {"uv": [11, 2, 13, 3], "texture": "#2"},
+        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
+        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [11, 11, 8],
+      "to": [14, 13, 9],
+      "faces": {
+        "north": {"uv": [2, 3, 5, 5], "texture": "#1"},
+        "east": {"uv": [2, 3, 3, 5], "texture": "#1"},
+        "south": {"uv": [11, 3, 14, 5], "texture": "#2"},
+        "west": {"uv": [11, 3, 12, 5], "texture": "#2"},
+        "up": {"uv": [2, 3, 5, 4], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [11, 4, 14, 5], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [3, 13, 8],
+      "to": [5, 14, 9],
+      "faces": {
+        "north": {"uv": [11, 2, 13, 3], "texture": "#1"},
+        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
+        "south": {"uv": [3, 2, 5, 3], "texture": "#2"},
+        "west": {"uv": [13, 3, 14, 4], "texture": "#1"},
+        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"},
+        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [2, 11, 8],
+      "to": [5, 13, 9],
+      "faces": {
+        "north": {"uv": [11, 3, 14, 5], "texture": "#1"},
+        "east": {"uv": [4, 3, 5, 5], "texture": "#2"},
+        "south": {"uv": [2, 3, 5, 5], "texture": "#2"},
+        "west": {"uv": [13, 3, 14, 5], "texture": "#1"},
+        "up": {"uv": [13, 3, 14, 4], "texture": "#1"},
+        "down": {"uv": [2, 4, 5, 5], "texture": "#2"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [11, 2, 8],
+      "to": [13, 3, 9],
+      "faces": {
+        "north": {"uv": [3, 13, 5, 14], "texture": "#1"},
+        "east": {"uv": [2, 12, 3, 13], "texture": "#1"},
+        "south": {"uv": [11, 13, 13, 14], "texture": "#2"},
+        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
+        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
+        "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [11, 3, 8],
+      "to": [14, 5, 9],
+      "faces": {
+        "north": {"uv": [2, 11, 5, 13], "texture": "#1"},
+        "east": {"uv": [2, 11, 3, 13], "texture": "#1"},
+        "south": {"uv": [11, 11, 14, 13], "texture": "#2"},
+        "west": {"uv": [11, 11, 12, 13], "texture": "#2"},
+        "up": {"uv": [11, 11, 14, 12], "texture": "#2"},
+        "down": {"uv": [2, 12, 3, 13], "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [3, 2, 8],
+      "to": [5, 3, 9],
+      "faces": {
+        "north": {"uv": [11, 13, 13, 14], "texture": "#1"},
+        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
+        "south": {"uv": [3, 13, 5, 14], "texture": "#2"},
+        "west": {"uv": [12, 13, 13, 14], "texture": "#1"},
+        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
+        "down": {"uv": [11, 13, 13, 14], "rotation": 180, "texture": "#1"}
+      }
+    },
+    {
+      "name": "f3",
+      "from": [2, 3, 8],
+      "to": [5, 5, 9],
+      "faces": {
+        "north": {"uv": [11, 11, 14, 13], "texture": "#1"},
+        "east": {"uv": [4, 11, 5, 13], "texture": "#2"},
+        "south": {"uv": [2, 11, 5, 13], "texture": "#2"},
+        "west": {"uv": [13, 11, 14, 13], "texture": "#1"},
+        "up": {"uv": [2, 11, 5, 12], "texture": "#2"},
+        "down": {"uv": [13, 12, 14, 13], "texture": "#1"}
+      }
+    }
+  ],
+  "display": {
+    "thirdperson_righthand": {
+      "rotation": [0, -90, 0],
+      "translation": [2.3, -2, 5]
+    },
+    "thirdperson_lefthand": {
+      "rotation": [0, -90, 0],
+      "translation": [2.3, -2, 5]
+    },
+    "firstperson_righthand": {
+      "rotation": [0, -75, 15],
+      "translation": [4, -3, 0]
+    },
+    "firstperson_lefthand": {
+      "rotation": [0, -75, 15],
+      "translation": [4, -3, 0]
+    },
+    "ground": {
+      "translation": [0, 2, 0],
+      "scale": [0.5, 0.5, 0.5]
+    },
+    "gui": {
+      "rotation": [0, 180, 0]
+    },
+    "head": {
+      "translation": [0, 0, -7.56]
+    },
+    "fixed": {
+      "translation": [0, 0, -0.38],
+      "scale": [2, 2, 2]
+    }
+  },
+  "overrides": [
+    {
+      "predicate": {
+        "blocking": 1
+      },
+      "model": "tfc:item/metal/shield/bronze_blocking"
+    }
+  ]
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bronze.json
@@ -163,7 +163,6 @@
       "to": [6, 12, 8],
       "faces": {
         "north": {"uv": [10, 4, 12, 6], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 4, 6, 6], "texture": "#2"},
         "west": {"uv": [11, 4, 12, 6], "texture": "#1"},
         "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
@@ -189,7 +188,6 @@
       "to": [6, 6, 8],
       "faces": {
         "north": {"uv": [10, 10, 12, 12], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 10, 6, 12], "texture": "#2"},
         "west": {"uv": [11, 10, 12, 12], "texture": "#1"},
         "up": {"uv": [4, 10, 6, 11], "texture": "#2"},
@@ -269,9 +267,7 @@
         "north": {"uv": [3, 2, 5, 3], "texture": "#1"},
         "east": {"uv": [2, 4, 3, 5], "texture": "#1"},
         "south": {"uv": [11, 2, 13, 3], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -293,11 +289,9 @@
       "to": [5, 14, 9],
       "faces": {
         "north": {"uv": [11, 2, 13, 3], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 2, 5, 3], "texture": "#2"},
         "west": {"uv": [13, 3, 14, 4], "texture": "#1"},
-        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -321,8 +315,6 @@
         "north": {"uv": [3, 13, 5, 14], "texture": "#1"},
         "east": {"uv": [2, 12, 3, 13], "texture": "#1"},
         "south": {"uv": [11, 13, 13, 14], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#1"}
       }
     },
@@ -345,10 +337,8 @@
       "to": [5, 3, 9],
       "faces": {
         "north": {"uv": [11, 13, 13, 14], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 13, 5, 14], "texture": "#2"},
         "west": {"uv": [12, 13, 13, 14], "texture": "#1"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [11, 13, 13, 14], "rotation": 180, "texture": "#1"}
       }
     },

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bronze_blocking.json
@@ -12,7 +12,6 @@
       "from": [7, 10, 8],
       "to": [8, 11, 13],
       "faces": {
-        "north": {"uv": [0, 0, 0, 0], "texture": "#texture"},
         "east": {"uv": [6, 1, 11, 2], "texture": "#2"},
         "south": {"uv": [14, 9, 15, 10], "texture": "#2"},
         "west": {"uv": [6, 14, 11, 15], "texture": "#2"},

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bronze_blocking.json
@@ -2,9 +2,9 @@
   "credit": "Made with Blockbench",
   "gui_light": "front",
   "textures": {
-    "1": "tfc:item/metal/shield/black_bronze_front",
-    "2": "tfc:item/metal/shield/black_bronze_back",
-    "particle": "tfc:item/metal/shield/black_bronze_front"
+    "1": "tfc:item/metal/shield/bronze_front",
+    "2": "tfc:item/metal/shield/bronze_back",
+    "particle": "tfc:item/metal/shield/bronze_front"
   },
   "elements": [
     {
@@ -376,12 +376,12 @@
       "translation": [2.3, -2, 5]
     },
     "firstperson_righthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "firstperson_lefthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "ground": {
       "translation": [0, 2, 0],
@@ -397,13 +397,5 @@
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
     }
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "blocking": 1
-      },
-      "model": "tfc:item/metal/shield/black_bronze_blocking"
-    }
-  ]
+  }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bronze_blocking.json
@@ -163,7 +163,6 @@
       "to": [6, 12, 8],
       "faces": {
         "north": {"uv": [10, 4, 12, 6], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 4, 6, 6], "texture": "#2"},
         "west": {"uv": [11, 4, 12, 6], "texture": "#1"},
         "up": {"uv": [10, 4, 12, 5], "texture": "#1"},
@@ -189,7 +188,6 @@
       "to": [6, 6, 8],
       "faces": {
         "north": {"uv": [10, 10, 12, 12], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4, 10, 6, 12], "texture": "#2"},
         "west": {"uv": [11, 10, 12, 12], "texture": "#1"},
         "up": {"uv": [4, 10, 6, 11], "texture": "#2"},
@@ -269,9 +267,7 @@
         "north": {"uv": [3, 2, 5, 3], "texture": "#1"},
         "east": {"uv": [2, 4, 3, 5], "texture": "#1"},
         "south": {"uv": [11, 2, 13, 3], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -293,11 +289,9 @@
       "to": [5, 14, 9],
       "faces": {
         "north": {"uv": [11, 2, 13, 3], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 2, 5, 3], "texture": "#2"},
         "west": {"uv": [13, 3, 14, 4], "texture": "#1"},
-        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"},
-        "down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+        "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#1"}
       }
     },
     {
@@ -321,8 +315,6 @@
         "north": {"uv": [3, 13, 5, 14], "texture": "#1"},
         "east": {"uv": [2, 12, 3, 13], "texture": "#1"},
         "south": {"uv": [11, 13, 13, 14], "texture": "#2"},
-        "west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#1"}
       }
     },
@@ -345,10 +337,8 @@
       "to": [5, 3, 9],
       "faces": {
         "north": {"uv": [11, 13, 13, 14], "texture": "#1"},
-        "east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "south": {"uv": [3, 13, 5, 14], "texture": "#2"},
         "west": {"uv": [12, 13, 13, 14], "texture": "#1"},
-        "up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
         "down": {"uv": [11, 13, 13, 14], "rotation": 180, "texture": "#1"}
       }
     },

--- a/src/main/resources/assets/tfc/models/item/metal/shield/copper.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/copper.json
@@ -79,7 +79,6 @@
       "to": [5, 14, 7],
       "faces": {
         "north": {"uv": [11, 2, 13, 14], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 12], "texture": "#missing"},
         "south": {"uv": [3, 2, 5, 14], "texture": "#1"},
         "west": {"uv": [12, 2, 13, 14], "texture": "#2"},
         "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#2"},
@@ -92,7 +91,6 @@
       "to": [3, 13, 7],
       "faces": {
         "north": {"uv": [13, 3, 14, 13], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 10], "texture": "#missing"},
         "south": {"uv": [2, 3, 3, 13], "texture": "#1"},
         "west": {"uv": [13, 3, 14, 13], "texture": "#2"},
         "up": {"uv": [13, 3, 14, 4], "texture": "#2"},
@@ -107,7 +105,6 @@
         "north": {"uv": [3, 2, 5, 14], "texture": "#2"},
         "east": {"uv": [3, 2, 4, 14], "texture": "#2"},
         "south": {"uv": [11, 2, 13, 14], "texture": "#1"},
-        "west": {"uv": [0, 0, 1, 12], "texture": "#missing"},
         "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#2"},
         "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#2"}
       }
@@ -120,7 +117,6 @@
         "north": {"uv": [2, 3, 3, 13], "texture": "#2"},
         "east": {"uv": [2, 3, 3, 13], "texture": "#2"},
         "south": {"uv": [13, 3, 14, 13], "texture": "#1"},
-        "west": {"uv": [0, 0, 1, 10], "texture": "#missing"},
         "up": {"uv": [2, 3, 3, 4], "texture": "#2"},
         "down": {"uv": [2, 12, 3, 13], "texture": "#2"}
       }
@@ -131,7 +127,6 @@
       "to": [2, 11, 7],
       "faces": {
         "north": {"uv": [14, 5, 15, 11], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "south": {"uv": [1, 5, 2, 11], "texture": "#1"},
         "west": {"uv": [14, 5, 15, 11], "texture": "#2"},
         "up": {"uv": [14, 5, 15, 6], "texture": "#2"},
@@ -146,7 +141,6 @@
         "north": {"uv": [1, 5, 2, 11], "texture": "#2"},
         "east": {"uv": [1, 5, 2, 11], "texture": "#2"},
         "south": {"uv": [14, 5, 15, 11], "texture": "#1"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [1, 5, 2, 6], "texture": "#2"},
         "down": {"uv": [1, 10, 2, 11], "texture": "#2"}
       }
@@ -157,8 +151,6 @@
       "to": [5, 10, 6],
       "faces": {
         "north": {"uv": [11, 6, 12, 10], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 4], "texture": "#missing"},
-        "south": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "west": {"uv": [11, 6, 12, 10], "texture": "#2"},
         "up": {"uv": [11, 6, 12, 7], "texture": "#2"},
         "down": {"uv": [11, 9, 12, 10], "texture": "#2"}
@@ -171,8 +163,6 @@
       "faces": {
         "north": {"uv": [5, 5, 6, 11], "texture": "#2"},
         "east": {"uv": [5, 5, 6, 11], "texture": "#2"},
-        "south": {"uv": [0, 0, 1, 6], "texture": "#missing"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [5, 5, 6, 6], "texture": "#2"},
         "down": {"uv": [5, 10, 6, 11], "texture": "#2"}
       }
@@ -184,8 +174,6 @@
       "faces": {
         "north": {"uv": [4, 6, 5, 10], "texture": "#2"},
         "east": {"uv": [4, 6, 5, 10], "texture": "#2"},
-        "south": {"uv": [0, 0, 1, 4], "texture": "#missing"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [4, 6, 5, 7], "texture": "#2"},
         "down": {"uv": [4, 9, 5, 10], "texture": "#2"}
       }
@@ -197,7 +185,6 @@
       "faces": {
         "north": {"uv": [6, 4, 10, 12], "texture": "#2"},
         "east": {"uv": [6, 4, 7, 12], "texture": "#2"},
-        "south": {"uv": [0, 0, 4, 8], "texture": "#missing"},
         "west": {"uv": [9, 4, 10, 12], "texture": "#2"},
         "up": {"uv": [6, 4, 10, 5], "texture": "#2"},
         "down": {"uv": [6, 11, 10, 12], "texture": "#2"}
@@ -209,8 +196,6 @@
       "to": [6, 11, 6],
       "faces": {
         "north": {"uv": [10, 5, 11, 11], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
-        "south": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "west": {"uv": [10, 5, 11, 11], "texture": "#2"},
         "up": {"uv": [10, 5, 11, 6], "texture": "#2"},
         "down": {"uv": [10, 10, 11, 11], "texture": "#2"}
@@ -223,8 +208,6 @@
       "faces": {
         "north": {"uv": [5, 6, 6, 10], "texture": "#2"},
         "east": {"uv": [5, 6, 6, 10], "texture": "#2"},
-        "south": {"uv": [0, 0, 1, 4], "texture": "#missing"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [5, 6, 6, 7], "texture": "#2"},
         "down": {"uv": [5, 9, 6, 10], "texture": "#2"}
       }
@@ -235,8 +218,6 @@
       "to": [6, 10, 5],
       "faces": {
         "north": {"uv": [10, 6, 11, 10], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 4], "texture": "#missing"},
-        "south": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "west": {"uv": [10, 6, 11, 10], "texture": "#2"},
         "up": {"uv": [10, 6, 11, 7], "texture": "#2"},
         "down": {"uv": [10, 9, 11, 10], "texture": "#2"}
@@ -249,7 +230,6 @@
       "faces": {
         "north": {"uv": [6, 5, 10, 11], "texture": "#2"},
         "east": {"uv": [6, 5, 7, 11], "texture": "#2"},
-        "south": {"uv": [0, 0, 4, 6], "texture": "#missing"},
         "west": {"uv": [9, 5, 10, 11], "texture": "#2"},
         "up": {"uv": [6, 5, 10, 6], "texture": "#2"},
         "down": {"uv": [6, 10, 10, 11], "texture": "#2"}

--- a/src/main/resources/assets/tfc/models/item/metal/shield/copper_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/copper_blocking.json
@@ -79,7 +79,6 @@
       "to": [5, 14, 7],
       "faces": {
         "north": {"uv": [11, 2, 13, 14], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 12], "texture": "#missing"},
         "south": {"uv": [3, 2, 5, 14], "texture": "#1"},
         "west": {"uv": [12, 2, 13, 14], "texture": "#2"},
         "up": {"uv": [11, 2, 13, 3], "rotation": 180, "texture": "#2"},
@@ -92,7 +91,6 @@
       "to": [3, 13, 7],
       "faces": {
         "north": {"uv": [13, 3, 14, 13], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 10], "texture": "#missing"},
         "south": {"uv": [2, 3, 3, 13], "texture": "#1"},
         "west": {"uv": [13, 3, 14, 13], "texture": "#2"},
         "up": {"uv": [13, 3, 14, 4], "texture": "#2"},
@@ -107,7 +105,6 @@
         "north": {"uv": [3, 2, 5, 14], "texture": "#2"},
         "east": {"uv": [3, 2, 4, 14], "texture": "#2"},
         "south": {"uv": [11, 2, 13, 14], "texture": "#1"},
-        "west": {"uv": [0, 0, 1, 12], "texture": "#missing"},
         "up": {"uv": [3, 2, 5, 3], "rotation": 180, "texture": "#2"},
         "down": {"uv": [3, 13, 5, 14], "rotation": 180, "texture": "#2"}
       }
@@ -120,7 +117,6 @@
         "north": {"uv": [2, 3, 3, 13], "texture": "#2"},
         "east": {"uv": [2, 3, 3, 13], "texture": "#2"},
         "south": {"uv": [13, 3, 14, 13], "texture": "#1"},
-        "west": {"uv": [0, 0, 1, 10], "texture": "#missing"},
         "up": {"uv": [2, 3, 3, 4], "texture": "#2"},
         "down": {"uv": [2, 12, 3, 13], "texture": "#2"}
       }
@@ -131,7 +127,6 @@
       "to": [2, 11, 7],
       "faces": {
         "north": {"uv": [14, 5, 15, 11], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "south": {"uv": [1, 5, 2, 11], "texture": "#1"},
         "west": {"uv": [14, 5, 15, 11], "texture": "#2"},
         "up": {"uv": [14, 5, 15, 6], "texture": "#2"},
@@ -146,7 +141,6 @@
         "north": {"uv": [1, 5, 2, 11], "texture": "#2"},
         "east": {"uv": [1, 5, 2, 11], "texture": "#2"},
         "south": {"uv": [14, 5, 15, 11], "texture": "#1"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [1, 5, 2, 6], "texture": "#2"},
         "down": {"uv": [1, 10, 2, 11], "texture": "#2"}
       }
@@ -157,8 +151,6 @@
       "to": [5, 10, 6],
       "faces": {
         "north": {"uv": [11, 6, 12, 10], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 4], "texture": "#missing"},
-        "south": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "west": {"uv": [11, 6, 12, 10], "texture": "#2"},
         "up": {"uv": [11, 6, 12, 7], "texture": "#2"},
         "down": {"uv": [11, 9, 12, 10], "texture": "#2"}
@@ -171,8 +163,6 @@
       "faces": {
         "north": {"uv": [5, 5, 6, 11], "texture": "#2"},
         "east": {"uv": [5, 5, 6, 11], "texture": "#2"},
-        "south": {"uv": [0, 0, 1, 6], "texture": "#missing"},
-        "west": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "up": {"uv": [5, 5, 6, 6], "texture": "#2"},
         "down": {"uv": [5, 10, 6, 11], "texture": "#2"}
       }
@@ -184,8 +174,6 @@
       "faces": {
         "north": {"uv": [4, 6, 5, 10], "texture": "#2"},
         "east": {"uv": [4, 6, 5, 10], "texture": "#2"},
-        "south": {"uv": [0, 0, 1, 4], "texture": "#missing"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [4, 6, 5, 7], "texture": "#2"},
         "down": {"uv": [4, 9, 5, 10], "texture": "#2"}
       }
@@ -197,7 +185,6 @@
       "faces": {
         "north": {"uv": [6, 4, 10, 12], "texture": "#2"},
         "east": {"uv": [6, 4, 7, 12], "texture": "#2"},
-        "south": {"uv": [0, 0, 4, 8], "texture": "#missing"},
         "west": {"uv": [9, 4, 10, 12], "texture": "#2"},
         "up": {"uv": [6, 4, 10, 5], "texture": "#2"},
         "down": {"uv": [6, 11, 10, 12], "texture": "#2"}
@@ -209,8 +196,6 @@
       "to": [6, 11, 6],
       "faces": {
         "north": {"uv": [10, 5, 11, 11], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 6], "texture": "#missing"},
-        "south": {"uv": [0, 0, 1, 6], "texture": "#missing"},
         "west": {"uv": [10, 5, 11, 11], "texture": "#2"},
         "up": {"uv": [10, 5, 11, 6], "texture": "#2"},
         "down": {"uv": [10, 10, 11, 11], "texture": "#2"}
@@ -223,8 +208,6 @@
       "faces": {
         "north": {"uv": [5, 6, 6, 10], "texture": "#2"},
         "east": {"uv": [5, 6, 6, 10], "texture": "#2"},
-        "south": {"uv": [0, 0, 1, 4], "texture": "#missing"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [5, 6, 6, 7], "texture": "#2"},
         "down": {"uv": [5, 9, 6, 10], "texture": "#2"}
       }
@@ -235,8 +218,6 @@
       "to": [6, 10, 5],
       "faces": {
         "north": {"uv": [10, 6, 11, 10], "texture": "#2"},
-        "east": {"uv": [0, 0, 1, 4], "texture": "#missing"},
-        "south": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "west": {"uv": [10, 6, 11, 10], "texture": "#2"},
         "up": {"uv": [10, 6, 11, 7], "texture": "#2"},
         "down": {"uv": [10, 9, 11, 10], "texture": "#2"}
@@ -249,7 +230,6 @@
       "faces": {
         "north": {"uv": [6, 5, 10, 11], "texture": "#2"},
         "east": {"uv": [6, 5, 7, 11], "texture": "#2"},
-        "south": {"uv": [0, 0, 4, 6], "texture": "#missing"},
         "west": {"uv": [9, 5, 10, 11], "texture": "#2"},
         "up": {"uv": [6, 5, 10, 6], "texture": "#2"},
         "down": {"uv": [6, 10, 10, 11], "texture": "#2"}

--- a/src/main/resources/assets/tfc/models/item/metal/shield/copper_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/copper_blocking.json
@@ -277,12 +277,12 @@
       "translation": [2.3, -2, 5]
     },
     "firstperson_righthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "firstperson_lefthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "ground": {
       "translation": [0, 2, 0],
@@ -298,13 +298,5 @@
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
     }
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "blocking": 1
-      },
-      "model": "tfc:item/metal/shield/copper_blocking"
-    }
-  ]
+  }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/red_steel.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/red_steel.json
@@ -73,7 +73,6 @@
 				"east": {"uv": [3.5, 8.5, 4, 9.5], "texture": "#texture"},
 				"south": {"uv": [10.5, 8.5, 12.5, 9.5], "texture": "#texture"},
 				"west": {"uv": [5, 8.5, 5.5, 9.5], "texture": "#texture"},
-				"up": {"uv": [0, 0, 4, 1], "texture": "#missing"},
 				"down": {"uv": [3.5, 9, 5.5, 9.5], "texture": "#texture"}
 			}
 		},
@@ -137,8 +136,6 @@
 				"north": {"uv": [2.5, 6.5, 3, 7.5], "texture": "#texture"},
 				"east": {"uv": [2.5, 6.5, 3, 7.5], "texture": "#texture"},
 				"south": {"uv": [13, 6.5, 13.5, 7.5], "texture": "#texture"},
-				"west": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-				"up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"down": {"uv": [2.5, 7, 3, 7.5], "texture": "#texture"}
 			}
 		},
@@ -151,8 +148,7 @@
 				"east": {"uv": [2.5, 0.5, 3, 1.5], "texture": "#texture"},
 				"south": {"uv": [13, 0.5, 13.5, 1.5], "texture": "#texture"},
 				"west": {"uv": [2.5, 0.5, 3, 1.5], "texture": "#texture"},
-				"up": {"uv": [2.5, 0.5, 3, 1], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [2.5, 0.5, 3, 1], "texture": "#texture"}
 			}
 		},
 		{
@@ -164,8 +160,7 @@
 				"east": {"uv": [5.5, 0.5, 6, 1.5], "texture": "#texture"},
 				"south": {"uv": [10, 0.5, 10.5, 1.5], "texture": "#texture"},
 				"west": {"uv": [5.5, 0.5, 6, 1.5], "texture": "#texture"},
-				"up": {"uv": [5.5, 0.5, 6, 1], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [5.5, 0.5, 6, 1], "texture": "#texture"}
 			}
 		},
 		{
@@ -174,10 +169,8 @@
 			"to": [5, 6, 7],
 			"faces": {
 				"north": {"uv": [5.5, 6.5, 6, 7.5], "texture": "#texture"},
-				"east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
 				"south": {"uv": [10, 6.5, 10.5, 7.5], "texture": "#texture"},
 				"west": {"uv": [5.5, 6.5, 6, 7.5], "texture": "#texture"},
-				"up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"down": {"uv": [5.5, 7, 6, 7.5], "texture": "#texture"}
 			}
 		},
@@ -189,8 +182,6 @@
 				"north": {"uv": [4, 9.5, 5, 10], "texture": "#texture"},
 				"east": {"uv": [4, 9.5, 4.5, 10], "texture": "#texture"},
 				"south": {"uv": [11, 9.5, 12, 10], "texture": "#texture"},
-				"west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-				"up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
 				"down": {"uv": [4, 9.5, 5, 10], "texture": "#texture"}
 			}
 		},
@@ -200,11 +191,9 @@
 			"to": [5, 1, 7],
 			"faces": {
 				"north": {"uv": [5.5, 9, 6, 9.5], "texture": "#texture"},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"south": {"uv": [10, 9, 10.5, 9.5], "texture": "#texture"},
 				"west": {"uv": [5.5, 9, 6, 9.5], "texture": "#texture"},
-				"up": {"uv": [5.5, 9, 6, 9.5], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [5.5, 9, 6, 9.5], "texture": "#texture"}
 			}
 		},
 		{
@@ -213,11 +202,9 @@
 			"to": [10, 15, 7],
 			"faces": {
 				"north": {"uv": [3, 2, 3.5, 3], "texture": "#texture"},
-				"east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
 				"south": {"uv": [12.5, 2, 13, 3], "texture": "#texture"},
 				"west": {"uv": [3, 2, 3.5, 3], "texture": "#texture"},
-				"up": {"uv": [3, 2, 3.5, 2.5], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [3, 2, 3.5, 2.5], "texture": "#texture"}
 			}
 		},
 		{
@@ -228,9 +215,7 @@
 				"north": {"uv": [5, 2, 5.5, 3], "texture": "#texture"},
 				"east": {"uv": [5, 2, 5.5, 3], "texture": "#texture"},
 				"south": {"uv": [10.5, 2, 11, 3], "texture": "#texture"},
-				"west": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-				"up": {"uv": [5, 2, 5.5, 2.5], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [5, 2, 5.5, 2.5], "texture": "#texture"}
 			}
 		},
 		{
@@ -240,7 +225,6 @@
 			"faces": {
 				"north": {"uv": [2.5, 5.5, 6, 6], "texture": "#texture"},
 				"east": {"uv": [2.5, 5.5, 3, 6], "texture": "#texture"},
-				"south": {"uv": [0, 0, 7, 1], "texture": "#missing"},
 				"west": {"uv": [5.5, 5.5, 6, 6], "texture": "#texture"},
 				"up": {"uv": [2.5, 5.5, 6, 6], "texture": "#texture"},
 				"down": {"uv": [2.5, 5.5, 6, 6], "texture": "#texture"}
@@ -253,9 +237,7 @@
 			"faces": {
 				"north": {"uv": [3.5, 6.5, 5, 7], "texture": "#texture"},
 				"east": {"uv": [3.5, 6.5, 4, 7], "texture": "#texture"},
-				"south": {"uv": [0, 0, 3, 1], "texture": "#missing"},
 				"west": {"uv": [4.5, 6.5, 5, 7], "texture": "#texture"},
-				"up": {"uv": [0, 0, 3, 1], "texture": "#missing"},
 				"down": {"uv": [3.5, 6.5, 5, 7], "texture": "#texture"}
 			}
 		},
@@ -266,9 +248,7 @@
 			"faces": {
 				"north": {"uv": [3, 6, 5.5, 6.5], "texture": "#texture"},
 				"east": {"uv": [3, 6, 3.5, 6.5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 5, 1], "texture": "#missing"},
 				"west": {"uv": [5, 6, 5.5, 6.5], "texture": "#texture"},
-				"up": {"uv": [0, 0, 5, 1], "texture": "#missing"},
 				"down": {"uv": [3, 8, 5.5, 8.5], "texture": "#texture"}
 			}
 		},
@@ -279,9 +259,7 @@
 			"faces": {
 				"north": {"uv": [4, 7, 4.5, 8], "texture": "#texture"},
 				"east": {"uv": [4, 7, 4.5, 8], "texture": "#texture"},
-				"south": {"uv": [0, 0, 1, 2], "texture": "#missing"},
 				"west": {"uv": [4, 7, 4.5, 8], "texture": "#texture"},
-				"up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"down": {"uv": [4, 7.5, 4.5, 8], "texture": "#texture"}
 			}
 		},
@@ -292,10 +270,8 @@
 			"faces": {
 				"north": {"uv": [2.5, 4, 3.5, 5], "texture": "#texture"},
 				"east": {"uv": [2.5, 4, 3, 5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 2, 2], "texture": "#missing"},
 				"west": {"uv": [3, 4, 3.5, 5], "texture": "#texture"},
-				"up": {"uv": [2.5, 4, 3.5, 4.5], "rotation": 180, "texture": "#texture"},
-				"down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+				"up": {"uv": [2.5, 4, 3.5, 4.5], "rotation": 180, "texture": "#texture"}
 			}
 		},
 		{
@@ -305,10 +281,8 @@
 			"faces": {
 				"north": {"uv": [5, 4, 6, 5], "texture": "#texture"},
 				"east": {"uv": [5, 4, 5.5, 5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 2, 3], "texture": "#missing"},
 				"west": {"uv": [5.5, 4, 6, 5], "texture": "#texture"},
-				"up": {"uv": [5, 4, 6, 4.5], "rotation": 180, "texture": "#texture"},
-				"down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+				"up": {"uv": [5, 4, 6, 4.5], "rotation": 180, "texture": "#texture"}
 			}
 		},
 		{
@@ -318,10 +292,8 @@
 			"faces": {
 				"north": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"},
 				"east": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"west": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"},
-				"up": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"}
 			}
 		},
 		{
@@ -331,10 +303,8 @@
 			"faces": {
 				"north": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"},
 				"east": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"west": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"},
-				"up": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"}
 			}
 		},
 		{
@@ -344,10 +314,8 @@
 			"faces": {
 				"north": {"uv": [2.5, 5, 4, 5.5], "texture": "#texture"},
 				"east": {"uv": [2.5, 5, 3, 5.5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 3, 1], "texture": "#missing"},
 				"west": {"uv": [3.5, 5, 4, 5.5], "texture": "#texture"},
-				"up": {"uv": [2.5, 5, 4, 5.5], "rotation": 180, "texture": "#texture"},
-				"down": {"uv": [0, 0, 3, 1], "texture": "#missing"}
+				"up": {"uv": [2.5, 5, 4, 5.5], "rotation": 180, "texture": "#texture"}
 			}
 		},
 		{
@@ -357,10 +325,8 @@
 			"faces": {
 				"north": {"uv": [4.5, 5, 6, 5.5], "texture": "#texture"},
 				"east": {"uv": [4.5, 5, 5, 5.5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 3, 1], "texture": "#missing"},
 				"west": {"uv": [5.5, 5, 6, 5.5], "texture": "#texture"},
-				"up": {"uv": [4.5, 5, 6, 5.5], "rotation": 180, "texture": "#texture"},
-				"down": {"uv": [0, 0, 3, 1], "texture": "#missing"}
+				"up": {"uv": [4.5, 5, 6, 5.5], "rotation": 180, "texture": "#texture"}
 			}
 		}
 	],

--- a/src/main/resources/assets/tfc/models/item/metal/shield/red_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/red_steel_blocking.json
@@ -73,7 +73,6 @@
 				"east": {"uv": [3.5, 8.5, 4, 9.5], "texture": "#texture"},
 				"south": {"uv": [10.5, 8.5, 12.5, 9.5], "texture": "#texture"},
 				"west": {"uv": [5, 8.5, 5.5, 9.5], "texture": "#texture"},
-				"up": {"uv": [0, 0, 4, 1], "texture": "#missing"},
 				"down": {"uv": [3.5, 9, 5.5, 9.5], "texture": "#texture"}
 			}
 		},
@@ -137,8 +136,6 @@
 				"north": {"uv": [2.5, 6.5, 3, 7.5], "texture": "#texture"},
 				"east": {"uv": [2.5, 6.5, 3, 7.5], "texture": "#texture"},
 				"south": {"uv": [13, 6.5, 13.5, 7.5], "texture": "#texture"},
-				"west": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-				"up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"down": {"uv": [2.5, 7, 3, 7.5], "texture": "#texture"}
 			}
 		},
@@ -151,8 +148,7 @@
 				"east": {"uv": [2.5, 0.5, 3, 1.5], "texture": "#texture"},
 				"south": {"uv": [13, 0.5, 13.5, 1.5], "texture": "#texture"},
 				"west": {"uv": [2.5, 0.5, 3, 1.5], "texture": "#texture"},
-				"up": {"uv": [2.5, 0.5, 3, 1], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [2.5, 0.5, 3, 1], "texture": "#texture"}
 			}
 		},
 		{
@@ -164,8 +160,7 @@
 				"east": {"uv": [5.5, 0.5, 6, 1.5], "texture": "#texture"},
 				"south": {"uv": [10, 0.5, 10.5, 1.5], "texture": "#texture"},
 				"west": {"uv": [5.5, 0.5, 6, 1.5], "texture": "#texture"},
-				"up": {"uv": [5.5, 0.5, 6, 1], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [5.5, 0.5, 6, 1], "texture": "#texture"}
 			}
 		},
 		{
@@ -174,10 +169,8 @@
 			"to": [5, 6, 7],
 			"faces": {
 				"north": {"uv": [5.5, 6.5, 6, 7.5], "texture": "#texture"},
-				"east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
 				"south": {"uv": [10, 6.5, 10.5, 7.5], "texture": "#texture"},
 				"west": {"uv": [5.5, 6.5, 6, 7.5], "texture": "#texture"},
-				"up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"down": {"uv": [5.5, 7, 6, 7.5], "texture": "#texture"}
 			}
 		},
@@ -189,8 +182,6 @@
 				"north": {"uv": [4, 9.5, 5, 10], "texture": "#texture"},
 				"east": {"uv": [4, 9.5, 4.5, 10], "texture": "#texture"},
 				"south": {"uv": [11, 9.5, 12, 10], "texture": "#texture"},
-				"west": {"uv": [0, 0, 1, 1], "texture": "#missing"},
-				"up": {"uv": [0, 0, 2, 1], "texture": "#missing"},
 				"down": {"uv": [4, 9.5, 5, 10], "texture": "#texture"}
 			}
 		},
@@ -200,11 +191,9 @@
 			"to": [5, 1, 7],
 			"faces": {
 				"north": {"uv": [5.5, 9, 6, 9.5], "texture": "#texture"},
-				"east": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"south": {"uv": [10, 9, 10.5, 9.5], "texture": "#texture"},
 				"west": {"uv": [5.5, 9, 6, 9.5], "texture": "#texture"},
-				"up": {"uv": [5.5, 9, 6, 9.5], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [5.5, 9, 6, 9.5], "texture": "#texture"}
 			}
 		},
 		{
@@ -213,11 +202,9 @@
 			"to": [10, 15, 7],
 			"faces": {
 				"north": {"uv": [3, 2, 3.5, 3], "texture": "#texture"},
-				"east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
 				"south": {"uv": [12.5, 2, 13, 3], "texture": "#texture"},
 				"west": {"uv": [3, 2, 3.5, 3], "texture": "#texture"},
-				"up": {"uv": [3, 2, 3.5, 2.5], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [3, 2, 3.5, 2.5], "texture": "#texture"}
 			}
 		},
 		{
@@ -228,9 +215,7 @@
 				"north": {"uv": [5, 2, 5.5, 3], "texture": "#texture"},
 				"east": {"uv": [5, 2, 5.5, 3], "texture": "#texture"},
 				"south": {"uv": [10.5, 2, 11, 3], "texture": "#texture"},
-				"west": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-				"up": {"uv": [5, 2, 5.5, 2.5], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [5, 2, 5.5, 2.5], "texture": "#texture"}
 			}
 		},
 		{
@@ -240,7 +225,6 @@
 			"faces": {
 				"north": {"uv": [2.5, 5.5, 6, 6], "texture": "#texture"},
 				"east": {"uv": [2.5, 5.5, 3, 6], "texture": "#texture"},
-				"south": {"uv": [0, 0, 7, 1], "texture": "#missing"},
 				"west": {"uv": [5.5, 5.5, 6, 6], "texture": "#texture"},
 				"up": {"uv": [2.5, 5.5, 6, 6], "texture": "#texture"},
 				"down": {"uv": [2.5, 5.5, 6, 6], "texture": "#texture"}
@@ -253,9 +237,7 @@
 			"faces": {
 				"north": {"uv": [3.5, 6.5, 5, 7], "texture": "#texture"},
 				"east": {"uv": [3.5, 6.5, 4, 7], "texture": "#texture"},
-				"south": {"uv": [0, 0, 3, 1], "texture": "#missing"},
 				"west": {"uv": [4.5, 6.5, 5, 7], "texture": "#texture"},
-				"up": {"uv": [0, 0, 3, 1], "texture": "#missing"},
 				"down": {"uv": [3.5, 6.5, 5, 7], "texture": "#texture"}
 			}
 		},
@@ -266,9 +248,7 @@
 			"faces": {
 				"north": {"uv": [3, 6, 5.5, 6.5], "texture": "#texture"},
 				"east": {"uv": [3, 6, 3.5, 6.5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 5, 1], "texture": "#missing"},
 				"west": {"uv": [5, 6, 5.5, 6.5], "texture": "#texture"},
-				"up": {"uv": [0, 0, 5, 1], "texture": "#missing"},
 				"down": {"uv": [3, 8, 5.5, 8.5], "texture": "#texture"}
 			}
 		},
@@ -279,9 +259,7 @@
 			"faces": {
 				"north": {"uv": [4, 7, 4.5, 8], "texture": "#texture"},
 				"east": {"uv": [4, 7, 4.5, 8], "texture": "#texture"},
-				"south": {"uv": [0, 0, 1, 2], "texture": "#missing"},
 				"west": {"uv": [4, 7, 4.5, 8], "texture": "#texture"},
-				"up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"down": {"uv": [4, 7.5, 4.5, 8], "texture": "#texture"}
 			}
 		},
@@ -292,10 +270,8 @@
 			"faces": {
 				"north": {"uv": [2.5, 4, 3.5, 5], "texture": "#texture"},
 				"east": {"uv": [2.5, 4, 3, 5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 2, 2], "texture": "#missing"},
 				"west": {"uv": [3, 4, 3.5, 5], "texture": "#texture"},
-				"up": {"uv": [2.5, 4, 3.5, 4.5], "rotation": 180, "texture": "#texture"},
-				"down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+				"up": {"uv": [2.5, 4, 3.5, 4.5], "rotation": 180, "texture": "#texture"}
 			}
 		},
 		{
@@ -305,10 +281,8 @@
 			"faces": {
 				"north": {"uv": [5, 4, 6, 5], "texture": "#texture"},
 				"east": {"uv": [5, 4, 5.5, 5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 2, 3], "texture": "#missing"},
 				"west": {"uv": [5.5, 4, 6, 5], "texture": "#texture"},
-				"up": {"uv": [5, 4, 6, 4.5], "rotation": 180, "texture": "#texture"},
-				"down": {"uv": [0, 0, 2, 1], "texture": "#missing"}
+				"up": {"uv": [5, 4, 6, 4.5], "rotation": 180, "texture": "#texture"}
 			}
 		},
 		{
@@ -318,10 +292,8 @@
 			"faces": {
 				"north": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"},
 				"east": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"west": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"},
-				"up": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [2.5, 3.5, 3, 4], "texture": "#texture"}
 			}
 		},
 		{
@@ -331,10 +303,8 @@
 			"faces": {
 				"north": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"},
 				"east": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"},
-				"south": {"uv": [0, 0, 1, 1], "texture": "#missing"},
 				"west": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"},
-				"up": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"},
-				"down": {"uv": [0, 0, 1, 1], "texture": "#missing"}
+				"up": {"uv": [5.5, 3.5, 6, 4], "texture": "#texture"}
 			}
 		},
 		{
@@ -344,10 +314,8 @@
 			"faces": {
 				"north": {"uv": [2.5, 5, 4, 5.5], "texture": "#texture"},
 				"east": {"uv": [2.5, 5, 3, 5.5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 3, 1], "texture": "#missing"},
 				"west": {"uv": [3.5, 5, 4, 5.5], "texture": "#texture"},
-				"up": {"uv": [2.5, 5, 4, 5.5], "rotation": 180, "texture": "#texture"},
-				"down": {"uv": [0, 0, 3, 1], "texture": "#missing"}
+				"up": {"uv": [2.5, 5, 4, 5.5], "rotation": 180, "texture": "#texture"}
 			}
 		},
 		{
@@ -357,10 +325,8 @@
 			"faces": {
 				"north": {"uv": [4.5, 5, 6, 5.5], "texture": "#texture"},
 				"east": {"uv": [4.5, 5, 5, 5.5], "texture": "#texture"},
-				"south": {"uv": [0, 0, 3, 1], "texture": "#missing"},
 				"west": {"uv": [5.5, 5, 6, 5.5], "texture": "#texture"},
-				"up": {"uv": [4.5, 5, 6, 5.5], "rotation": 180, "texture": "#texture"},
-				"down": {"uv": [0, 0, 3, 1], "texture": "#missing"}
+				"up": {"uv": [4.5, 5, 6, 5.5], "rotation": 180, "texture": "#texture"}
 			}
 		}
 	],

--- a/src/main/resources/assets/tfc/models/item/metal/shield/red_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/red_steel_blocking.json
@@ -374,12 +374,12 @@
 			"translation": [2.3, -2, 5]
 		},
 		"firstperson_righthand": {
-			"rotation": [0, -75, 15],
-			"translation": [4, -3, 0]
+			"rotation": [0, -15, 15],
+			"translation": [2, -2.5, 0]
 		},
 		"firstperson_lefthand": {
-			"rotation": [0, -75, 15],
-			"translation": [4, -3, 0]
+			"rotation": [0, -15, 15],
+			"translation": [2, -2.5, 0]
 		},
 		"ground": {
 			"translation": [0, 2, 0],
@@ -396,12 +396,5 @@
 			"translation": [0, 0, -0.38],
 			"scale": [2, 2, 2]
 		}
-	},
-    "overrides": [  {
-        "predicate": {
-            "blocking": 1
-        },
-        "model": "tfc:item/metal/shield/red_steel_blocking"
-    }
-  ]
+	}
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/steel_blocking.json
@@ -500,12 +500,12 @@
       "translation": [2.3, -2, 5]
     },
     "firstperson_righthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "firstperson_lefthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -3, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -2.5, 0]
     },
     "ground": {
       "translation": [0, 2, 0],
@@ -521,13 +521,5 @@
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
     }
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "blocking": 1
-      },
-      "model": "tfc:item/metal/shield/steel_blocking"
-    }
-  ]
+  }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron.json
@@ -94,10 +94,8 @@
       "to": [7, -3, 7],
       "faces": {
         "north": {"uv": [4.5, 10.5, 5, 11.5], "texture": "#texture"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4.5, 10.5, 5, 11.5], "texture": "#texture"},
         "west": {"uv": [4.5, 10.5, 5, 11.5], "texture": "#texture"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [4.5, 11, 5, 11.5], "texture": "#texture"}
       }
     },
@@ -109,8 +107,6 @@
         "north": {"uv": [3, 10.5, 3.5, 11.5], "texture": "#texture"},
         "east": {"uv": [3, 10.5, 3.5, 11.5], "texture": "#texture"},
         "south": {"uv": [3, 10.5, 3.5, 11.5], "texture": "#texture"},
-        "west": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [3, 11, 3.5, 11.5], "texture": "#texture"}
       }
     },
@@ -135,7 +131,6 @@
         "east": {"uv": [2.5, 9, 3, 10.5], "texture": "#texture"},
         "south": {"uv": [13.5, 7.5, 14, 9], "texture": "#texture"},
         "west": {"uv": [13.5, 7.5, 14, 9], "texture": "#texture"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [2.5, 10, 3, 10.5], "texture": "#texture"}
       }
     },
@@ -148,7 +143,6 @@
         "east": {"uv": [10, 7.5, 10.5, 9], "texture": "#texture"},
         "south": {"uv": [10.5, 9, 11, 10.5], "texture": "#texture"},
         "west": {"uv": [5.5, 7.5, 6, 9], "texture": "#texture"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [5.5, 8.5, 6, 9], "texture": "#texture"}
       }
     },
@@ -171,7 +165,6 @@
       "to": [3, 15, 8],
       "faces": {
         "north": {"uv": [6.5, 1.5, 7, 6.5], "texture": "#texture"},
-        "east": {"uv": [0, 0, 1, 10], "texture": "#missing"},
         "south": {"uv": [9, 1.5, 9.5, 6.5], "texture": "#texture"},
         "west": {"uv": [6.5, 1.5, 7, 6.5], "texture": "#texture"},
         "up": {"uv": [6.5, 1.5, 7, 2], "texture": "#texture"},
@@ -184,7 +177,6 @@
       "to": [2, 14, 8],
       "faces": {
         "north": {"uv": [7, 2, 7.5, 4.5], "texture": "#texture"},
-        "east": {"uv": [0, 0, 1, 5], "texture": "#missing"},
         "south": {"uv": [8.5, 2, 9, 4.5], "texture": "#texture"},
         "west": {"uv": [7, 2, 7.5, 4.5], "texture": "#texture"},
         "up": {"uv": [7, 2, 7.5, 2.5], "texture": "#texture"},
@@ -212,7 +204,6 @@
         "north": {"uv": [1, 1.5, 1.5, 6.5], "texture": "#texture"},
         "east": {"uv": [1, 1.5, 1.5, 6.5], "texture": "#texture"},
         "south": {"uv": [14.5, 1.5, 15, 6.5], "texture": "#texture"},
-        "west": {"uv": [0, 0, 1, 10], "texture": "#missing"},
         "up": {"uv": [1, 1.5, 1.5, 2], "texture": "#texture"},
         "down": {"uv": [1, 6, 1.5, 6.5], "texture": "#texture"}
       }
@@ -225,7 +216,6 @@
         "north": {"uv": [0.5, 2, 1, 4.5], "texture": "#texture"},
         "east": {"uv": [0.5, 2, 1, 4.5], "texture": "#texture"},
         "south": {"uv": [15, 2, 15.5, 4.5], "texture": "#texture"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [0.5, 2, 1, 2.5], "texture": "#texture"},
         "down": {"uv": [0.5, 4, 1, 4.5], "texture": "#texture"}
       }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron_blocking.json
@@ -241,12 +241,12 @@
       "translation": [2.3, -2, 5]
     },
     "firstperson_righthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -4, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -4.5, 0]
     },
     "firstperson_lefthand": {
-      "rotation": [0, -75, 15],
-      "translation": [4, -4, 0]
+      "rotation": [0, -15, 15],
+      "translation": [2, -4.5, 0]
     },
     "ground": {
       "translation": [0, 10, 0],
@@ -264,13 +264,5 @@
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
     }
-  },
-  "overrides": [
-    {
-      "predicate": {
-        "blocking": 1
-      },
-      "model": "tfc:item/metal/shield/wrought_iron_blocking"
-    }
-  ]
+  }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron_blocking.json
@@ -94,10 +94,8 @@
       "to": [7, -3, 7],
       "faces": {
         "north": {"uv": [4.5, 10.5, 5, 11.5], "texture": "#texture"},
-        "east": {"uv": [0, 0, 1, 2], "texture": "#missing"},
         "south": {"uv": [4.5, 10.5, 5, 11.5], "texture": "#texture"},
         "west": {"uv": [4.5, 10.5, 5, 11.5], "texture": "#texture"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [4.5, 11, 5, 11.5], "texture": "#texture"}
       }
     },
@@ -109,8 +107,6 @@
         "north": {"uv": [3, 10.5, 3.5, 11.5], "texture": "#texture"},
         "east": {"uv": [3, 10.5, 3.5, 11.5], "texture": "#texture"},
         "south": {"uv": [3, 10.5, 3.5, 11.5], "texture": "#texture"},
-        "west": {"uv": [0, 0, 1, 2], "texture": "#missing"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [3, 11, 3.5, 11.5], "texture": "#texture"}
       }
     },
@@ -135,7 +131,6 @@
         "east": {"uv": [2.5, 9, 3, 10.5], "texture": "#texture"},
         "south": {"uv": [13.5, 7.5, 14, 9], "texture": "#texture"},
         "west": {"uv": [13.5, 7.5, 14, 9], "texture": "#texture"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [2.5, 10, 3, 10.5], "texture": "#texture"}
       }
     },
@@ -148,7 +143,6 @@
         "east": {"uv": [10, 7.5, 10.5, 9], "texture": "#texture"},
         "south": {"uv": [10.5, 9, 11, 10.5], "texture": "#texture"},
         "west": {"uv": [5.5, 7.5, 6, 9], "texture": "#texture"},
-        "up": {"uv": [0, 0, 1, 1], "texture": "#missing"},
         "down": {"uv": [5.5, 8.5, 6, 9], "texture": "#texture"}
       }
     },
@@ -171,7 +165,6 @@
       "to": [3, 15, 8],
       "faces": {
         "north": {"uv": [6.5, 1.5, 7, 6.5], "texture": "#texture"},
-        "east": {"uv": [0, 0, 1, 10], "texture": "#missing"},
         "south": {"uv": [9, 1.5, 9.5, 6.5], "texture": "#texture"},
         "west": {"uv": [6.5, 1.5, 7, 6.5], "texture": "#texture"},
         "up": {"uv": [6.5, 1.5, 7, 2], "texture": "#texture"},
@@ -184,7 +177,6 @@
       "to": [2, 14, 8],
       "faces": {
         "north": {"uv": [7, 2, 7.5, 4.5], "texture": "#texture"},
-        "east": {"uv": [0, 0, 1, 5], "texture": "#missing"},
         "south": {"uv": [8.5, 2, 9, 4.5], "texture": "#texture"},
         "west": {"uv": [7, 2, 7.5, 4.5], "texture": "#texture"},
         "up": {"uv": [7, 2, 7.5, 2.5], "texture": "#texture"},
@@ -212,7 +204,6 @@
         "north": {"uv": [1, 1.5, 1.5, 6.5], "texture": "#texture"},
         "east": {"uv": [1, 1.5, 1.5, 6.5], "texture": "#texture"},
         "south": {"uv": [14.5, 1.5, 15, 6.5], "texture": "#texture"},
-        "west": {"uv": [0, 0, 1, 10], "texture": "#missing"},
         "up": {"uv": [1, 1.5, 1.5, 2], "texture": "#texture"},
         "down": {"uv": [1, 6, 1.5, 6.5], "texture": "#texture"}
       }
@@ -225,7 +216,6 @@
         "north": {"uv": [0.5, 2, 1, 4.5], "texture": "#texture"},
         "east": {"uv": [0.5, 2, 1, 4.5], "texture": "#texture"},
         "south": {"uv": [15, 2, 15.5, 4.5], "texture": "#texture"},
-        "west": {"uv": [0, 0, 1, 4], "texture": "#missing"},
         "up": {"uv": [0.5, 2, 1, 2.5], "texture": "#texture"},
         "down": {"uv": [0.5, 4, 1, 4.5], "texture": "#texture"}
       }


### PR DESCRIPTION
Changes over 1.12:
- Copied shield model jsons from 1.12
- added `"gui_light": "front",` to all model jsons
- Implemented ` ItemProperties.register` in the Item init. #1956 

Therefor fixed #1956 .