### PR TITLE
Add .rotate() and .mirror() methods to directional blocks

### DIFF
--- a/src/main/java/net/dries007/tfc/client/render/blockentity/SheetPileBlockEntityRenderer.java
+++ b/src/main/java/net/dries007/tfc/client/render/blockentity/SheetPileBlockEntityRenderer.java
@@ -41,7 +41,7 @@ public class SheetPileBlockEntityRenderer implements BlockEntityRenderer<SheetPi
             {
                 if (state.getValue(DirectionPropertyBlock.getProperty(direction))) // The properties are authoritative on which sides should be rendered
                 {
-                    final Metal metal = pile.getOrCacheMetal(direction);
+                    final Metal metal = pile.getOrCacheMetal(SheetPileBlock.faceToIndex(state, direction));
                     final TextureAtlasSprite sprite = textureAtlas.apply(metal.getTextureId());
 
                     renderSheet(poseStack, sprite, builder, direction, packedLight, packedOverlay);

--- a/src/main/java/net/dries007/tfc/client/render/blockentity/SheetPileBlockEntityRenderer.java
+++ b/src/main/java/net/dries007/tfc/client/render/blockentity/SheetPileBlockEntityRenderer.java
@@ -41,7 +41,7 @@ public class SheetPileBlockEntityRenderer implements BlockEntityRenderer<SheetPi
             {
                 if (state.getValue(DirectionPropertyBlock.getProperty(direction))) // The properties are authoritative on which sides should be rendered
                 {
-                    final Metal metal = pile.getOrCacheMetal(SheetPileBlock.faceToIndex(state, direction));
+                    final Metal metal = pile.getOrCacheMetal(direction);
                     final TextureAtlasSprite sprite = textureAtlas.apply(metal.getTextureId());
 
                     renderSheet(poseStack, sprite, builder, direction, packedLight, packedOverlay);

--- a/src/main/java/net/dries007/tfc/common/blockentities/SheetPileBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/SheetPileBlockEntity.java
@@ -7,7 +7,6 @@
 package net.dries007.tfc.common.blockentities;
 
 import java.util.Arrays;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -32,7 +31,11 @@ public class SheetPileBlockEntity extends TFCBlockEntity
     private static final BooleanProperty MIRROR = SheetPileBlock.MIRROR;
 
     /**
-     * Apply internal rotation & mirroring to map requested face to an inventory slot.
+     * Sheet piles use a seperate rotation + mirror block state property to map their states (up, down, left, etc.) to an index.
+     * We do this as we want to be able to mirror and rotate the block (which only provide a state, not a block entity).
+     * So, this method takes the state and a requested direction, and converts it to a index into the (un-rotated) {@code stacks} array.
+     * <p>
+     * A mirror of {@code Mirror.NONE} and a rotation of {@code Direction.NORTH} is considered the reference frame of no-rotation, i.e. where the {@code stacks} is indexed by direction ordinal.
      */
     private int faceToIndex(Direction face)
     {

--- a/src/main/java/net/dries007/tfc/common/blockentities/SheetPileBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/SheetPileBlockEntity.java
@@ -9,7 +9,6 @@ package net.dries007.tfc.common.blockentities;
 import java.util.Arrays;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.ItemStack;
@@ -33,17 +32,15 @@ public class SheetPileBlockEntity extends TFCBlockEntity
         Arrays.fill(stacks, ItemStack.EMPTY);
     }
 
-    public void addSheet(Direction direction, ItemStack stack)
+    public void addSheet(int index, ItemStack stack)
     {
-        final int index = direction.ordinal();
         stacks[index] = stack;
         cachedMetals[index] = null;
         markForSync();
     }
 
-    public ItemStack removeSheet(Direction direction)
+    public ItemStack removeSheet(int index)
     {
-        final int index = direction.ordinal();
         final ItemStack stack = stacks[index];
         stacks[index] = ItemStack.EMPTY;
         cachedMetals[index] = null;
@@ -51,9 +48,9 @@ public class SheetPileBlockEntity extends TFCBlockEntity
         return stack;
     }
 
-    public ItemStack getSheet(Direction direction)
+    public ItemStack getSheet(int index)
     {
-        return stacks[direction.ordinal()].copy();
+        return stacks[index].copy();
     }
 
     /**
@@ -61,9 +58,8 @@ public class SheetPileBlockEntity extends TFCBlockEntity
      * The metal is defined by checking what metal the stack would melt into if heated.
      * Any other items turn into {@link Metal#unknown()}.
      */
-    public Metal getOrCacheMetal(Direction direction)
+    public Metal getOrCacheMetal(int index)
     {
-        final int index = direction.ordinal();
         final ItemStack stack = stacks[index];
 
         Metal metal = cachedMetals[index];

--- a/src/main/java/net/dries007/tfc/common/blocks/DirectionPropertyBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/DirectionPropertyBlock.java
@@ -15,6 +15,8 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -78,5 +80,37 @@ public interface DirectionPropertyBlock
                         .orElseGet(Shapes::empty)
                 )
             );
+    }
+
+    static BlockState rotate(BlockState state, Rotation rot)
+    {
+        return switch (rot)
+            {
+                case CLOCKWISE_90 -> state.setValue(NORTH, state.getValue(WEST))
+                    .setValue(EAST, state.getValue(NORTH))
+                    .setValue(SOUTH, state.getValue(EAST))
+                    .setValue(WEST, state.getValue(SOUTH));
+                case CLOCKWISE_180 -> state.setValue(NORTH, state.getValue(SOUTH))
+                    .setValue(EAST, state.getValue(WEST))
+                    .setValue(SOUTH, state.getValue(NORTH))
+                    .setValue(WEST, state.getValue(EAST));
+                case COUNTERCLOCKWISE_90 -> state.setValue(NORTH, state.getValue(EAST))
+                    .setValue(EAST, state.getValue(SOUTH))
+                    .setValue(SOUTH, state.getValue(WEST))
+                    .setValue(WEST, state.getValue(NORTH));
+                default -> state;
+            };
+    }
+
+    static BlockState mirror(BlockState state, Mirror mirror)
+    {
+        return switch (mirror)
+            {
+                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH))
+                    .setValue(SOUTH, state.getValue(NORTH));
+                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST))
+                    .setValue(WEST, state.getValue(EAST));
+                default -> state;
+            };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/DirectionPropertyBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/DirectionPropertyBlock.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import net.minecraft.core.Direction;

--- a/src/main/java/net/dries007/tfc/common/blocks/TFCBlockStateProperties.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/TFCBlockStateProperties.java
@@ -7,7 +7,6 @@
 package net.dries007.tfc.common.blocks;
 
 import java.util.stream.Stream;
-
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;

--- a/src/main/java/net/dries007/tfc/common/blocks/TFCBlockStateProperties.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/TFCBlockStateProperties.java
@@ -107,6 +107,7 @@ public class TFCBlockStateProperties
     public static final IntegerProperty HEAT_LEVEL = IntegerProperty.create("heat_level", 0, 7);
 
     public static final EnumProperty<Flow> FLOW = EnumProperty.create("flow", Flow.class);
