### PR TITLE
Improve barrel recipes

### DIFF
--- a/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipe.java
@@ -66,14 +66,21 @@ public abstract class BarrelRecipe implements ISimpleRecipe<BarrelBlockEntity.Ba
             {
                 multiplier = stack.getCount() / inputItem.count();
             }
-            else {
+            else
+            {
                 multiplier = Math.min(fluid.getAmount() / inputFluid.amount(), stack.getCount() / inputItem.count());
             }
 
             // Trim multiplier to a maximum fluid capacity of output
-            if (!outputFluid.isEmpty()) {
-                int max_multiplier = TFCConfig.SERVER.barrelCapacity.get() / outputFluid.getAmount();
-                multiplier = Math.min(multiplier, max_multiplier);
+            if (!outputFluid.isEmpty())
+            {
+                int capacity = TFCConfig.SERVER.barrelCapacity.get();
+                if (outputFluid.isFluidEqual(fluid))
+                {
+                    capacity -= fluid.getAmount();
+                }
+                int maxMultiplier = capacity / outputFluid.getAmount();
+                multiplier = Math.min(multiplier, maxMultiplier);
             }
 
             // Output items
@@ -108,7 +115,12 @@ public abstract class BarrelRecipe implements ISimpleRecipe<BarrelBlockEntity.Ba
             }
             else
             {
-                outputFluid.setAmount(Math.min(TFCConfig.SERVER.barrelCapacity.get(), outputFluid.getAmount() * multiplier));
+                int amount = outputFluid.getAmount() * multiplier;
+                if (outputFluid.isFluidEqual(fluid))
+                {
+                    amount = amount + fluid.getAmount();
+                }
+                outputFluid.setAmount(Math.min(TFCConfig.SERVER.barrelCapacity.get(), amount));
                 inventory.fill(outputFluid, IFluidHandler.FluidAction.EXECUTE);
             }
         });

--- a/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipe.java
@@ -57,7 +57,7 @@ public abstract class BarrelRecipe implements ISimpleRecipe<BarrelBlockEntity.Ba
             final FluidStack fluid = inventory.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.EXECUTE);
 
             // Calculate the multiplier in use for this recipe
-            final int multiplier;
+            int multiplier;
             if (inputItem.count() == 0)
             {
                 multiplier = fluid.getAmount() / inputFluid.amount();
@@ -66,9 +66,14 @@ public abstract class BarrelRecipe implements ISimpleRecipe<BarrelBlockEntity.Ba
             {
                 multiplier = stack.getCount() / inputItem.count();
             }
-            else
-            {
+            else {
                 multiplier = Math.min(fluid.getAmount() / inputFluid.amount(), stack.getCount() / inputItem.count());
+            }
+
+            // Trim multiplier to a maximum fluid capacity of output
+            if (!outputFluid.isEmpty()) {
+                int max_multiplier = TFCConfig.SERVER.barrelCapacity.get() / outputFluid.getAmount();
+                multiplier = Math.min(multiplier, max_multiplier);
             }
 
             // Output items


### PR DESCRIPTION
* Do not create more fluid in Barrel than its capacity
Example recipe for which the current code is incorrect:
```
{
  "type": "tfc:barrel_instant",
  "input_item": {
    "ingredient": {
      "item": "tfc:powder/flux"
    }
  },
  "input_fluid": {
    "ingredient": "minecraft:water",
    "amount": 500
  },
  "output_fluid": {
    "fluid": "tfc:limewater",
    "amount": 1000
  }
}
```
* Do not erase barrel output fluid if it is the same as the recipes
  * Means duplication recipes (like Firmalife yeast) will work correctly, and the input won't get erased. 
```
{
  "type": "tfc:barrel_sealed",
  "input_item": {
    "ingredient": {
      "tag": "tfc:makes_tannin"
    }
  },
  "input_fluid": {
    "ingredient": "tfc:tannin",
    "amount": 100
  },
  "output_fluid": {
    "fluid": "tfc:tannin",
    "amount": 500
  },
  "duration": 12
}
```

## TODO
- [x] Tests

Before fully committing and writing tests, I wanted to ask if this is even something you would be willing to accept.