### PR TITLE
pillars as a cave feature rather than noise

### DIFF
--- a/resources/constants.py
+++ b/resources/constants.py
@@ -512,7 +512,7 @@ FOREST_DECORATORS = ('sticks_forest', 'pinecone', 'salt_lick', 'dead_grass', 'hu
 OCEAN_PLANT_TYPES = ('grass_water', 'floating', 'water', 'emergent', 'tall_water')
 MISC_PLANT_FEATURES = ('hanging_vines', 'hanging_vines_cave', 'ivy', 'jungle_vines', 'liana', 'moss_cover_patch', 'reindeer_lichen_cover_patch', 'morning_glory_cover_patch', 'tree_fern', 'arundo')
 SURFACE_GRASS_FEATURES = ('fountain_', 'orchard_', 'rye', 'scutch_', 'timothy_', 'brome', 'blue', 'raddia_')
-UNDERGROUND_FEATURES = ('cave_spike', 'large_cave_spike', 'water_spring', 'lava_spring', 'calcite', 'mega_calcite', 'icicle', 'underground_loose_rocks', 'underground_guano_patch', 'hanging_roots_patch')
+UNDERGROUND_FEATURES = ('cave_column', 'cave_spike', 'large_cave_spike', 'water_spring', 'lava_spring', 'calcite', 'mega_calcite', 'icicle', 'underground_loose_rocks', 'underground_guano_patch', 'hanging_roots_patch')
 
 # For now, bush hydration ranges are unused, and rainfall ranges are just used for world gen
 BERRIES: Dict[str, Berry] = {

--- a/resources/world_gen.py
+++ b/resources/world_gen.py
@@ -206,6 +206,8 @@ def generate(rm: ResourceManager):
     rm.placed_feature('cave_spike', 'tfc:cave_spike', decorate_carving_mask(), decorate_chance(5))
     rm.placed_feature('large_cave_spike', 'tfc:large_cave_spike', decorate_carving_mask(utils.vertical_anchor(25, 'above_bottom')), decorate_chance(0.006))
 
+    configured_placed_feature(rm, 'cave_column', 'tfc:cave_column', {}, decorate_carving_mask(utils.vertical_anchor(25, 'above_bottom')), decorate_chance(0.0015))
+
     rm.configured_feature('calcite', 'tfc:thin_spike', {
         'state': 'tfc:calcite',
         'radius': 5,

--- a/src/main/java/net/dries007/tfc/world/feature/TFCFeatures.java
+++ b/src/main/java/net/dries007/tfc/world/feature/TFCFeatures.java
@@ -38,6 +38,7 @@ public class TFCFeatures
     public static final RegistryObject<FissureFeature> FISSURE = register("fissure", FissureFeature::new, FissureConfig.CODEC);
     public static final RegistryObject<HotSpringFeature> HOT_SPRING = register("hot_spring", HotSpringFeature::new, HotSpringConfig.CODEC);
     public static final RegistryObject<TFCGeodeFeature> GEODE = register("geode", TFCGeodeFeature::new, TFCGeodeConfig.CODEC);
+    public static final RegistryObject<CaveColumnFeature> CAVE_COLUMN = register("cave_column", CaveColumnFeature::new, NoneFeatureConfiguration.CODEC);
 
     public static final RegistryObject<ClusterVeinFeature> CLUSTER_VEIN = register("cluster_vein", ClusterVeinFeature::new, VeinConfig.CODEC);
     public static final RegistryObject<DiscVeinFeature> DISC_VEIN = register("disc_vein", DiscVeinFeature::new, DiscVeinConfig.CODEC);

--- a/src/main/java/net/dries007/tfc/world/feature/cave/CaveColumnFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/cave/CaveColumnFeature.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the EUPL, Version 1.2.
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+package net.dries007.tfc.world.feature.cave;
+
+import java.util.Random;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
+import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
+
+import com.mojang.serialization.Codec;
+import net.dries007.tfc.util.Helpers;
+import net.dries007.tfc.world.chunkdata.ChunkDataProvider;
+import net.dries007.tfc.world.chunkdata.RockData;
+
+public class CaveColumnFeature extends Feature<NoneFeatureConfiguration>
+{
+    public CaveColumnFeature(Codec<NoneFeatureConfiguration> codec)
+    {
+        super(codec);
+    }
+
+    @Override
+    public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> context)
+    {
+        final WorldGenLevel level = context.level();
+        final BlockPos pos = context.origin();
+
+        final Random random = context.random();
+
+        final ChunkDataProvider provider = ChunkDataProvider.get(context.chunkGenerator());
+        final RockData data = provider.get(context.level(), pos).getRockData();
+
+        final BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos().set(pos);
+        final float amp = Mth.nextFloat(random, 0.25f, 0.6f);
+        final float offset = Mth.nextInt(random, 1, 5);
+        final float period = Mth.nextFloat(random, 0.4f, 0.6f);
+        final int xo = pos.getX();
+        final int zo = pos.getZ();
+
+        int y = mutablePos.getY();
+
+        mutablePos.move(0, -1, 0);
+        if (!Helpers.isBlock(level.getBlockState(mutablePos), BlockTags.BASE_STONE_OVERWORLD))
+        {
+            return false;
+        }
+        else
+        {
+            mutablePos.move(0, 1, 0);
+        }
+
+        while (true)
+        {
+            final BlockState state = data.getRock(mutablePos).raw().defaultBlockState();
+            final int radius = (int) (amp * Mth.sin(period * y + offset) + 2);
+            for (int x = -radius; x <= radius; x++)
+            {
+                for (int z = -radius; z <= radius; z++)
+                {
+                    if (x * x * z * z < radius * radius)
+                    {
+                        mutablePos.set(xo + x, y, zo + z);
+                        setBlock(level, mutablePos, state);
+                    }
+                }
+            }
+            y++;
+            mutablePos.set(xo, y, zo);
+            BlockState middleState = level.getBlockState(mutablePos);
+            if (!Helpers.isBlock(middleState, Blocks.CAVE_AIR) && !Helpers.isBlock(middleState, Blocks.LAVA))
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/main/java/net/dries007/tfc/world/noise/NoiseSampler.java
+++ b/src/main/java/net/dries007/tfc/world/noise/NoiseSampler.java
@@ -48,9 +48,6 @@ public class NoiseSampler
 
     private final NoiseSettings noiseSettings;
 
-    private final NormalNoise pillarNoiseSource;
-    private final NormalNoise pillarRarenessModulator;
-    private final NormalNoise pillarThicknessModulator;
     private final NormalNoise spaghetti2DNoiseSource;
     private final NormalNoise spaghetti2DElevationModulator;
     private final NormalNoise spaghetti2DRarityModulator;
@@ -72,9 +69,6 @@ public class NoiseSampler
 
         // Noise Caves
         this.noiseCaves = this::calculateNoiseCaves;
-        this.pillarNoiseSource = Noises.instantiate(parameters, positionalRandomFactory, Noises.PILLAR);
-        this.pillarRarenessModulator = Noises.instantiate(parameters, positionalRandomFactory, Noises.PILLAR_RARENESS);
-        this.pillarThicknessModulator = Noises.instantiate(parameters, positionalRandomFactory, Noises.PILLAR_THICKNESS);
         this.spaghetti2DNoiseSource = Noises.instantiate(parameters, positionalRandomFactory, Noises.SPAGHETTI_2D);
         this.spaghetti2DElevationModulator = Noises.instantiate(parameters, positionalRandomFactory, Noises.SPAGHETTI_2D_ELEVATION);
         this.spaghetti2DRarityModulator = Noises.instantiate(parameters, positionalRandomFactory, Noises.SPAGHETTI_2D_MODULATOR);
@@ -115,16 +109,10 @@ public class NoiseSampler
         final double spaghetti3D = getSpaghetti3D(x, y, z);
         final double spaghetti = spaghettiRoughness + Math.min(spaghetti2D, spaghetti3D);
 
-        final double pillars = getPillars(x, y, z);
         final double cheese = Mth.clamp(cheeseNoiseSource.getValue(x, y / 1.5, z) + 0.27, -1, 1);
         final double layerizedCaverns = getLayerizedCaverns(x, y, z);
 
-        // todo: remove pillar noise and replace with a feature that does this but better, without perlerp
-        double noise = Math.min(cheese + layerizedCaverns, Math.min(spaghetti, bigEntrances));
-        if (pillars > 0 && noise < 0)
-        {
-            noise = 0.1;
-        }
+        final double noise = Math.min(cheese + layerizedCaverns, Math.min(spaghetti, bigEntrances));
 
         final double clamped = Mth.clamp(noise, -1, 1);
         return applySlide(clamped, y);
@@ -145,18 +133,6 @@ public class NoiseSampler
         double d3 = bigEntranceNoiseSource.getValue(x * 0.75, y * 0.5, z * 0.75) + 0.37;
         double d4 = (y + 10) / 40d;
         return d3 + Mth.clampedLerp(0.3, 0, d4);
-    }
-
-    private double getPillars(int x, int y, int z)
-    {
-        double rarityMod = Helpers.sampleNoiseAndMapToRange(pillarRarenessModulator, x, y, z, 0, 2);
-        double thicknessMod = Helpers.sampleNoiseAndMapToRange(pillarThicknessModulator, x, y, z, 0, 1.1);
-
-        thicknessMod *= thicknessMod * thicknessMod;
-
-        double pillarNoise = pillarNoiseSource.getValue(x * 25, y * 0.3, z * 25);
-        pillarNoise = thicknessMod * (pillarNoise * 2 - rarityMod);
-        return pillarNoise > 0.03 ? pillarNoise : Double.NEGATIVE_INFINITY;
     }
 
     private double getLayerizedCaverns(int x, int y, int z)

--- a/src/main/resources/data/tfc/tags/worldgen/placed_feature/in_biome/underground_decoration.json
+++ b/src/main/resources/data/tfc/tags/worldgen/placed_feature/in_biome/underground_decoration.json
@@ -2,6 +2,7 @@
   "__comment__": "This file was automatically created by mcresources",
   "replace": false,
   "values": [
+    "tfc:cave_column",
     "tfc:cave_spike",
     "tfc:large_cave_spike",
     "tfc:water_spring",

--- a/src/main/resources/data/tfc/worldgen/configured_feature/cave_column.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/cave_column.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "type": "tfc:cave_column",
+  "config": {}
+}

--- a/src/main/resources/data/tfc/worldgen/placed_feature/cave_column.json
+++ b/src/main/resources/data/tfc/worldgen/placed_feature/cave_column.json
@@ -1,0 +1,17 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "feature": "tfc:cave_column",
+  "placement": [
+    {
+      "type": "tfc:carving_mask",
+      "step": "air",
+      "min_y": {
+        "above_bottom": 25
+      }
+    },
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 667
+    }
+  ]
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59940116/184551773-99777f03-6667-4fef-8de4-acebed88e40f.png)

This executes before small spikes, so other features can attach to it.

Some improvements that could be made:
* Using two radii instead of one, so a +x +z radius and a -x -z radius, changes the look on either side / shape
* Modulate their rarity based on some other factor like weirdness
* Tweak internal parameters
* Find the minimum height they still look good at. Currently really deep caves are bounded against having large cave spikes and this feature, which is a little lame, but might be for good reasons