+    public static final BooleanProperty MIRROR = BooleanProperty.create("mirror");
 
     private static final IntegerProperty[] STAGES = {STAGE_1, STAGE_2, STAGE_3, STAGE_4, STAGE_5, STAGE_6, STAGE_7, STAGE_8, STAGE_9, STAGE_10, STAGE_11, STAGE_12};
     private static final IntegerProperty[] AGES = {AGE_1, AGE_2, AGE_3, AGE_4, AGE_5, AGE_6, AGE_7, AGE_8};

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/AnvilBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/AnvilBlock.java
@@ -175,13 +175,15 @@ public class AnvilBlock extends DeviceBlock implements Tiered
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/AnvilBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/AnvilBlock.java
@@ -21,6 +21,8 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -169,5 +171,17 @@ public class AnvilBlock extends DeviceBlock implements Tiered
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder)
     {
         super.createBlockStateDefinition(builder.add(FACING));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BellowsBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BellowsBlock.java
@@ -16,9 +16,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
@@ -141,4 +139,15 @@ public class BellowsBlock extends DeviceBlock implements IForgeBlockExtension, E
         return false;
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
+    }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BellowsBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BellowsBlock.java
@@ -7,6 +7,7 @@
 package net.dries007.tfc.common.blocks.devices;
 
 import java.util.Random;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -16,7 +17,11 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
@@ -141,13 +146,15 @@ public class BellowsBlock extends DeviceBlock implements IForgeBlockExtension, E
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BellowsBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BellowsBlock.java
@@ -7,7 +7,6 @@
 package net.dries007.tfc.common.blocks.devices;
 
 import java.util.Random;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BlastFurnaceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BlastFurnaceBlock.java
@@ -107,7 +107,7 @@ public class BlastFurnaceBlock extends DeviceBlock implements IBellowsConsumer
     private static boolean isTier3SheetOrHigherInDirection(BlockState state, SheetPileBlockEntity pile, Direction face)
     {
         return state.getValue(DirectionPropertyBlock.getProperty(face))
-            && pile.getOrCacheMetal(face).getTier() >= Metal.Tier.TIER_III.ordinal();
+            && pile.getOrCacheMetal(SheetPileBlock.faceToIndex(state, face)).getTier() >= Metal.Tier.TIER_III.ordinal();
     }
 
     public BlastFurnaceBlock(ExtendedProperties properties)

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BlastFurnaceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BlastFurnaceBlock.java
@@ -7,7 +7,6 @@
 package net.dries007.tfc.common.blocks.devices;
 
 import java.util.function.BiPredicate;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BlastFurnaceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BlastFurnaceBlock.java
@@ -7,6 +7,7 @@
 package net.dries007.tfc.common.blocks.devices;
 
 import java.util.function.BiPredicate;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BlastFurnaceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BlastFurnaceBlock.java
@@ -108,7 +108,7 @@ public class BlastFurnaceBlock extends DeviceBlock implements IBellowsConsumer
     private static boolean isTier3SheetOrHigherInDirection(BlockState state, SheetPileBlockEntity pile, Direction face)
     {
         return state.getValue(DirectionPropertyBlock.getProperty(face))
-            && pile.getOrCacheMetal(SheetPileBlock.faceToIndex(state, face)).getTier() >= Metal.Tier.TIER_III.ordinal();
+            && pile.getOrCacheMetal(face).getTier() >= Metal.Tier.TIER_III.ordinal();
     }
 
     public BlastFurnaceBlock(ExtendedProperties properties)

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BloomeryBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BloomeryBlock.java
@@ -10,6 +10,7 @@ import java.util.EnumMap;
 import java.util.Random;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
@@ -35,7 +36,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.EntityBlockExtension;
@@ -44,6 +44,7 @@ import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.MultiBlock;
+import org.jetbrains.annotations.Nullable;
 
 public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
 {
@@ -92,8 +93,8 @@ public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
     private static final MultiBlock BLOOMERY_CHIMNEY; // Helper for determining how high the chimney is
     private static final EnumMap<Direction, MultiBlock> BASE_MULTIBLOCKS; // If one of those is true, bloomery is formed and can operate (has at least one chimney)
     private static final MultiBlock GATE_Z, GATE_X; // Determines if the gate can stay in place
-    private static final Direction[] NORTH_SOUTH_DOWN = new Direction[] {Direction.NORTH, Direction.SOUTH, Direction.DOWN};
-    private static final Direction[] EAST_WEST_DOWN = new Direction[] {Direction.EAST, Direction.WEST, Direction.DOWN};
+    private static final Direction[] NORTH_SOUTH_DOWN = new Direction[] { Direction.NORTH, Direction.SOUTH, Direction.DOWN };
+    private static final Direction[] EAST_WEST_DOWN = new Direction[] { Direction.EAST, Direction.WEST, Direction.DOWN };
 
     static
     {
@@ -124,11 +125,11 @@ public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
         // Gate center is the bloomery gate block
         GATE_Z = new MultiBlock()
             .match(origin, state -> state.is(TFCBlocks.BLOOMERY.get()) || state.isAir())
-            .matchEachDirection(origin, stoneMatcher, new Direction[] {Direction.WEST, Direction.EAST, Direction.UP, Direction.DOWN}, 1);
+            .matchEachDirection(origin, stoneMatcher, new Direction[] { Direction.WEST, Direction.EAST, Direction.UP, Direction.DOWN }, 1);
 
         GATE_X = new MultiBlock()
             .match(origin, state -> state.is(TFCBlocks.BLOOMERY.get()) || state.isAir())
-            .matchEachDirection(origin, stoneMatcher, new Direction[] {Direction.NORTH, Direction.SOUTH, Direction.UP, Direction.DOWN}, 1);
+            .matchEachDirection(origin, stoneMatcher, new Direction[] { Direction.NORTH, Direction.SOUTH, Direction.UP, Direction.DOWN }, 1);
     }
 
     public static boolean isBloomeryInsulationBlock(BlockState state)
@@ -264,13 +265,15 @@ public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BloomeryBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BloomeryBlock.java
@@ -268,7 +268,6 @@ public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
-
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror) {

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BloomeryBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BloomeryBlock.java
@@ -24,6 +24,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -258,5 +260,18 @@ public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
                     default -> throw new IllegalArgumentException("Bloomery has no facing direction");
                 };
         }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BloomeryBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BloomeryBlock.java
@@ -10,7 +10,6 @@ import java.util.EnumMap;
 import java.util.Random;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.particles.ParticleTypes;
