### PR TITLE
Add support for Antique Atlas

### DIFF
--- a/resources/world_gen.py
+++ b/resources/world_gen.py
@@ -53,39 +53,39 @@ def generate(rm: ResourceManager):
     placed_feature_tag(rm, 'feature/volcanoes', 'tfc:volcano_rivulet', 'tfc:volcano_caldera', 'tfc:random_volcano_fissure')
 
     # Biomes
-    biome(rm, 'badlands', 'mesa', lake_features=False)
-    biome(rm, 'inverted_badlands', 'mesa', lake_features=False)
-    biome(rm, 'canyons', 'plains', boulders=True, lake_features=False, volcano_features=True, hot_spring_features=True)
-    biome(rm, 'low_canyons', 'swamp', boulders=True, lake_features=False, hot_spring_features='empty')
-    biome(rm, 'plains', 'plains')
-    biome(rm, 'plateau', 'extreme_hills', boulders=True, hot_spring_features='empty')
-    biome(rm, 'hills', 'plains')
-    biome(rm, 'rolling_hills', 'plains', boulders=True, hot_spring_features='empty')
-    biome(rm, 'lake', 'river', spawnable=False)
-    biome(rm, 'lowlands', 'swamp', lake_features=False)
-    biome(rm, 'mountains', 'extreme_hills')
-    biome(rm, 'volcanic_mountains', 'extreme_hills', volcano_features=True, hot_spring_features=True)
-    biome(rm, 'old_mountains', 'extreme_hills', hot_spring_features=True)
-    biome(rm, 'oceanic_mountains', 'extreme_hills', ocean_features='both')
-    biome(rm, 'volcanic_oceanic_mountains', 'extreme_hills', spawnable=False, ocean_features='both', volcano_features=True)
-    biome(rm, 'ocean', 'ocean', spawnable=False, ocean_features=True)
-    biome(rm, 'ocean_reef', 'ocean', spawnable=False, ocean_features=True, reef_features=True)
-    biome(rm, 'deep_ocean', 'ocean', spawnable=False, ocean_features=True)
-    biome(rm, 'deep_ocean_trench', 'ocean', spawnable=False, ocean_features=True)
-    biome(rm, 'river', 'river', spawnable=False)
-    biome(rm, 'shore', 'beach', spawnable=False, ocean_features=True)
+    biome(rm, 'badlands', 'mesa', 'mesa', lake_features=False)
+    biome(rm, 'inverted_badlands', 'mesa', 'mesa', lake_features=False)
+    biome(rm, 'canyons', 'plains', 'plains', boulders=True, lake_features=False, volcano_features=True, hot_spring_features=True)
+    biome(rm, 'low_canyons', 'swamp', 'swamp', boulders=True, lake_features=False, hot_spring_features='empty')
+    biome(rm, 'plains', 'plains', 'plains')
+    biome(rm, 'plateau', 'extreme_hills', 'hills', boulders=True, hot_spring_features='empty')
+    biome(rm, 'hills', 'plains', 'hills')
+    biome(rm, 'rolling_hills', 'plains', 'hills', boulders=True, hot_spring_features='empty')
+    biome(rm, 'lake', 'river', 'water', spawnable=False)
+    biome(rm, 'lowlands', 'swamp', 'swamp', lake_features=False)
+    biome(rm, 'mountains', 'extreme_hills', 'mountains_all')
+    biome(rm, 'volcanic_mountains', 'extreme_hills', 'mountains_all', volcano_features=True, hot_spring_features=True)
+    biome(rm, 'old_mountains', 'extreme_hills', 'mountains_all', hot_spring_features=True)
+    biome(rm, 'oceanic_mountains', 'extreme_hills', 'mountains_all', ocean_features='both')
+    biome(rm, 'volcanic_oceanic_mountains', 'extreme_hills', 'mountains_all', spawnable=False, ocean_features='both', volcano_features=True)
+    biome(rm, 'ocean', 'ocean', 'water', spawnable=False, ocean_features=True)
+    biome(rm, 'ocean_reef', 'ocean', 'water', spawnable=False, ocean_features=True, reef_features=True)
+    biome(rm, 'deep_ocean', 'ocean', 'water', spawnable=False, ocean_features=True)
+    biome(rm, 'deep_ocean_trench', 'ocean', 'water', spawnable=False, ocean_features=True)
+    biome(rm, 'river', 'river', 'water', spawnable=False)
+    biome(rm, 'shore', 'beach', 'shore', spawnable=False, ocean_features=True)
 
