### PR TITLE
Mineral worldgen fixes

### DIFF
--- a/resources/constants.py
+++ b/resources/constants.py
@@ -277,7 +277,7 @@ ORE_GRADES: Dict[str, OreGrade] = {
 DEFAULT_FORGE_ORE_TAGS: Tuple[str, ...] = ('coal', 'diamond', 'emerald', 'gold', 'iron', 'lapis', 'netherite_scrap', 'quartz', 'redstone')
 
 
-def vein(ore: str, vein_type: str, rarity: int, size: int, min_y: int, max_y: int, density: float, poor: float, normal: float, rich: float, rocks: List[str], spoiler_ore: Optional[str] = None, spoiler_rarity: int = 0, spoiler_rocks: List[str] = None, biomes: str = None, height: int = 0, deposits: bool = False):
+def vein(ore: str, vein_type: str, rarity: int, size: int, min_y: int, max_y: int, density: float, poor: float, normal: float, rich: float, rocks: List[str], spoiler_ore: Optional[str] = None, spoiler_rarity: int = 0, spoiler_rocks: List[str] = None, biomes: str = None, height: int = 2, deposits: bool = False):
     # Factory method to allow default values
     return Vein(ore, vein_type, rarity, size, min_y, max_y, density, poor, normal, rich, rocks, spoiler_ore, spoiler_rarity, spoiler_rocks, biomes, height, deposits)
 

--- a/resources/world_gen.py
+++ b/resources/world_gen.py
@@ -477,7 +477,7 @@ def generate(rm: ResourceManager):
                 'density': vein_density(vein.density),
                 'blocks': [{
                     'replace': ['tfc:rock/raw/%s' % rock],
-                    'with': [{'block': 'tfc:ore/%s/%s' % (vein.ore, rock)}]
+                    'with': mineral_ore_blocks(vein, rock)
                 } for rock in rocks],
                 'random_name': vein_name,
                 'biomes': vein.biomes
@@ -487,6 +487,8 @@ def generate(rm: ResourceManager):
                 vein_config['max_skew'] = 13
                 vein_config['min_slant'] = 0
                 vein_config['max_slant'] = 2
+            if vein.type == 'disc':
+                vein_config['height'] = vein.height
             configured_placed_feature(rm, ('vein', vein_name), 'tfc:%s_vein' % vein.type, vein_config)
 
     configured_placed_feature(rm, ('vein', 'gravel'), 'tfc:disc_vein', {
@@ -988,6 +990,20 @@ def vein_ore_blocks(vein: Vein, rock: str) -> List[Dict[str, Any]]:
             'block': 'tfc:deposit/%s/%s' % (vein.ore, rock)
         })
     return ore_blocks
+
+
+def mineral_ore_blocks(vein: Vein, rock: str) -> List[Dict[str, Any]]:
+    if vein.spoiler_ore is not None and rock in vein.spoiler_rocks:
+        ore_blocks = [{'weight': 100, 'block': 'tfc:ore/%s/%s' % (vein.ore, rock)}]
+        p = vein.spoiler_rarity * 0.01  # as a percentage of the overall vein
+        ore_blocks.append({
+            'weight': int(100 * p / (1 - p)),
+            'block': 'tfc:ore/%s/%s' % (vein.spoiler_ore, rock)
+        })
+    else:
+        ore_blocks = [{'block': 'tfc:ore/%s/%s' % (vein.ore, rock)}]
+    return ore_blocks
+
 
 def vein_density(density: int) -> float:
     assert 0 <= density <= 100, 'Invalid density: %s' % str(density)

--- a/src/main/resources/data/tfc/worldgen/configured_feature/vein/amethyst.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/vein/amethyst.json
@@ -144,6 +144,7 @@
       }
     ],
     "random_name": "amethyst",
-    "biomes": "#tfc:is_river"
+    "biomes": "#tfc:is_river",
+    "height": 4
   }
 }

--- a/src/main/resources/data/tfc/worldgen/configured_feature/vein/cinnabar.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/vein/cinnabar.json
@@ -58,7 +58,12 @@
         ],
         "with": [
           {
+            "weight": 100,
             "block": "tfc:ore/cinnabar/quartzite"
+          },
+          {
+            "weight": 11,
+            "block": "tfc:ore/opal/quartzite"
           }
         ]
       },

--- a/src/main/resources/data/tfc/worldgen/configured_feature/vein/gypsum.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/vein/gypsum.json
@@ -73,6 +73,7 @@
         ]
       }
     ],
-    "random_name": "gypsum"
+    "random_name": "gypsum",
+    "height": 2
   }
 }

--- a/src/main/resources/data/tfc/worldgen/configured_feature/vein/halite.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/vein/halite.json
@@ -83,6 +83,7 @@
         ]
       }
     ],
-    "random_name": "halite"
+    "random_name": "halite",
+    "height": 2
   }
 }

--- a/src/main/resources/data/tfc/worldgen/configured_feature/vein/opal.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/vein/opal.json
@@ -124,6 +124,7 @@
       }
     ],
     "random_name": "opal",
-    "biomes": "#tfc:is_river"
+    "biomes": "#tfc:is_river",
+    "height": 4
   }
 }

--- a/src/main/resources/data/tfc/worldgen/configured_feature/vein/saltpeter.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/vein/saltpeter.json
@@ -38,7 +38,12 @@
         ],
         "with": [
           {
+            "weight": 100,
             "block": "tfc:ore/saltpeter/limestone"
+          },
+          {
+            "weight": 25,
+            "block": "tfc:ore/gypsum/limestone"
           }
         ]
       },

--- a/src/main/resources/data/tfc/worldgen/configured_feature/vein/sulfur.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/vein/sulfur.json
@@ -18,7 +18,12 @@
         ],
         "with": [
           {
+            "weight": 100,
             "block": "tfc:ore/sulfur/rhyolite"
+          },
+          {
+            "weight": 25,
+            "block": "tfc:ore/gypsum/rhyolite"
           }
         ]
       },

--- a/src/main/resources/data/tfc/worldgen/configured_feature/vein/volcanic_sulfur.json
+++ b/src/main/resources/data/tfc/worldgen/configured_feature/vein/volcanic_sulfur.json
@@ -84,6 +84,7 @@
       }
     ],
     "random_name": "volcanic_sulfur",
-    "biomes": "#tfc:is_volcanic"
+    "biomes": "#tfc:is_volcanic",
+    "height": 6
   }
 }


### PR DESCRIPTION
Adds missing height parameter handling,
Changes default to match DiscVeinConfig,
Adds missing spoiler ore handling for minerals.