@@ -36,6 +35,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.EntityBlockExtension;
@@ -44,7 +44,6 @@ import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.MultiBlock;
-import org.jetbrains.annotations.Nullable;
 
 public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
 {
@@ -93,8 +92,8 @@ public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
     private static final MultiBlock BLOOMERY_CHIMNEY; // Helper for determining how high the chimney is
     private static final EnumMap<Direction, MultiBlock> BASE_MULTIBLOCKS; // If one of those is true, bloomery is formed and can operate (has at least one chimney)
     private static final MultiBlock GATE_Z, GATE_X; // Determines if the gate can stay in place
-    private static final Direction[] NORTH_SOUTH_DOWN = new Direction[] { Direction.NORTH, Direction.SOUTH, Direction.DOWN };
-    private static final Direction[] EAST_WEST_DOWN = new Direction[] { Direction.EAST, Direction.WEST, Direction.DOWN };
+    private static final Direction[] NORTH_SOUTH_DOWN = new Direction[] {Direction.NORTH, Direction.SOUTH, Direction.DOWN};
+    private static final Direction[] EAST_WEST_DOWN = new Direction[] {Direction.EAST, Direction.WEST, Direction.DOWN};
 
     static
     {
@@ -125,11 +124,11 @@ public class BloomeryBlock extends DeviceBlock implements EntityBlockExtension
         // Gate center is the bloomery gate block
         GATE_Z = new MultiBlock()
             .match(origin, state -> state.is(TFCBlocks.BLOOMERY.get()) || state.isAir())
-            .matchEachDirection(origin, stoneMatcher, new Direction[] { Direction.WEST, Direction.EAST, Direction.UP, Direction.DOWN }, 1);
+            .matchEachDirection(origin, stoneMatcher, new Direction[] {Direction.WEST, Direction.EAST, Direction.UP, Direction.DOWN}, 1);
 
         GATE_X = new MultiBlock()
             .match(origin, state -> state.is(TFCBlocks.BLOOMERY.get()) || state.isAir())
-            .matchEachDirection(origin, stoneMatcher, new Direction[] { Direction.NORTH, Direction.SOUTH, Direction.UP, Direction.DOWN }, 1);
+            .matchEachDirection(origin, stoneMatcher, new Direction[] {Direction.NORTH, Direction.SOUTH, Direction.UP, Direction.DOWN}, 1);
     }
 
     public static boolean isBloomeryInsulationBlock(BlockState state)

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/JackOLanternBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/JackOLanternBlock.java
@@ -53,5 +53,4 @@ public class JackOLanternBlock extends CarvedPumpkinBlock implements EntityBlock
             }
         }
     }
-
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/JackOLanternBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/JackOLanternBlock.java
@@ -8,7 +8,6 @@ package net.dries007.tfc.common.blocks.devices;
 
 import java.util.Random;
 import java.util.function.Supplier;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Block;

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/JackOLanternBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/JackOLanternBlock.java
@@ -8,6 +8,7 @@ package net.dries007.tfc.common.blocks.devices;
 
 import java.util.Random;
 import java.util.function.Supplier;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Block;

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
@@ -72,7 +72,7 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
 
     public static int faceToIndex(BlockState state, Direction face)
     {
-        if (face == Direction.DOWN || face == Direction.UP)
+        if (face.getAxis() == Direction.Axis.Y)
         {
             return face.ordinal();
         }
@@ -305,42 +305,13 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
     @SuppressWarnings("deprecation")
     public BlockState rotate(BlockState state, Rotation rot)
     {
-        return switch (rot)
-            {
-                case CLOCKWISE_90 -> state.setValue(NORTH, state.getValue(WEST))
-                    .setValue(EAST, state.getValue(NORTH))
-                    .setValue(SOUTH, state.getValue(EAST))
-                    .setValue(WEST, state.getValue(SOUTH))
-                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
-                case CLOCKWISE_180 -> state.setValue(NORTH, state.getValue(SOUTH))
-                    .setValue(EAST, state.getValue(WEST))
-                    .setValue(SOUTH, state.getValue(NORTH))
-                    .setValue(WEST, state.getValue(EAST))
-                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
-                case COUNTERCLOCKWISE_90 -> state.setValue(NORTH, state.getValue(EAST))
-                    .setValue(EAST, state.getValue(SOUTH))
-                    .setValue(SOUTH, state.getValue(WEST))
-                    .setValue(WEST, state.getValue(NORTH))
-                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
-                default -> state;
-            };
+        return DirectionPropertyBlock.rotate(state, rot).setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
-        return switch (mirror)
-            {
-                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH))
-                    .setValue(SOUTH, state.getValue(NORTH))
-                    .setValue(FACING, mirror.mirror(state.getValue(FACING)))
-                    .cycle(MIRROR);
-                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST))
-                    .setValue(WEST, state.getValue(EAST))
-                    .setValue(FACING, mirror.mirror(state.getValue(FACING)))
-                    .cycle(MIRROR);
-                default -> state;
-            };
+        return DirectionPropertyBlock.mirror(state, mirror).setValue(FACING, mirror.mirror(state.getValue(FACING))).cycle(MIRROR);
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
@@ -315,11 +315,11 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
         return switch (mirror) {
             case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH))
                 .setValue(SOUTH, state.getValue(NORTH))
-                .rotate(mirror.getRotation(state.getValue(FACING)))
+                .setValue(FACING, mirror.mirror(state.getValue(FACING)))
                 .cycle(MIRROR);
             case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST))
                 .setValue(WEST, state.getValue(EAST))
-                .rotate(mirror.getRotation(state.getValue(FACING)))
+                .setValue(FACING, mirror.mirror(state.getValue(FACING)))
                 .cycle(MIRROR);
             default -> state;
         };

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
@@ -312,6 +312,10 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
+        if (mirror == Mirror.NONE) {
+            return state; // don't flip MIRROR bit
+        }
+
         return DirectionPropertyBlock.mirror(state, mirror).setValue(FACING, mirror.mirror(state.getValue(FACING))).cycle(MIRROR);
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
@@ -9,7 +9,7 @@ package net.dries007.tfc.common.blocks.devices;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.Predicate;
-
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -38,8 +38,8 @@ import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
-import com.google.common.collect.ImmutableMap;
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.blocks.EntityBlockExtension;
@@ -47,7 +47,6 @@ import net.dries007.tfc.common.blocks.ExtendedBlock;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
 import net.dries007.tfc.util.Helpers;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * A collection of arbitrary metal sheets in a single block

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SheetPileBlock.java
@@ -69,26 +69,6 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
         .put(DOWN, box(0, 0, 0, 16, 1, 16))
         .build();
 
-
-    public static int faceToIndex(BlockState state, Direction face)
-    {
-        if (face.getAxis() == Direction.Axis.Y)
-        {
-            return face.ordinal();
-        }
-
-        final Mirror mirror = state.getValue(MIRROR) ? Mirror.FRONT_BACK : Mirror.NONE;
-        final Rotation rot = switch (state.getValue(FACING))
-            {
-                case SOUTH -> Rotation.CLOCKWISE_180;
-                case EAST -> Rotation.COUNTERCLOCKWISE_90;
-                case WEST -> Rotation.CLOCKWISE_90;
-                default -> Rotation.NONE;
-            };
-
-        return mirror.mirror(rot.rotate(face)).ordinal();
-    }
-
     public static void removeSheet(Level level, BlockPos pos, BlockState state, Direction face, @Nullable Player player, boolean doDrops)
     {
         final BlockState newState = state.setValue(PROPERTY_BY_DIRECTION.get(face), false);
@@ -98,7 +78,7 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
         {
             level.getBlockEntity(pos, TFCBlockEntities.SHEET_PILE.get()).ifPresent(pile ->
             {
-                final ItemStack stack = pile.removeSheet(faceToIndex(state, face));
+                final ItemStack stack = pile.removeSheet(face);
                 popResourceFromFace(level, pos, face, stack);
             });
         }
@@ -119,7 +99,7 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
         final BlockState newState = state.setValue(PROPERTY_BY_DIRECTION.get(face), true);
 
         level.setBlock(pos, newState, Block.UPDATE_CLIENTS);
-        level.getBlockEntity(pos, TFCBlockEntities.SHEET_PILE.get()).ifPresent(pile -> pile.addSheet(faceToIndex(state, face), stack));
+        level.getBlockEntity(pos, TFCBlockEntities.SHEET_PILE.get()).ifPresent(pile -> pile.addSheet(face, stack));
 
         final SoundType placementSound = state.getSoundType(level, pos, null);
         level.playSound(null, pos, state.getSoundType(level, pos, null).getPlaceSound(), SoundSource.BLOCKS, (placementSound.getVolume() + 1.0f) / 2.0f, placementSound.getPitch() * 0.8f);
@@ -257,7 +237,7 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
             if (targetFace != null)
             {
                 return level.getBlockEntity(pos, TFCBlockEntities.SHEET_PILE.get())
-                    .map(pile -> pile.getSheet(faceToIndex(state, targetFace)))
+                    .map(pile -> pile.getSheet(targetFace))
                     .orElse(ItemStack.EMPTY);
             }
         }