-    biome(rm, 'mountain_river', 'extreme_hills', spawnable=False)
-    biome(rm, 'volcanic_mountain_river', 'extreme_hills', spawnable=False, volcano_features=True)
-    biome(rm, 'old_mountain_river', 'extreme_hills', spawnable=False)
-    biome(rm, 'oceanic_mountain_river', 'river', spawnable=False, ocean_features='both')
-    biome(rm, 'volcanic_oceanic_mountain_river', 'river', spawnable=False, ocean_features='both', volcano_features=True)
-    biome(rm, 'mountain_lake', 'extreme_hills', spawnable=False)
-    biome(rm, 'volcanic_mountain_lake', 'extreme_hills', spawnable=False, volcano_features=True)
-    biome(rm, 'old_mountain_lake', 'extreme_hills', spawnable=False)
-    biome(rm, 'oceanic_mountain_lake', 'river', spawnable=False, ocean_features='both')
-    biome(rm, 'volcanic_oceanic_mountain_lake', 'river', spawnable=False, ocean_features='both', volcano_features=True)
-    biome(rm, 'plateau_lake', 'extreme_hills', boulders=True, spawnable=False)
+    biome(rm, 'mountain_river', 'extreme_hills', 'water', spawnable=False)
+    biome(rm, 'volcanic_mountain_river', 'extreme_hills', 'water', spawnable=False, volcano_features=True)
+    biome(rm, 'old_mountain_river', 'extreme_hills', 'water', spawnable=False)
+    biome(rm, 'oceanic_mountain_river', 'river', 'water', spawnable=False, ocean_features='both')
+    biome(rm, 'volcanic_oceanic_mountain_river', 'river', 'water', spawnable=False, ocean_features='both', volcano_features=True)
+    biome(rm, 'mountain_lake', 'extreme_hills', 'water', spawnable=False)
+    biome(rm, 'volcanic_mountain_lake', 'extreme_hills', 'water', spawnable=False, volcano_features=True)
+    biome(rm, 'old_mountain_lake', 'extreme_hills', 'water', spawnable=False)
+    biome(rm, 'oceanic_mountain_lake', 'river', 'water', spawnable=False, ocean_features='both')
+    biome(rm, 'volcanic_oceanic_mountain_lake', 'river', 'water', spawnable=False, ocean_features='both', volcano_features=True)
+    biome(rm, 'plateau_lake', 'extreme_hills', 'water', boulders=True, spawnable=False)
 
     # Carvers
     rm.configured_carver('cave', 'tfc:cave', {
@@ -1243,8 +1243,9 @@ def height_provider(min_y: VerticalAnchor, max_y: VerticalAnchor, height_type: H
         'max_inclusive': utils.as_vertical_anchor(max_y)
     }
 
-
-def biome(rm: ResourceManager, name: str, category: str, boulders: bool = False, spawnable: bool = True, ocean_features: Union[bool, Literal['both']] = False, lake_features: Union[bool, Literal['default']] = 'default', volcano_features: bool = False, reef_features: bool = False, hot_spring_features: Union[bool, Literal['empty']] = False):
+# For a list of built-in atlas texture sets, take a look here:
+# https://github.com/AntiqueAtlasTeam/AntiqueAtlas/tree/1.18/common/src/main/resources/assets/antiqueatlas/atlas/texture_sets
+def biome(rm: ResourceManager, name: str, category: str, atlas_texture: str, boulders: bool = False, spawnable: bool = True, ocean_features: Union[bool, Literal['both']] = False, lake_features: Union[bool, Literal['default']] = 'default', volcano_features: bool = False, reef_features: bool = False, hot_spring_features: Union[bool, Literal['empty']] = False):
     spawners = {}
     soil_discs = []
     large_features = []
@@ -1345,6 +1346,10 @@ def biome(rm: ResourceManager, name: str, category: str, boulders: bool = False,
     ]
 
     rm.lang('biome.tfc.%s' % name, lang(name))
+    rm.data(('atlas', 'tiles', name), {
+        'version': 1,
+        "texture_set": f"antiqueatlas:{atlas_texture}"
+    }, 'assets')
     rm.biome(
         name_parts=name,
         precipitation='rain',  # Hardcode to rain to make some mixins redundant since they do a == rain check.

--- a/src/main/resources/assets/tfc/atlas/tiles/badlands.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/badlands.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:mesa"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/canyons.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/canyons.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:plains"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/deep_ocean.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/deep_ocean.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/deep_ocean_trench.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/deep_ocean_trench.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/hills.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/hills.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:hills"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/inverted_badlands.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/inverted_badlands.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:mesa"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/lake.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/low_canyons.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/low_canyons.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:swamp"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/lowlands.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/lowlands.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:swamp"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/mountain_lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/mountain_lake.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/mountain_river.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/mountain_river.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/mountains.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/mountains.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:mountains_all"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/ocean.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/ocean.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/ocean_reef.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/ocean_reef.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/oceanic_mountain_lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/oceanic_mountain_lake.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/oceanic_mountain_river.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/oceanic_mountain_river.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/oceanic_mountains.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/oceanic_mountains.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:mountains_all"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/old_mountain_lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/old_mountain_lake.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/old_mountain_river.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/old_mountain_river.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/old_mountains.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/old_mountains.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:mountains_all"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/plains.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/plains.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:plains"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/plateau.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/plateau.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:hills"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/plateau_lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/plateau_lake.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/river.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/river.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/rolling_hills.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/rolling_hills.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:hills"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/shore.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/shore.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:shore"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/volcanic_mountain_lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/volcanic_mountain_lake.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/volcanic_mountain_river.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/volcanic_mountain_river.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/volcanic_mountains.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/volcanic_mountains.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:mountains_all"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/volcanic_oceanic_mountain_lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/volcanic_oceanic_mountain_lake.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/volcanic_oceanic_mountain_river.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/volcanic_oceanic_mountain_river.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/volcanic_oceanic_mountains.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/volcanic_oceanic_mountains.json
@@ -1,0 +1,5 @@
+{
+  "__comment__": "This file was automatically created by mcresources",
+  "version": 1,
+  "texture_set": "antiqueatlas:mountains_all"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/vulcanic_mountain_lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/vulcanic_mountain_lake.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "texture_set": "antiqueatlas:lake"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/vulcanic_mountain_river.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/vulcanic_mountain_river.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/vulcanic_mountains.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/vulcanic_mountains.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "texture_set": "antiqueatlas:mountains_all"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/vulcanic_oceanic_mountain_lake.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/vulcanic_oceanic_mountain_lake.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "texture_set": "antiqueatlas:lake"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/vulcanic_oceanic_mountain_river.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/vulcanic_oceanic_mountain_river.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "texture_set": "antiqueatlas:water"
+}

--- a/src/main/resources/assets/tfc/atlas/tiles/vulcanic_oceanic_mountains.json
+++ b/src/main/resources/assets/tfc/atlas/tiles/vulcanic_oceanic_mountains.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "texture_set": "antiqueatlas:mountains_all"
+}


### PR DESCRIPTION
Instead of looking empty, the antique atlas now looks like this:

![Screenshot from 2023-03-09 17-54-15](https://user-images.githubusercontent.com/28286961/224100760-66ca3f8f-28f7-4b70-bc56-320383c2be85.png)

I didn't add any custom terrain textures because I felt the vanilla ones fit fairly well.

I used a Python script to generate this, I think I'll take a look at how the other generations scripts work and push it later.