### PR TITLE
Fix for lamps not turning off when the fuel runs out

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/LampBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/LampBlockEntity.java
@@ -62,7 +62,7 @@ public class LampBlockEntity extends TickCounterBlockEntity implements FluidTank
             if (usage >= 1)
             {
                 FluidStack used = tank.drain(usage, IFluidHandler.FluidAction.EXECUTE);
-                if (used.isEmpty() || used.getAmount() < usage)
+                if (tank.isEmpty() || used.getAmount() < usage)
                 {
                     level.setBlockAndUpdate(getBlockPos(), level.getBlockState(getBlockPos()).setValue(LampBlock.LIT, false));
                     ranOut = true;


### PR DESCRIPTION
I noticed an issue with lamps staying lit when their fuel becomes empty.

I believe this is because the code is checking if the <used> FluidStack is empty instead of the <tank> FluidStack.

This bug is only noticeable when the fuel empties to 0 exactly. If the fuel dips into a negative value, the second check in the if statement is triggered and the lamp is correctly turned off.
Since the fuel level is only checked when the lamp receives a random tick, this bug happens most frequently when the lamp is in a loaded chunk and is receiving random ticks.

I've tested with both Tallow and Olive Oil, and both seem to be working as expected now.

Also, the second check in the if statement doesn't appear to be necessary anymore since tank.isEmpty() should handle all cases, I can remove that if you like.