@@ -312,7 +292,8 @@ public class SheetPileBlock extends ExtendedBlock implements EntityBlockExtensio
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
-        if (mirror == Mirror.NONE) {
+        if (mirror == Mirror.NONE)
+        {
             return state; // don't flip MIRROR bit
         }
 

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SluiceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SluiceBlock.java
@@ -185,7 +185,6 @@ public class SluiceBlock extends DeviceBlock implements EntityBlockExtension
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
-
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror) {

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SluiceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SluiceBlock.java
@@ -32,13 +32,13 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.EntityBlockExtension;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
 import net.dries007.tfc.util.Helpers;
+import org.jetbrains.annotations.Nullable;
 
 public class SluiceBlock extends DeviceBlock implements EntityBlockExtension
 {
@@ -181,13 +181,15 @@ public class SluiceBlock extends DeviceBlock implements EntityBlockExtension
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SluiceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SluiceBlock.java
@@ -21,6 +21,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -175,5 +177,18 @@ public class SluiceBlock extends DeviceBlock implements EntityBlockExtension
             }
         }
         super.wasExploded(level, pos, explosion);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SluiceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SluiceBlock.java
@@ -32,13 +32,13 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.EntityBlockExtension;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
 import net.dries007.tfc.util.Helpers;
-import org.jetbrains.annotations.Nullable;
 
 public class SluiceBlock extends DeviceBlock implements EntityBlockExtension
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/CreepingPlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/CreepingPlantBlock.java
@@ -7,7 +7,7 @@
 package net.dries007.tfc.common.blocks.plant;
 
 import java.util.Map;
-
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -25,14 +25,13 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.NotNull;
 
-import com.google.common.collect.ImmutableMap;
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.registry.RegistryPlant;
-import org.jetbrains.annotations.NotNull;
 
 public abstract class CreepingPlantBlock extends PlantBlock implements DirectionPropertyBlock
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/CreepingPlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/CreepingPlantBlock.java
@@ -155,27 +155,13 @@ public abstract class CreepingPlantBlock extends PlantBlock implements Direction
     @SuppressWarnings("deprecation")
     public BlockState rotate(BlockState state, Rotation rot)
     {
-        return switch (rot)
-            {
-                case CLOCKWISE_180 ->
-                    state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
-                case COUNTERCLOCKWISE_90 ->
-                    state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
-                case CLOCKWISE_90 ->
-                    state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
-                default -> state;
-            };
+        return DirectionPropertyBlock.rotate(state, rot);
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
-        return switch (mirror)
-            {
-                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
-                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
-                default -> super.mirror(state, mirror);
-            };
+        return DirectionPropertyBlock.mirror(state, mirror);
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/CreepingPlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/CreepingPlantBlock.java
@@ -16,9 +16,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.PipeBlock;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
@@ -147,5 +145,29 @@ public abstract class CreepingPlantBlock extends PlantBlock implements Direction
             }
         }
         return true;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return switch (rot) {
+            case CLOCKWISE_180 ->
+                state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
+            case COUNTERCLOCKWISE_90 ->
+                state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
+            case CLOCKWISE_90 ->
+                state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
+            default -> state;
+        };
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return switch (mirror) {
+            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
+            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
+            default -> super.mirror(state, mirror);
+        };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/CreepingPlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/CreepingPlantBlock.java
@@ -8,7 +8,6 @@ package net.dries007.tfc.common.blocks.plant;
 
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -16,13 +15,18 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.PipeBlock;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
+import com.google.common.collect.ImmutableMap;
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
@@ -149,25 +153,29 @@ public abstract class CreepingPlantBlock extends PlantBlock implements Direction
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
-        return switch (rot) {
-            case CLOCKWISE_180 ->
-                state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
-            case COUNTERCLOCKWISE_90 ->
-                state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
-            case CLOCKWISE_90 ->
-                state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
-            default -> state;
-        };
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
+        return switch (rot)
+            {
+                case CLOCKWISE_180 ->
+                    state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
+                case COUNTERCLOCKWISE_90 ->
+                    state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
+                case CLOCKWISE_90 ->
+                    state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
+                default -> state;
+            };
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
-        return switch (mirror) {
-            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
-            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
-            default -> super.mirror(state, mirror);
-        };
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
+        return switch (mirror)
+            {
+                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
+                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
+                default -> super.mirror(state, mirror);
+            };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/EpiphytePlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/EpiphytePlantBlock.java
@@ -8,31 +8,30 @@ package net.dries007.tfc.common.blocks.plant;
 
 import java.util.Map;
 
-import net.dries007.tfc.common.blocks.ExtendedProperties;
-import net.dries007.tfc.util.registry.RegistryPlant;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.Rotation;
-import org.jetbrains.annotations.Nullable;
-
-import com.google.common.collect.ImmutableMap;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.tags.BlockTags;
-import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.phys.shapes.CollisionContext;
-import net.minecraft.world.phys.shapes.VoxelShape;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.phys.shapes.CollisionContext;
+import net.minecraft.world.phys.shapes.VoxelShape;
 
