### PR TITLE
Fix being unable to pick up pot & grill

### DIFF
--- a/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockFirePit.java
+++ b/src/main/java/net/dries007/tfc/objects/blocks/devices/BlockFirePit.java
@@ -326,7 +326,7 @@ public class BlockFirePit extends Block implements IBellowsConsumerBlock, ILight
             {
                 TFCGuiHandler.openGui(worldIn, pos, player, TFCGuiHandler.Type.FIRE_PIT);
             }
-            else if ((held == ItemStack.EMPTY) && (attachment != FirePitAttachment.NONE))
+            else if (held.isEmpty() && (attachment != FirePitAttachment.NONE))
             {
                 boolean anythingInTheInv = false;
                 if (tile != null)


### PR DESCRIPTION
#### The bug:
Sometimes the player is unable to crouch+right click on the firepit to pick up the attachment or receive damage.
#### Fix description:
The check `held == ItemStack.EMPTY` fails after installing a pot/grill onto firepit because in that case the player will hold a stack of `0 x AIR`, while `ItemStack.EMPTY` is `1 x AIR`. Other interactions that use `stack.split()` could also cause this to happen because they might also create a stack of 0 air in the player's hand.

I didn't see other uses of this comparison after a quick search, but it makes sense to double-check.