### PR TITLE
Disable rubidium fast biome colors. (Fixes #2279)

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -41,3 +41,7 @@ issueTrackerURL = "https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues"
     versionRange = "[1.18.2,)"
     ordering = "AFTER"
     side = "BOTH"
+
+# We do our own biome coloring, see #2279
+[mods."sodium:options"]
+    "mixin.features.fast_biome_colors"=false


### PR DESCRIPTION
Depends on https://github.com/Asek3/Rubidium/pull/466