+import com.google.common.collect.ImmutableMap;
+import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.util.Helpers;
+import net.dries007.tfc.util.registry.RegistryPlant;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class EpiphytePlantBlock extends PlantBlock
 {
@@ -118,13 +117,15 @@ public abstract class EpiphytePlantBlock extends PlantBlock
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/EpiphytePlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/EpiphytePlantBlock.java
@@ -10,6 +10,8 @@ import java.util.Map;
 
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.util.registry.RegistryPlant;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import org.jetbrains.annotations.Nullable;
 
 import com.google.common.collect.ImmutableMap;
@@ -112,5 +114,18 @@ public abstract class EpiphytePlantBlock extends PlantBlock
     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder)
     {
         super.createBlockStateDefinition(builder.add(FACING));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/EpiphytePlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/EpiphytePlantBlock.java
@@ -7,7 +7,7 @@
 package net.dries007.tfc.common.blocks.plant;
 
 import java.util.Map;
-
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.tags.BlockTags;
@@ -26,12 +26,11 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
-import com.google.common.collect.ImmutableMap;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.registry.RegistryPlant;
-import org.jetbrains.annotations.Nullable;
 
 public abstract class EpiphytePlantBlock extends PlantBlock
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/EpiphytePlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/EpiphytePlantBlock.java
@@ -122,7 +122,6 @@ public abstract class EpiphytePlantBlock extends PlantBlock
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
-
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror) {

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeBlock.java
@@ -153,25 +153,29 @@ public abstract class KelpTreeBlock extends PipeBlock implements IFluidLoggable
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
-        return switch (rot) {
-            case CLOCKWISE_180 ->
-                state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
-            case COUNTERCLOCKWISE_90 ->
-                state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
-            case CLOCKWISE_90 ->
-                state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
-            default -> state;
-        };
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
+        return switch (rot)
+            {
+                case CLOCKWISE_180 ->
+                    state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
+                case COUNTERCLOCKWISE_90 ->
+                    state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
+                case CLOCKWISE_90 ->
+                    state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
+                default -> state;
+            };
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
-        return switch (mirror) {
-            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
-            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
-            default -> super.mirror(state, mirror);
-        };
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
+        return switch (mirror)
+            {
+                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
+                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
+                default -> super.mirror(state, mirror);
+            };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeBlock.java
@@ -18,7 +18,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.PipeBlock;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -146,5 +148,30 @@ public abstract class KelpTreeBlock extends PipeBlock implements IFluidLoggable
         {
             level.destroyBlock(pos, true);
         }
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return switch (rot) {
+            case CLOCKWISE_180 ->
+                state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
+            case COUNTERCLOCKWISE_90 ->
+                state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
+            case CLOCKWISE_90 ->
+                state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
+            default -> state;
+        };
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return switch (mirror) {
+            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
+            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
+            default -> super.mirror(state, mirror);
+        };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeBlock.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.level.material.Fluids;
 
 import net.dries007.tfc.common.TFCTags;
+import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.fluids.FluidHelpers;
 import net.dries007.tfc.common.fluids.FluidProperty;
 import net.dries007.tfc.common.fluids.IFluidLoggable;
@@ -155,27 +156,13 @@ public abstract class KelpTreeBlock extends PipeBlock implements IFluidLoggable
     @SuppressWarnings("deprecation")
     public BlockState rotate(BlockState state, Rotation rot)
     {
-        return switch (rot)
-            {
-                case CLOCKWISE_180 ->
-                    state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
-                case COUNTERCLOCKWISE_90 ->
-                    state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
-                case CLOCKWISE_90 ->
-                    state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
-                default -> state;
-            };
+        return DirectionPropertyBlock.rotate(state, rot);
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
-        return switch (mirror)
-            {
-                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
-                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
-                default -> super.mirror(state, mirror);
-            };
+        return DirectionPropertyBlock.mirror(state, mirror);
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeBlock.java
@@ -7,7 +7,6 @@
 package net.dries007.tfc.common.blocks.plant;
 
 import java.util.Random;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeFlowerBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeFlowerBlock.java
@@ -19,6 +19,8 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -399,5 +401,18 @@ public abstract class KelpTreeFlowerBlock extends Block implements IFluidLoggabl
     protected Supplier<? extends Block> getBodyBlock()
     {
         return bodyBlock;
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeFlowerBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeFlowerBlock.java
@@ -406,13 +406,15 @@ public abstract class KelpTreeFlowerBlock extends Block implements IFluidLoggabl
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeFlowerBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/KelpTreeFlowerBlock.java
@@ -8,7 +8,6 @@ package net.dries007.tfc.common.blocks.plant;
 
 import java.util.Random;
 import java.util.function.Supplier;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -33,6 +32,7 @@ import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.common.ForgeHooks;
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
@@ -42,7 +42,6 @@ import net.dries007.tfc.common.fluids.FluidProperty;
 import net.dries007.tfc.common.fluids.IFluidLoggable;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Almost all methods in here are adapted from {@link net.minecraft.world.level.block.ChorusFlowerBlock}

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/FruitTreeBranchBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/FruitTreeBranchBlock.java
@@ -20,7 +20,9 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.PipeBlock;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
@@ -149,5 +151,30 @@ public class FruitTreeBranchBlock extends PipeBlock implements IForgeBlockExtens
     public ExtendedProperties getExtendedProperties()
     {
         return properties;
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return switch (rot) {
+            case CLOCKWISE_180 ->
+                state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
+            case COUNTERCLOCKWISE_90 ->
+                state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
+            case CLOCKWISE_90 ->
+                state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
+            default -> state;
+        };
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return switch (mirror) {
+            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
+            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
+            default -> super.mirror(state, mirror);
+        };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/FruitTreeBranchBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/FruitTreeBranchBlock.java
@@ -156,25 +156,29 @@ public class FruitTreeBranchBlock extends PipeBlock implements IForgeBlockExtens
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
-        return switch (rot) {
-            case CLOCKWISE_180 ->
-                state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
-            case COUNTERCLOCKWISE_90 ->
-                state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
-            case CLOCKWISE_90 ->
-                state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
-            default -> state;
-        };
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
+        return switch (rot)
+            {
+                case CLOCKWISE_180 ->
+                    state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
+                case COUNTERCLOCKWISE_90 ->
+                    state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
+                case CLOCKWISE_90 ->
+                    state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
+                default -> state;
+            };
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
-        return switch (mirror) {
-            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
-            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
-            default -> super.mirror(state, mirror);
-        };
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
+        return switch (mirror)
+            {
+                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
+                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
+                default -> super.mirror(state, mirror);
+            };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/FruitTreeBranchBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/FruitTreeBranchBlock.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 
 import net.dries007.tfc.common.TFCTags;
+import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.IForgeBlockExtension;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
@@ -158,27 +159,13 @@ public class FruitTreeBranchBlock extends PipeBlock implements IForgeBlockExtens
     @SuppressWarnings("deprecation")
     public BlockState rotate(BlockState state, Rotation rot)
     {
-        return switch (rot)
-            {
-                case CLOCKWISE_180 ->
-                    state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
-                case COUNTERCLOCKWISE_90 ->
-                    state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
-                case CLOCKWISE_90 ->
-                    state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
-                default -> state;
-            };
+        return DirectionPropertyBlock.rotate(state, rot);
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
-        return switch (mirror)
-            {
-                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
-                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
-                default -> super.mirror(state, mirror);
-            };
+        return DirectionPropertyBlock.mirror(state, mirror);
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/FruitTreeBranchBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/FruitTreeBranchBlock.java
@@ -9,7 +9,6 @@ package net.dries007.tfc.common.blocks.plant.fruit;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/SpreadingCaneBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/SpreadingCaneBlock.java
@@ -141,7 +141,6 @@ public class SpreadingCaneBlock extends SpreadingBushBlock implements IBushBlock
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
-
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror) {

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/SpreadingCaneBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/SpreadingCaneBlock.java
@@ -8,6 +8,9 @@ package net.dries007.tfc.common.blocks.plant.fruit;
 
 import java.util.Random;
 import java.util.function.Supplier;
+
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.core.BlockPos;
@@ -130,5 +133,18 @@ public class SpreadingCaneBlock extends SpreadingBushBlock implements IBushBlock
     public ItemStack getCloneItemStack(BlockState state, HitResult target, BlockGetter level, BlockPos pos, Player player)
     {
         return new ItemStack(companion.get());
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/SpreadingCaneBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/SpreadingCaneBlock.java
@@ -8,7 +8,6 @@ package net.dries007.tfc.common.blocks.plant.fruit;
 
 import java.util.Random;
 import java.util.function.Supplier;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -27,13 +26,13 @@ import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.NotNull;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.climate.ClimateRange;
-import org.jetbrains.annotations.NotNull;
 
 public class SpreadingCaneBlock extends SpreadingBushBlock implements IBushBlock
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/SpreadingCaneBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/fruit/SpreadingCaneBlock.java
@@ -9,10 +9,6 @@ package net.dries007.tfc.common.blocks.plant.fruit;
 import java.util.Random;
 import java.util.function.Supplier;
 
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.Rotation;
-import org.jetbrains.annotations.NotNull;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
@@ -22,6 +18,8 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -35,6 +33,7 @@ import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.climate.ClimateRange;
+import org.jetbrains.annotations.NotNull;
 
 public class SpreadingCaneBlock extends SpreadingBushBlock implements IBushBlock
 {
@@ -137,13 +136,15 @@ public class SpreadingCaneBlock extends SpreadingBushBlock implements IBushBlock
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
@@ -7,7 +7,6 @@
 package net.dries007.tfc.common.blocks.rock;
 
 import java.util.Random;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -33,13 +32,13 @@ import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
 import net.dries007.tfc.common.fluids.FluidHelpers;
 import net.dries007.tfc.common.fluids.FluidProperty;
 import net.dries007.tfc.common.fluids.IFluidLoggable;
-import org.jetbrains.annotations.Nullable;
 
 
 public class AqueductBlock extends HorizontalDirectionalBlock implements IFluidLoggable
@@ -61,7 +60,7 @@ public class AqueductBlock extends HorizontalDirectionalBlock implements IFluidL
         final VoxelShape west = box(0, 10, 4, 4, 16, 12);
 
         // Must match Direction.data2d order
-        final VoxelShape[] directions = new VoxelShape[] { south, west, north, east };
+        final VoxelShape[] directions = new VoxelShape[] {south, west, north, east};
 
         final VoxelShape base = Shapes.or(
             box(0, 0, 0, 16, 10, 16),

--- a/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
@@ -332,40 +332,13 @@ public class AqueductBlock extends Block implements IFluidLoggable
     @SuppressWarnings("deprecation")
     public BlockState rotate(BlockState state, Rotation rot)
     {
-        return switch (rot)
-            {
-                case CLOCKWISE_90 -> state.setValue(NORTH, state.getValue(WEST))
-                    .setValue(EAST, state.getValue(NORTH))
-                    .setValue(SOUTH, state.getValue(EAST))
-                    .setValue(WEST, state.getValue(SOUTH))
-                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
-                case CLOCKWISE_180 -> state.setValue(NORTH, state.getValue(SOUTH))
-                    .setValue(EAST, state.getValue(WEST))
-                    .setValue(SOUTH, state.getValue(NORTH))
-                    .setValue(WEST, state.getValue(EAST))
-                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
-                case COUNTERCLOCKWISE_90 -> state.setValue(NORTH, state.getValue(EAST))
-                    .setValue(EAST, state.getValue(SOUTH))
-                    .setValue(SOUTH, state.getValue(WEST))
-                    .setValue(WEST, state.getValue(NORTH))
-                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
-                default -> state;
-            };
+        return DirectionPropertyBlock.rotate(state, rot).setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
-        return switch (mirror)
-            {
-                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH))
-                    .setValue(SOUTH, state.getValue(NORTH))
-                    .setValue(FACING, mirror.mirror(state.getValue(FACING)));
-                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST))
-                    .setValue(WEST, state.getValue(EAST))
-                    .setValue(FACING, mirror.mirror(state.getValue(FACING)));
-                default -> super.mirror(state, mirror);
-            };
+        return DirectionPropertyBlock.mirror(state, mirror).setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
@@ -7,6 +7,7 @@
 package net.dries007.tfc.common.blocks.rock;
 
 import java.util.Random;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -16,7 +17,10 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.block.*;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -326,38 +330,42 @@ public class AqueductBlock extends Block implements IFluidLoggable
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
-        return switch (rot) {
-            case CLOCKWISE_90 -> state.setValue(NORTH, state.getValue(WEST))
-                .setValue(EAST, state.getValue(NORTH))
-                .setValue(SOUTH, state.getValue(EAST))
-                .setValue(WEST, state.getValue(SOUTH))
-                .setValue(FACING, rot.rotate(state.getValue(FACING)));
-            case CLOCKWISE_180 -> state.setValue(NORTH, state.getValue(SOUTH))
-                .setValue(EAST, state.getValue(WEST))
-                .setValue(SOUTH, state.getValue(NORTH))
-                .setValue(WEST, state.getValue(EAST))
-                .setValue(FACING, rot.rotate(state.getValue(FACING)));
-            case COUNTERCLOCKWISE_90 -> state.setValue(NORTH, state.getValue(EAST))
-                .setValue(EAST, state.getValue(SOUTH))
-                .setValue(SOUTH, state.getValue(WEST))
-                .setValue(WEST, state.getValue(NORTH))
-                .setValue(FACING, rot.rotate(state.getValue(FACING)));
-            default -> state;
-        };
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
+        return switch (rot)
+            {
+                case CLOCKWISE_90 -> state.setValue(NORTH, state.getValue(WEST))
+                    .setValue(EAST, state.getValue(NORTH))
+                    .setValue(SOUTH, state.getValue(EAST))
+                    .setValue(WEST, state.getValue(SOUTH))
+                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
+                case CLOCKWISE_180 -> state.setValue(NORTH, state.getValue(SOUTH))
+                    .setValue(EAST, state.getValue(WEST))
+                    .setValue(SOUTH, state.getValue(NORTH))
+                    .setValue(WEST, state.getValue(EAST))
+                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
+                case COUNTERCLOCKWISE_90 -> state.setValue(NORTH, state.getValue(EAST))
+                    .setValue(EAST, state.getValue(SOUTH))
+                    .setValue(SOUTH, state.getValue(WEST))
+                    .setValue(WEST, state.getValue(NORTH))
+                    .setValue(FACING, rot.rotate(state.getValue(FACING)));
+                default -> state;
+            };
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
-        return switch (mirror) {
-            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH))
-                .setValue(SOUTH, state.getValue(NORTH))
-                .setValue(FACING, mirror.mirror(state.getValue(FACING)));
-            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST))
-                .setValue(WEST, state.getValue(EAST))
-                .setValue(FACING, mirror.mirror(state.getValue(FACING)));
-            default -> super.mirror(state, mirror);
-        };
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
+        return switch (mirror)
+            {
+                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH))
+                    .setValue(SOUTH, state.getValue(NORTH))
+                    .setValue(FACING, mirror.mirror(state.getValue(FACING)));
+                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST))
+                    .setValue(WEST, state.getValue(EAST))
+                    .setValue(FACING, mirror.mirror(state.getValue(FACING)));
+                default -> super.mirror(state, mirror);
+            };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
@@ -16,13 +16,12 @@ import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
@@ -39,12 +38,13 @@ import net.dries007.tfc.common.fluids.IFluidLoggable;
 import org.jetbrains.annotations.Nullable;
 
 
