### PR TITLE
fix game crash on January when checking in the future

### DIFF
--- a/src/main/java/net/dries007/tfc/util/calendar/ServerCalendar.java
+++ b/src/main/java/net/dries007/tfc/util/calendar/ServerCalendar.java
@@ -248,7 +248,7 @@ public class ServerCalendar extends Calendar
     void checkIfInTheFuture(ServerLevel level)
     {
         final LocalDate date = LocalDate.now();
-        if (date.isBefore(LocalDate.of((int) getTotalCalendarYears(), getCalendarMonthOfYear().ordinal(), getCalendarDayOfMonth())))
+        if (date.isBefore(LocalDate.of((int) getTotalCalendarYears(), getCalendarMonthOfYear().ordinal() + 1, getCalendarDayOfMonth())))
         {
             level.getServer().getPlayerList().getPlayers().forEach(TFCAdvancements.PRESENT_DAY::trigger);
         }


### PR DESCRIPTION
`LocalDate` accepts only month 1-12, `Month.JANUARY.ordinal()` is 0