### PR TITLE
Small tweak to avoid reimplementation in extending classes

### DIFF
--- a/src/main/java/net/dries007/tfc/common/items/DiscreteFluidContainerItem.java
+++ b/src/main/java/net/dries007/tfc/common/items/DiscreteFluidContainerItem.java
@@ -128,7 +128,7 @@ public class DiscreteFluidContainerItem extends Item
                 }
 
                 final ItemStack stack = new ItemStack(this);
-                stack.getCapability(Capabilities.FLUID_ITEM).ifPresent(c -> c.fill(new FluidStack(fluid, FluidHelpers.BUCKET_VOLUME), IFluidHandler.FluidAction.EXECUTE));
+                stack.getCapability(Capabilities.FLUID_ITEM).ifPresent(c -> c.fill(new FluidStack(fluid, capacity.get()), IFluidHandler.FluidAction.EXECUTE));
                 items.add(stack);
             }
         }


### PR DESCRIPTION
Use the actual capacity of the item rather than an assumption.