-public class AqueductBlock extends HorizontalDirectionalBlock implements IFluidLoggable
+public class AqueductBlock extends Block implements IFluidLoggable
 {
     public static final BooleanProperty NORTH = BlockStateProperties.NORTH;
     public static final BooleanProperty EAST = BlockStateProperties.EAST;
     public static final BooleanProperty SOUTH = BlockStateProperties.SOUTH;
     public static final BooleanProperty WEST = BlockStateProperties.WEST;
+    public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 
     public static final FluidProperty FLUID = TFCBlockStateProperties.ALL_WATER;
 
@@ -322,5 +322,42 @@ public class AqueductBlock extends HorizontalDirectionalBlock implements IFluidL
                 tickAllAdjacentAqueducts(level, pos, LONG_TICK_DELAY, state.getValue(FACING));
             }
         }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return switch (rot) {
+            case CLOCKWISE_90 -> state.setValue(NORTH, state.getValue(WEST))
+                .setValue(EAST, state.getValue(NORTH))
+                .setValue(SOUTH, state.getValue(EAST))
+                .setValue(WEST, state.getValue(SOUTH))
+                .setValue(FACING, rot.rotate(state.getValue(FACING)));
+            case CLOCKWISE_180 -> state.setValue(NORTH, state.getValue(SOUTH))
+                .setValue(EAST, state.getValue(WEST))
+                .setValue(SOUTH, state.getValue(NORTH))
+                .setValue(WEST, state.getValue(EAST))
+                .setValue(FACING, rot.rotate(state.getValue(FACING)));
+            case COUNTERCLOCKWISE_90 -> state.setValue(NORTH, state.getValue(EAST))
+                .setValue(EAST, state.getValue(SOUTH))
+                .setValue(SOUTH, state.getValue(WEST))
+                .setValue(WEST, state.getValue(NORTH))
+                .setValue(FACING, rot.rotate(state.getValue(FACING)));
+            default -> state;
+        };
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return switch (mirror) {
+            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH))
+                .setValue(SOUTH, state.getValue(NORTH))
+                .setValue(FACING, mirror.mirror(state.getValue(FACING)));
+            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST))
+                .setValue(WEST, state.getValue(EAST))
+                .setValue(FACING, mirror.mirror(state.getValue(FACING)));
+            default -> super.mirror(state, mirror);
+        };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/rock/AqueductBlock.java
@@ -19,13 +19,13 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.material.FlowingFluid;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.FluidState;
@@ -42,13 +42,12 @@ import net.dries007.tfc.common.fluids.IFluidLoggable;
 import org.jetbrains.annotations.Nullable;
 
 
