### PR TITLE
Fix dogs and cats don't move

### DIFF
--- a/src/main/java/net/dries007/tfc/common/entities/ai/pet/TamableAi.java
+++ b/src/main/java/net/dries007/tfc/common/entities/ai/pet/TamableAi.java
@@ -96,7 +96,7 @@ public class TamableAi
         brain.addActivity(Activity.CORE, 0, ImmutableList.of(
             new Swim(0.8F), // float in water
             new LookAtTargetSink(45, 90), // if memory of look target, looks at that
-            new RunIf<>(e -> !e.isSleeping(), new MoveToTargetSink()), // tries to walk to its internal walk target. This could just be a random block.
+            new RunIf<>(e -> !e.isSleeping(), new MoveToTargetSink(), true), // tries to walk to its internal walk target. This could just be a random block.
             new CountDownCooldownTicks(MemoryModuleType.TEMPTATION_COOLDOWN_TICKS) // cools down between being tempted if its concentration broke
         ));
     }


### PR DESCRIPTION
 Fix #2300

Seems that we have to set `checkWhileRunningAlso` of `RunIf` to true, so that it will check the predicate (sleeping state) every tick, otherwise `MoveToTargetSink` will stop when checking `RunIf#canStillUse`