### PR TITLE
Minor Jade fixes

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/LoomBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/LoomBlockEntity.java
@@ -57,7 +57,6 @@ public class LoomBlockEntity extends InventoryBlockEntity<ItemStackHandler>
                         loom.inventory.setStackInSlot(SLOT_RECIPE, ItemStack.EMPTY);
                         loom.inventory.setStackInSlot(SLOT_OUTPUT, recipe.assemble(new ItemStackInventory(loom.inventory.getStackInSlot(SLOT_RECIPE))));
                     }
-                    loom.markForSync();
                 }
             }
         }

--- a/src/main/java/net/dries007/tfc/common/blockentities/PitKilnBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/PitKilnBlockEntity.java
@@ -31,6 +31,8 @@ import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.calendar.Calendars;
 
+import java.util.function.Predicate;
+
 public class PitKilnBlockEntity extends PlacedItemBlockEntity
 {
     public static final Vec3i[] DIAGONALS = new Vec3i[] {new Vec3i(1, 0, 1), new Vec3i(-1, 0, 1), new Vec3i(1, 0, -1), new Vec3i(-1, 0, -1)};
@@ -272,6 +274,14 @@ public class PitKilnBlockEntity extends PlacedItemBlockEntity
     public NonNullList<ItemStack> getStraws()
     {
         return strawItems;
+    }
+
+    public Long getLogsCount() {
+        return logItems.stream().filter(Predicate.not(ItemStack::isEmpty)).count();
+    }
+
+    public Long getStrawsCount() {
+        return strawItems.stream().filter(Predicate.not(ItemStack::isEmpty)).count();
     }
 
     private void cookContents()

--- a/src/main/java/net/dries007/tfc/compat/jade/common/BlockEntityTooltips.java
+++ b/src/main/java/net/dries007/tfc/compat/jade/common/BlockEntityTooltips.java
@@ -394,8 +394,8 @@ public final class BlockEntityTooltips
             }
             else
             {
-                tooltip.accept(Helpers.translatable("tfc.jade.straws", kiln.getStraws().size()));
-                tooltip.accept(Helpers.translatable("tfc.jade.logs", kiln.getLogs().size()));
+                tooltip.accept(Helpers.translatable("tfc.jade.straws", kiln.getStrawsCount()));
+                tooltip.accept(Helpers.translatable("tfc.jade.logs", kiln.getLogsCount()));
             }
         }
     }

--- a/src/main/java/net/dries007/tfc/compat/jade/common/BlockEntityTooltips.java
+++ b/src/main/java/net/dries007/tfc/compat/jade/common/BlockEntityTooltips.java
@@ -79,7 +79,7 @@ public final class BlockEntityTooltips
         registerBlock.accept(HOE_OVERLAY, FruitTreeBranchBlock.class);
         registerBlock.accept(HOE_OVERLAY, FruitTreeLeavesBlock.class);
         registerBlock.accept(HOE_OVERLAY, StationaryBerryBushBlock.class);
-        registerBlock.accept(HOE_OVERLAY, SpreadingBushBlock.class);
+//        registerBlock.accept(HOE_OVERLAY, SpreadingBushBlock.class);
         registerBlock.accept(LAMP, LampBlock.class);
         registerBlock.accept(NEST_BOX, NestBoxBlock.class);
         registerBlock.accept(PIT_KILN_INTERNAL, PitKilnBlock.class);
@@ -378,7 +378,7 @@ public final class BlockEntityTooltips
             final LoomRecipe recipe = loom.getRecipe();
             if (recipe != null)
             {
-                tooltip.accept(Helpers.translatable("tfc.jade.loom_progress", loom.getProgress(), recipe.getStepCount(), recipe.getResultItem()));
+                tooltip.accept(Helpers.translatable("tfc.jade.loom_progress", loom.getProgress(), recipe.getStepCount(), recipe.getResultItem().getDisplayName().getString()));
             }
         }
     };

--- a/src/main/java/net/dries007/tfc/compat/jade/common/EntityTooltips.java
+++ b/src/main/java/net/dries007/tfc/compat/jade/common/EntityTooltips.java
@@ -90,9 +90,10 @@ public final class EntityTooltips
                 tooltip.accept(Helpers.translatable("tfc.jade.can_mate"));
             }
 
+            final long totalDays = Calendars.get(level).getTotalDays();
             switch (age)
             {
-                case CHILD -> tooltip.accept(Helpers.translatable("tfc.jade.adulthood_days", animal.getDaysToAdulthood()));
+                case CHILD -> tooltip.accept(Helpers.translatable("tfc.jade.adulthood_days", animal.getDaysToAdulthood() - (totalDays - animal.getBirthDay()) + 1)); // Add 1 so tooltip doesn't say 0 days on day before birth
                 case ADULT -> tooltip.accept(Helpers.translatable("tfc.jade.animal_wear", String.format("%d%%", Math.round(100f * animal.getUses() / animal.getUsesToElderly()))));
                 case OLD -> tooltip.accept(Helpers.translatable("tfc.jade.old_animal"));
             }
@@ -105,7 +106,7 @@ public final class EntityTooltips
                 tooltip.accept(Helpers.translatable("tfc.tooltip.animal.pregnant", entity.getName().getString()));
 
                 final long totalDays = Calendars.get(level).getTotalDays();
-                tooltip.accept(Helpers.translatable("tfc.jade.gestation_progress", String.format("%d%%", Math.round(100f * (mammal.getPregnantTime() - totalDays) / mammal.getGestationDays()))));
+                tooltip.accept(Helpers.translatable("tfc.jade.gestation_progress", String.format("%d%%", Math.round(100f * (totalDays - mammal.getPregnantTime()) / mammal.getGestationDays()))));
             }
         }
         if (entity instanceof HorseProperties horse)


### PR DESCRIPTION
Fixes loom desync where client would be one 'progress' ahead of server (caused the progress counter on Jade to jump around). Haven't tested on server, only singleplayer, so might cause other issues that I'm unaware of.

Fixes #2117, I added one day to the display as otherwise it would show 0 days left on the day before the animal would grow up, if this is intended I will revert it.

Fixes #2114, As spreading bush extends staitionary bush it was getting the tooltips from both, if it needs a different tooltip from stationary bushes in the future a different fix will be needed.

Fixes pit klins tooltip displaying that all kilns always have 8 logs and straw.