-public class AqueductBlock extends Block implements IFluidLoggable
+public class AqueductBlock extends HorizontalDirectionalBlock implements IFluidLoggable
 {
     public static final BooleanProperty NORTH = BlockStateProperties.NORTH;
     public static final BooleanProperty EAST = BlockStateProperties.EAST;
     public static final BooleanProperty SOUTH = BlockStateProperties.SOUTH;
     public static final BooleanProperty WEST = BlockStateProperties.WEST;
-    public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 
     public static final FluidProperty FLUID = TFCBlockStateProperties.ALL_WATER;
 
@@ -329,16 +328,15 @@ public class AqueductBlock extends Block implements IFluidLoggable
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public BlockState rotate(BlockState state, Rotation rot)
     {
-        return DirectionPropertyBlock.rotate(state, rot).setValue(FACING, rot.rotate(state.getValue(FACING)));
+        return DirectionPropertyBlock.rotate(super.rotate(state, rot), rot);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
+        // super method uses rotate which breaks the orientation of asymmetrical blocks
         return DirectionPropertyBlock.mirror(state, mirror).setValue(FACING, mirror.mirror(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
@@ -32,6 +32,7 @@ import net.minecraftforge.common.ToolActions;
 
 import com.google.common.collect.ImmutableMap;
 import net.dries007.tfc.common.TFCTags;
+import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
@@ -232,27 +233,13 @@ public class ConnectedGrassBlock extends Block implements IGrassBlock
     @SuppressWarnings("deprecation")
     public BlockState rotate(BlockState state, Rotation rot)
     {
-        return switch (rot)
-            {
-                case CLOCKWISE_180 ->
-                    state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
-                case COUNTERCLOCKWISE_90 ->
-                    state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
-                case CLOCKWISE_90 ->
-                    state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
-                default -> state;
-            };
+        return DirectionPropertyBlock.rotate(state, rot);
     }
 
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror)
     {
-        return switch (mirror)
-            {
-                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
-                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
-                default -> super.mirror(state, mirror);
-            };
+        return DirectionPropertyBlock.mirror(state, mirror);
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
@@ -9,7 +9,7 @@ package net.dries007.tfc.common.blocks.soil;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.Supplier;
-
+import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -29,15 +29,14 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
+import org.jetbrains.annotations.Nullable;
 
-import com.google.common.collect.ImmutableMap;
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.DirectionPropertyBlock;
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.registry.RegistrySoilVariant;
-import org.jetbrains.annotations.Nullable;
 
 public class ConnectedGrassBlock extends Block implements IGrassBlock
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
@@ -22,6 +22,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -222,5 +224,29 @@ public class ConnectedGrassBlock extends Block implements IGrassBlock
     protected BlockState updateStateFromDirection(BlockGetter worldIn, BlockPos pos, BlockState stateIn, Direction direction)
     {
         return stateIn.setValue(PROPERTIES.get(direction), worldIn.getBlockState(pos.relative(direction).below()).getBlock() instanceof IGrassBlock);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return switch (rot) {
+            case CLOCKWISE_180 ->
+                state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
+            case COUNTERCLOCKWISE_90 ->
+                state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
+            case CLOCKWISE_90 ->
+                state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
+            default -> state;
+        };
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return switch (mirror) {
+            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
+            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
+            default -> super.mirror(state, mirror);
+        };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.function.Supplier;
 
-import com.google.common.collect.ImmutableMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -31,6 +30,7 @@ import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.ToolActions;
 
+import com.google.common.collect.ImmutableMap;
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.config.TFCConfig;
@@ -51,8 +51,10 @@ public class ConnectedGrassBlock extends Block implements IGrassBlock
     private static final Map<Direction, BooleanProperty> PROPERTIES = ImmutableMap.of(Direction.NORTH, NORTH, Direction.EAST, EAST, Direction.WEST, WEST, Direction.SOUTH, SOUTH);
 
     private final Supplier<? extends Block> dirt;
-    @Nullable private final Supplier<? extends Block> path;
-    @Nullable private final Supplier<? extends Block> farmland;
+    @Nullable
+    private final Supplier<? extends Block> path;
+    @Nullable
+    private final Supplier<? extends Block> farmland;
 
     public ConnectedGrassBlock(Properties properties, Supplier<? extends Block> dirt, @Nullable Supplier<? extends Block> path, @Nullable Supplier<? extends Block> farmland)
     {
@@ -228,25 +230,29 @@ public class ConnectedGrassBlock extends Block implements IGrassBlock
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
-        return switch (rot) {
-            case CLOCKWISE_180 ->
-                state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
-            case COUNTERCLOCKWISE_90 ->
-                state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
-            case CLOCKWISE_90 ->
-                state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
-            default -> state;
-        };
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
+        return switch (rot)
+            {
+                case CLOCKWISE_180 ->
+                    state.setValue(NORTH, state.getValue(SOUTH)).setValue(EAST, state.getValue(WEST)).setValue(SOUTH, state.getValue(NORTH)).setValue(WEST, state.getValue(EAST));
+                case COUNTERCLOCKWISE_90 ->
+                    state.setValue(NORTH, state.getValue(EAST)).setValue(EAST, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(WEST)).setValue(WEST, state.getValue(NORTH));
+                case CLOCKWISE_90 ->
+                    state.setValue(NORTH, state.getValue(WEST)).setValue(EAST, state.getValue(NORTH)).setValue(SOUTH, state.getValue(EAST)).setValue(WEST, state.getValue(SOUTH));
+                default -> state;
+            };
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
-        return switch (mirror) {
-            case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
-            case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
-            default -> super.mirror(state, mirror);
-        };
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
+        return switch (mirror)
+            {
+                case LEFT_RIGHT -> state.setValue(NORTH, state.getValue(SOUTH)).setValue(SOUTH, state.getValue(NORTH));
+                case FRONT_BACK -> state.setValue(EAST, state.getValue(WEST)).setValue(WEST, state.getValue(EAST));
+                default -> super.mirror(state, mirror);
+            };
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/BookshelfBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/BookshelfBlock.java
@@ -112,13 +112,15 @@ public class BookshelfBlock extends DeviceBlock
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/BookshelfBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/BookshelfBlock.java
@@ -7,7 +7,6 @@
 package net.dries007.tfc.common.blocks.wood;
 
 import java.util.Random;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -27,6 +26,7 @@ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.phys.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.blockentities.BookshelfBlockEntity;
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
@@ -34,7 +34,6 @@ import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
 import net.dries007.tfc.common.blocks.devices.DeviceBlock;
 import net.dries007.tfc.util.Helpers;
-import org.jetbrains.annotations.Nullable;
 
 public class BookshelfBlock extends DeviceBlock
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/BookshelfBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/BookshelfBlock.java
@@ -116,7 +116,6 @@ public class BookshelfBlock extends DeviceBlock
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
-
     @Override
     @SuppressWarnings("deprecation")
     public BlockState mirror(BlockState state, Mirror mirror) {

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/BookshelfBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/BookshelfBlock.java
@@ -19,6 +19,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -106,5 +108,18 @@ public class BookshelfBlock extends DeviceBlock
     public int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos)
     {
         return state.getValue(LAST_INTERACTION_BOOK_SLOT);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/ScribingTableBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/ScribingTableBlock.java
@@ -27,12 +27,12 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.IForgeBlockExtension;
 import net.dries007.tfc.common.container.ScribingTableContainer;
 import net.dries007.tfc.util.Helpers;
-import org.jetbrains.annotations.Nullable;
 
 public class ScribingTableBlock extends HorizontalDirectionalBlock implements IForgeBlockExtension
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/ScribingTableBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/ScribingTableBlock.java
@@ -9,7 +9,6 @@ package net.dries007.tfc.common.blocks.wood;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/TFCLoomBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/TFCLoomBlock.java
@@ -6,11 +6,6 @@
 
 package net.dries007.tfc.common.blocks.wood;
 
-import net.dries007.tfc.common.blocks.devices.BottomSupportedDeviceBlock;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.Rotation;
-import org.jetbrains.annotations.Nullable;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
@@ -22,6 +17,8 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
@@ -31,6 +28,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
+import net.dries007.tfc.common.blocks.devices.BottomSupportedDeviceBlock;
+import org.jetbrains.annotations.Nullable;
 
 public class TFCLoomBlock extends BottomSupportedDeviceBlock
 {
@@ -90,13 +89,15 @@ public class TFCLoomBlock extends BottomSupportedDeviceBlock
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/TFCLoomBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/TFCLoomBlock.java
@@ -7,6 +7,8 @@
 package net.dries007.tfc.common.blocks.wood;
 
 import net.dries007.tfc.common.blocks.devices.BottomSupportedDeviceBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.core.BlockPos;
@@ -86,4 +88,15 @@ public class TFCLoomBlock extends BottomSupportedDeviceBlock
         builder.add(FACING);
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
+    }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/TFCLoomBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/TFCLoomBlock.java
@@ -25,11 +25,11 @@ import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.devices.BottomSupportedDeviceBlock;
-import org.jetbrains.annotations.Nullable;
 
 public class TFCLoomBlock extends BottomSupportedDeviceBlock
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/ToolRackBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/ToolRackBlock.java
@@ -6,6 +6,7 @@
 
 package net.dries007.tfc.common.blocks.wood;
 
+import net.minecraft.world.level.block.*;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.world.level.material.FluidState;
@@ -24,10 +25,6 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
@@ -167,5 +164,17 @@ public class ToolRackBlock extends DeviceBlock implements SimpleWaterloggedBlock
             slot += 2;
         }
         return slot;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState rotate(BlockState state, Rotation rot) {
+        return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/ToolRackBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/ToolRackBlock.java
@@ -33,12 +33,12 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.blockentities.ToolRackBlockEntity;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.devices.DeviceBlock;
-import org.jetbrains.annotations.Nullable;
 
 public class ToolRackBlock extends DeviceBlock implements SimpleWaterloggedBlock
 {

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/ToolRackBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/ToolRackBlock.java
@@ -6,26 +6,29 @@
 
 package net.dries007.tfc.common.blocks.wood;
 
-import net.minecraft.world.level.block.*;
-import org.jetbrains.annotations.Nullable;
-
-import net.minecraft.world.level.material.FluidState;
-import net.minecraft.world.level.material.Fluids;
-import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.level.block.state.properties.BooleanProperty;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
-import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.SimpleWaterloggedBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
@@ -35,6 +38,7 @@ import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.blockentities.ToolRackBlockEntity;
 import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.devices.DeviceBlock;
+import org.jetbrains.annotations.Nullable;
 
 public class ToolRackBlock extends DeviceBlock implements SimpleWaterloggedBlock
 {
@@ -168,13 +172,15 @@ public class ToolRackBlock extends DeviceBlock implements SimpleWaterloggedBlock
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState rotate(BlockState state, Rotation rot) {
+    public BlockState rotate(BlockState state, Rotation rot)
+    {
         return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
     }
 
     @Override
     @SuppressWarnings("deprecation")
-    public BlockState mirror(BlockState state, Mirror mirror) {
+    public BlockState mirror(BlockState state, Mirror mirror)
+    {
         return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 }


### PR DESCRIPTION
Implements missing rotation and mirror methods on several blocks including:

 - Sheet piles
 - Anvils
 - Bloomery
 - Sluices
 - Creeping plants
 - Epiphyte plants
 - Spreading bushes
 - Giant kelp trees & flowers
 - Aqueducts
 - Bookshelves
 - Bellows
 - Fruit tree branches
 - Looms
 - Tool Racks