### PR TITLE
Assortment of minor model-related fixes

### DIFF
--- a/src/main/resources/assets/tfc/models/block/crucible.json
+++ b/src/main/resources/assets/tfc/models/block/crucible.json
@@ -1,67 +1,65 @@
 {
-  "credit": "Made with Blockbench",
-  "parent": "block/block",
+  "parent":   "minecraft:block/block",
   "textures": {
-    "side": "tfc:block/devices/crucible/side",
-    "top": "tfc:block/devices/crucible/top",
+    "side":     "tfc:block/devices/crucible/side",
+    "top":      "tfc:block/devices/crucible/top",
     "particle": "tfc:block/devices/crucible/side"
   },
   "elements": [
     {
-      "from": [1, 1, 1],
-      "to": [3, 16, 15],
-      "faces": {
-        "north": {"uv": [13, 1, 15, 16], "texture": "#side"},
-        "east": {"uv": [1, 1, 15, 15], "texture": "#side"},
-        "south": {"uv": [1, 1, 3, 16], "texture": "#side"},
-        "west": {"uv": [1, 1, 15, 16], "texture": "#side"},
-        "up": {"uv": [1, 1, 3, 15], "texture": "#top"},
-        "down": {"uv": [13, 1, 15, 15], "rotation": 180, "texture": "#top"}
-      }
-    },
-    {
-      "from": [3, 1, 13],
-      "to": [13, 16, 15],
-      "faces": {
-        "north": {"uv": [3, 1, 13, 16], "texture": "#side"},
-        "south": {"uv": [3, 1, 13, 16], "texture": "#side"},
-        "up": {"uv": [3, 13, 13, 15], "texture": "#top"},
-        "down": {"uv": [3, 13, 13, 15], "texture": "#top"}
-      }
-    },
-    {
-      "from": [3, 1, 1],
-      "to": [13, 16, 3],
-      "faces": {
-        "north": {"uv": [3, 1, 13, 16], "texture": "#side"},
-        "south": {"uv": [3, 1, 13, 16], "texture": "#side"},
-        "up": {"uv": [3, 1, 13, 3], "texture": "#top"},
-        "down": {"uv": [3, 1, 13, 3], "texture": "#top"}
-      }
-    },
-    {
-      "from": [13, 1, 1],
-      "to": [15, 16, 15],
-      "faces": {
-        "north": {"uv": [1, 1, 3, 16], "texture": "#side"},
-        "east": {"uv": [1, 1, 15, 16], "texture": "#side"},
-        "south": {"uv": [13, 1, 15, 16], "texture": "#side"},
-        "west": {"uv": [1, 1, 15, 16], "texture": "#side"},
-        "up": {"uv": [13, 1, 15, 15], "texture": "#top"},
-        "down": {"uv": [13, 1, 15, 15], "texture": "#top"}
-      }
-    },
-    {
-      "from": [3, 0, 3],
-      "to": [13, 2, 13],
-      "faces": {
-        "north": {"uv": [0, 0, 10, 2], "texture": "#top"},
-        "east": {"uv": [0, 0, 10, 2], "texture": "#top"},
-        "south": {"uv": [0, 0, 10, 2], "texture": "#top"},
-        "west": {"uv": [0, 0, 10, 2], "texture": "#top"},
-        "up": {"uv": [3, 3, 13, 13], "texture": "#top"},
-        "down": {"uv": [3, 3, 13, 13], "texture": "#top"}
-      }
-    }
+	  "from":  [  3, 0,  3 ],
+	  "to":    [ 13, 2, 13 ],
+	  "faces": {
+		"down":  { "uv": [ 3, 3, 13, 13 ], "texture": "#top", "cullface": "down" },
+		"up":    { "uv": [ 3, 3, 13, 13 ], "texture": "#top" },
+		"north": { "uv": [ 0, 0, 10,  2 ], "texture": "#top" },
+		"south": { "uv": [ 0, 0, 10,  2 ], "texture": "#top" },
+		"west":  { "uv": [ 0, 0, 10,  2 ], "texture": "#top" },
+		"east":  { "uv": [ 0, 0, 10,  2 ], "texture": "#top" }
+	  }
+	},
+	{
+	  "from":  [  1,  1, 1 ],
+	  "to":    [ 15, 16, 3 ],
+	  "faces": {
+		"up":    { "uv": [ 1,  1, 15,  3 ], "texture": "#top", "cullface": "up" },
+		"north": { "uv": [ 1,  1, 15, 16 ], "texture": "#side" },
+		"south": { "uv": [ 1,  1, 15, 16 ], "texture": "#side" }
+	  }
+	},
+	{
+	  "from":  [ 1,  1,  1 ],
+	  "to":    [ 3, 16, 15 ],
+	  "faces": {
+		"up":    { "uv": [ 1, 1,  3, 15 ], "texture": "#top", "cullface": "up" },
+		"west":  { "uv": [ 1, 1, 15, 16 ], "texture": "#side" },
+		"east":  { "uv": [ 1, 1, 15, 16 ], "texture": "#side" }
+	  }
+	},
+	{
+	  "from":  [  1,  1, 13 ],
+	  "to":    [ 15, 16, 15 ],
+	  "faces": {
+		"up":    { "uv": [ 1, 13, 15, 15 ], "texture": "#top", "cullface": "up" },
+		"north": { "uv": [ 1,  1, 15, 16 ], "texture": "#side" },
+		"south": { "uv": [ 1,  1, 15, 16 ], "texture": "#side" }
+	  }
+	},
+	{
+	  "from":  [ 13,  1,  1 ],
+	  "to":    [ 15, 16, 15 ],
+	  "faces": {
+		"up":    { "uv": [ 13, 1, 15, 15 ], "texture": "#top", "cullface": "up" },
+		"west":  { "uv": [  1, 1, 15, 16 ], "texture": "#side" },
+		"east":  { "uv": [  1, 1, 15, 16 ], "texture": "#side" }
+	  }
+	},
+	{
+	  "from":  [  1, 1,  1 ],
+	  "to":    [ 15, 1, 15 ],
+	  "faces": {
+		"down":  { "uv": [ 1, 1, 15, 15 ], "texture": "#top" }
+	  }
+	}
   ]
 }

--- a/src/main/resources/assets/tfc/models/block/large_tinted_cross.json
+++ b/src/main/resources/assets/tfc/models/block/large_tinted_cross.json
@@ -1,28 +1,38 @@
 {
-	"credit": "Made with Blockbench",
-	"textures": {
-		"particle": "#cross"
+  "ambientocclusion": false,
+  "textures":         {
+	"particle": "#cross"
+  },
+  "elements":         [
+	{
+	  "from":     [ 8,  0, -7.2 ],
+	  "to":       [ 8, 32, 23.2 ],
+	  "rotation": {
+		"angle":   -45,
+		"axis":    "y",
+		"origin":  [ 8, 0, 8 ],
+		"rescale": true
+	  },
+	  "shade":    false,
+	  "faces":    {
+		"west": { "uv": [ 0, 0, 16, 16 ], "texture": "#cross", "tintindex": 0 },
+		"east": { "uv": [ 0, 0, 16, 16 ], "texture": "#cross", "tintindex": 0 }
+	  }
 	},
-	"elements": [
-		{
-			"name": "cross1",
-			"from": [8, 0, -8],
-			"to": [8, 32, 24],
-			"rotation": {"angle": -45, "axis": "y", "origin": [8, 0, 8]},
-			"faces": {
-				"east": {"uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0}
-			}
-		},
-		{
-			"name": "cross2",
-			"from": [8, 0, -8],
-			"to": [8, 32, 24],
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 0, 8]},
-			"faces": {
-				"east": {"uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#cross", "tintindex": 0}
-			}
-		}
-	]
+	{
+	  "from":     [ 8,  0, -7.2 ],
+	  "to":       [ 8, 32, 23.2 ],
+	  "rotation": {
+		"angle":   45,
+		"axis":    "y",
+		"origin":  [ 8, 0, 8 ],
+		"rescale": true
+	  },
+	  "shade":    false,
+	  "faces":    {
+		"west": { "uv": [ 0, 0, 16, 16 ], "texture": "#cross", "tintindex": 0 },
+		"east": { "uv": [ 0, 0, 16, 16 ], "texture": "#cross", "tintindex": 0 }
+	  }
+	}
+  ]
 }

--- a/src/main/resources/assets/tfc/models/block/large_vessel_opened.json
+++ b/src/main/resources/assets/tfc/models/block/large_vessel_opened.json
@@ -1,93 +1,91 @@
 {
-	"credit": "Made with Blockbench",
-	"parent": "block/block",
-	"elements": [
-		{
-			"name": "Bottom",
-			"from": [4, 0, 4],
-			"to": [12, 1, 12],
-			"faces": {
-				"up": {"uv": [4, 4, 12, 12], "texture": "#bottom"},
-				"down": {"uv": [4, 4, 12, 12], "texture": "#bottom", "cullface": "down"}
-			}
+  "parent":   "minecraft:block/block",
+  "display":  {
+	"ground": {
+	  "translation": [    0,    3,    0 ],
+	  "scale":       [ 0.25, 0.25, 0.25 ]
+	},
+	"gui": {
+	  "rotation": [    30,   225,     0 ],
+	  "scale":    [ 0.625, 0.625, 0.625 ]
 		},
-		{
-			"name": "northSide",
-			"from": [3, 0, 3],
-			"to": [13, 10, 4],
-			"faces": {
-				"north": {"uv": [3, 6, 13, 16], "texture": "#side"},
-				"east": {"uv": [12, 6, 13, 16], "texture": "#side"},
-				"south": {"uv": [3, 6, 13, 16], "texture": "#side"},
-				"west": {"uv": [3, 6, 4, 16], "texture": "#side"},
-				"up": {"uv": [13, 5, 3, 6], "texture": "#side"},
-				"down": {"uv": [3, 12, 13, 13], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"name": "southSide",
-			"from": [3, 0, 12],
-			"to": [13, 10, 13],
-			"faces": {
-				"north": {"uv": [3, 6, 13, 16], "texture": "#side"},
-				"east": {"uv": [3, 6, 4, 16], "texture": "#side"},
-				"south": {"uv": [3, 6, 13, 16], "texture": "#side"},
-				"west": {"uv": [12, 6, 13, 16], "texture": "#side"},
-				"up": {"uv": [3, 5, 13, 6], "texture": "#side"},
-				"down": {"uv": [3, 3, 13, 4], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"name": "westSide",
-			"from": [3, 0, 4],
-			"to": [4, 10, 12],
-			"faces": {
-				"east": {"uv": [4, 6, 12, 16], "texture": "#side"},
-				"west": {"uv": [4, 6, 12, 16], "texture": "#side"},
-				"up": {"uv": [4, 4, 12, 5], "rotation": 90, "texture": "#side"},
-				"down": {"uv": [3, 4, 4, 12], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"name": "eastSide",
-			"from": [12, 0, 4],
-			"to": [13, 10, 12],
-			"faces": {
-				"east": {"uv": [4, 6, 12, 16], "texture": "#side"},
-				"west": {"uv": [4, 6, 12, 16], "texture": "#side"},
-				"up": {"uv": [4, 5, 12, 6], "rotation": 270, "texture": "#side"},
-				"down": {"uv": [12, 4, 13, 12], "texture": "#bottom", "cullface": "down"}
-			}
-		}
-	],
-	"display": {
-		"thirdperson_righthand": {
-			"rotation": [75, 45, 0],
-			"translation": [0, 2.5, 0],
-			"scale": [0.375, 0.375, 0.375]
-		},
-		"thirdperson_lefthand": {
-			"rotation": [75, 45, 0],
-			"translation": [0, 2.5, 0],
-			"scale": [0.375, 0.375, 0.375]
-		},
-		"firstperson_righthand": {
-			"rotation": [0, 45, 0],
-			"translation": [0, 2, 0],
-			"scale": [0.4, 0.4, 0.4]
-		},
-		"firstperson_lefthand": {
-			"rotation": [0, 45, 0],
-			"translation": [0, 2, 0],
-			"scale": [0.4, 0.4, 0.4]
-		},
-		"ground": {
-			"translation": [0, 3, 0],
-			"scale": [0.25, 0.25, 0.25]
-		},
-		"gui": {
-			"rotation": [30, 225, 0],
-			"scale": [0.625, 0.625, 0.625]
-		}
+	"thirdperson_righthand": {
+	  "rotation":    [    75,    45,     0 ],
+	  "translation": [     0,   2.5,     0 ],
+	  "scale":       [ 0.375, 0.375, 0.375 ]
+	},
+	"thirdperson_lefthand": {
+	  "rotation":    [    75,    45,     0 ],
+	  "translation": [     0,   2.5,     0 ],
+	  "scale":       [ 0.375, 0.375, 0.375 ]
+	},
+	"firstperson_righthand": {
+	  "rotation":    [   0,  45,   0 ],
+	  "translation": [   0,   2,   0 ],
+	  "scale":       [ 0.4, 0.4, 0.4 ]
+	},
+	"firstperson_lefthand": {
+	  "rotation":    [   0,  45,   0 ],
+	  "translation": [   0,   2,   0 ],
+	  "scale":       [ 0.4, 0.4, 0.4 ]
 	}
+  },
+  "elements": [
+    {
+	  "from":  [  3, 0,  3 ],
+	  "to":    [ 13, 1, 13 ],
+	  "faces": {
+		"down": { "uv": [ 3, 3, 13, 13 ], "texture": "#bottom", "cullface": "down" },
+		"up":   { "uv": [ 3, 3, 13, 13 ], "texture": "#bottom" }
+	  }
+	},
+    {
+	  "from":  [ 3,  0,  3 ],
+	  "to":    [ 4, 10, 13 ],
+	  "faces": {
+		"west": { "uv": [ 3, 6, 13, 16 ], "texture": "#side" },
+		"east": { "uv": [ 3, 6, 13, 16 ], "texture": "#side" }
+	  }
+	},
+    {
+	  "from":  [ 12,  0,  3 ],
+	  "to":    [ 13, 10, 13 ],
+	  "faces": {
+		"west": { "uv": [ 3, 6, 13, 16 ], "texture": "#side" },
+		"east": { "uv": [ 3, 6, 13, 16 ], "texture": "#side" }
+	  }
+	},
+    {
+	  "from":  [  3,  0, 3 ],
+	  "to":    [ 13, 10, 4 ],
+	  "faces": {
+		"up":    { "uv": [ 13, 5,  3,  6 ], "texture": "#side" },
+		"north": { "uv": [  3, 6, 13, 16 ], "texture": "#side" },
+		"south": { "uv": [  3, 6, 13, 16 ], "texture": "#side" }
+	  }
+	},
+    {
+	  "from":  [  3,  0, 12 ],
+	  "to":    [ 13, 10, 13 ],
+	  "faces": {
+		"up":    { "uv": [ 3, 5, 13,  6 ], "texture": "#side" },
+		"north": { "uv": [ 3, 6, 13, 16 ], "texture": "#side" },
+		"south": { "uv": [ 3, 6, 13, 16 ], "texture": "#side" }
+	  }
+	},
+    {
+	  "from":  [ 3, 10,  4 ],
+	  "to":    [ 4, 10, 12 ],
+	  "faces": {
+		"up":   { "uv": [ 4, 4, 12, 5 ], "rotation": 90, "texture": "#side" }
+	  }
+	},
+    {
+	  "from":  [ 12, 10,  4 ],
+	  "to":    [ 13, 10, 12 ],
+	  "faces": {
+		"up":   { "uv": [ 4, 5, 12, 6 ], "rotation": 270, "texture": "#side" }
+	  }
+	}
+  ]
 }

--- a/src/main/resources/assets/tfc/models/block/large_vessel_sealed.json
+++ b/src/main/resources/assets/tfc/models/block/large_vessel_sealed.json
@@ -1,109 +1,69 @@
 {
-	"credit": "Made with Blockbench",
-	"parent": "block/block",
-	"elements": [
-		{
-			"name": "Bottom",
-			"from": [4, 0, 4],
-			"to": [12, 1, 12],
-			"faces": {
-				"down": {"uv": [4, 4, 12, 12], "texture": "#bottom", "cullface": "down"}
-			}
+  "parent":   "minecraft:block/block",
+  "display":  {
+	"ground": {
+	  "translation": [    0,    3,    0 ],
+	  "scale":       [ 0.25, 0.25, 0.25 ]
+	},
+	"gui": {
+	  "rotation": [    30,   225,     0 ],
+	  "scale":    [ 0.625, 0.625, 0.625 ]
 		},
-		{
-			"name": "northSide",
-			"from": [3, 0, 3],
-			"to": [13, 10, 4],
-			"faces": {
-				"north": {"uv": [3, 6, 13, 16], "texture": "#side"},
-				"east": {"uv": [12, 6, 13, 16], "texture": "#side"},
-				"west": {"uv": [3, 6, 4, 16], "texture": "#side"},
-				"down": {"uv": [3, 12, 13, 13], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"name": "southSide",
-			"from": [3, 0, 12],
-			"to": [13, 10, 13],
-			"faces": {
-				"east": {"uv": [3, 6, 4, 16], "texture": "#side"},
-				"south": {"uv": [3, 6, 13, 16], "texture": "#side"},
-				"west": {"uv": [12, 6, 13, 16], "texture": "#side"},
-				"down": {"uv": [3, 3, 13, 4], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"name": "westSide",
-			"from": [3, 0, 4],
-			"to": [4, 10, 12],
-			"faces": {
-				"west": {"uv": [4, 6, 12, 16], "texture": "#side"},
-				"down": {"uv": [3, 4, 4, 12], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"name": "eastSide",
-			"from": [12, 0, 4],
-			"to": [13, 10, 12],
-			"faces": {
-				"east": {"uv": [4, 6, 12, 16], "texture": "#side"},
-				"down": {"uv": [12, 4, 13, 12], "texture": "#bottom", "cullface": "down"}
-			}
-		},
-		{
-			"name": "Top",
-			"from": [2.5, 9.5, 2.5],
-			"to": [13.5, 11, 13.5],
-			"faces": {
-				"north": {"uv": [13.5, 2.5, 2.5, 1], "texture": "#top"},
-				"east": {"uv": [15, 13.5, 13.5, 2.5], "rotation": 270, "texture": "#top"},
-				"south": {"uv": [13.5, 15, 2.5, 13.5], "rotation": 180, "texture": "#top"},
-				"west": {"uv": [1, 2.5, 2.5, 13.5], "rotation": 270, "texture": "#top"},
-				"up": {"uv": [2.5, 2.5, 13.5, 13.5], "texture": "#top"},
-				"down": {"uv": [2.5, 2.5, 13.5, 13.5], "texture": "#top"}
-			}
-		},
-		{
-			"name": "Nob",
-			"from": [7, 11, 7],
-			"to": [9, 12, 9],
-			"faces": {
-				"north": {"uv": [7, 7, 9, 8], "rotation": 180, "texture": "#top"},
-				"east": {"uv": [8, 7, 9, 9], "rotation": 90, "texture": "#top"},
-				"south": {"uv": [7, 8, 9, 9], "texture": "#top"},
-				"west": {"uv": [7, 7, 8, 9], "rotation": 270, "texture": "#top"},
-				"up": {"uv": [7, 7, 9, 9], "texture": "#top"}
-			}
-		}
-	],
-	"display": {
-		"thirdperson_righthand": {
-			"rotation": [75, 45, 0],
-			"translation": [0, 2.5, 0],
-			"scale": [0.375, 0.375, 0.375]
-		},
-		"thirdperson_lefthand": {
-			"rotation": [75, 45, 0],
-			"translation": [0, 2.5, 0],
-			"scale": [0.375, 0.375, 0.375]
-		},
-		"firstperson_righthand": {
-			"rotation": [0, 45, 0],
-			"translation": [0, 2, 0],
-			"scale": [0.4, 0.4, 0.4]
-		},
-		"firstperson_lefthand": {
-			"rotation": [0, 45, 0],
-			"translation": [0, 2, 0],
-			"scale": [0.4, 0.4, 0.4]
-		},
-		"ground": {
-			"translation": [0, 3, 0],
-			"scale": [0.25, 0.25, 0.25]
-		},
-		"gui": {
-			"rotation": [30, 225, 0],
-			"scale": [0.625, 0.625, 0.625]
-		}
+	"thirdperson_righthand": {
+	  "rotation":    [    75,    45,     0 ],
+	  "translation": [     0,   2.5,     0 ],
+	  "scale":       [ 0.375, 0.375, 0.375 ]
+	},
+	"thirdperson_lefthand": {
+	  "rotation":    [    75,    45,     0 ],
+	  "translation": [     0,   2.5,     0 ],
+	  "scale":       [ 0.375, 0.375, 0.375 ]
+	},
+	"firstperson_righthand": {
+	  "rotation":    [   0,  45,   0 ],
+	  "translation": [   0,   2,   0 ],
+	  "scale":       [ 0.4, 0.4, 0.4 ]
+	},
+	"firstperson_lefthand": {
+	  "rotation":    [   0,  45,   0 ],
+	  "translation": [   0,   2,   0 ],
+	  "scale":       [ 0.4, 0.4, 0.4 ]
 	}
+  },
+  "elements": [
+    {
+	  "from":  [  3,  0,  3 ],
+	  "to":    [ 13, 10, 13 ],
+	  "faces": {
+		"down":  { "uv": [ 3, 3, 13, 13 ], "texture": "#bottom", "cullface": "down" },
+		"north": { "uv": [ 3, 6, 13, 16 ], "texture": "#side" },
+		"south": { "uv": [ 3, 6, 13, 16 ], "texture": "#side" },
+		"west":  { "uv": [ 3, 6, 13, 16 ], "texture": "#side" },
+		"east":  { "uv": [ 3, 6, 13, 16 ], "texture": "#side" }
+	  }
+	},
+	{
+	  "from":  [  2.5, 9.5,  2.5 ],
+	  "to":    [ 13.5,  11, 13.5 ],
+	  "faces": {
+		"down":  { "uv": [  2.5,   2.5, 13.5, 13.5 ], "texture": "#top" },
+		"up":    { "uv": [  2.5,   2.5, 13.5, 13.5 ], "texture": "#top" },
+		"north": { "uv": [ 13.5,   2.5,  2.5,    1 ], "texture": "#top" },
+		"south": { "uv": [ 13.5,   15,   2.5, 13.5 ], "texture": "#top", "rotation": 180 },
+		"west":  { "uv": [    1,  2.5,   2.5, 13.5 ], "texture": "#top", "rotation": 270 },
+		"east":  { "uv": [   15, 13.5,  13.5,  2.5 ], "texture": "#top", "rotation": 270 }
+	  }
+	},
+	{
+	  "from":  [ 7, 11, 7 ],
+	  "to":    [ 9, 12, 9 ],
+	  "faces": {
+		"up":    { "uv": [ 7, 7, 9, 9 ], "texture": "#top" },
+		"north": { "uv": [ 7, 7, 9, 8 ], "texture": "#top", "rotation": 180 },
+		"south": { "uv": [ 7, 8, 9, 9 ], "texture": "#top" },
+		"west":  { "uv": [ 7, 7, 8, 9 ], "texture": "#top", "rotation": 270 },
+		"east":  { "uv": [ 8, 7, 9, 9 ], "texture": "#top", "rotation": 90 }
+	  }
+	}
+  ]
 }

--- a/src/main/resources/assets/tfc/models/block/nest_box.json
+++ b/src/main/resources/assets/tfc/models/block/nest_box.json
@@ -1,114 +1,96 @@
 {
-  "credit": "Made with Blockbench",
-  "parent": "block/block",
+  "parent":   "minecraft:block/block",
   "textures": {
-    "texture": "tfc:block/thatch",
+    "texture":  "tfc:block/thatch",
     "particle": "tfc:block/thatch"
   },
   "elements": [
     {
-      "from": [6, 0, 6],
-      "to": [10, 1, 10],
-      "faces": {
-        "north": {"uv": [5, 5, 9, 6], "texture": "#texture"},
-        "east": {"uv": [0, 11, 4, 12], "texture": "#texture"},
-        "south": {"uv": [0, 5, 4, 6], "texture": "#texture"},
-        "west": {"uv": [8, 4, 12, 5], "texture": "#texture"},
-        "up": {"uv": [6, 6, 10, 10], "texture": "#texture"},
-        "down": {"uv": [5, 5, 9, 9], "texture": "#texture"}
-      }
-    },
+	  "from":  [  6, 0,  6 ],
+	  "to":    [ 10, 1, 10 ],
+	  "faces": {
+		"down":  { "uv": [ 6,  6, 10, 10 ], "texture": "#texture", "cullface": "down" },
+		"up":    { "uv": [ 6,  6, 10, 10 ], "texture": "#texture" },
+		"north": { "uv": [ 6, 15, 10, 16 ], "texture": "#texture" },
+		"south": { "uv": [ 6, 15, 10, 16 ], "texture": "#texture" },
+		"west":  { "uv": [ 6, 15, 10, 16 ], "texture": "#texture" },
+		"east":  { "uv": [ 6, 15, 10, 16 ], "texture": "#texture" }
+	  }
+	},
     {
-      "from": [6, 1, 10],
-      "to": [13, 2, 13],
-      "faces": {
-        "north": {"uv": [8, 0, 15, 1], "texture": "#texture"},
-        "south": {"uv": [0, 0, 15, 6], "texture": "#texture"},
-        "west": {"uv": [0, 0, 9, 6], "texture": "#texture"},
-        "up": {"uv": [10, 3, 13, 10], "rotation": 90, "texture": "#texture"},
-        "down": {"uv": [8, 0, 15, 3], "texture": "#texture"}
-      }
-    },
+	  "from":  [  2, 1,  2 ],
+	  "to":    [ 14, 4, 14 ],
+	  "faces": {
+		"down":  { "uv": [ 2,  2, 14, 14 ], "texture": "#texture" },
+		"north": { "uv": [ 2, 12, 14, 15 ], "texture": "#texture" },
+		"south": { "uv": [ 2, 12, 14, 15 ], "texture": "#texture" },
+		"west":  { "uv": [ 2, 12, 14, 15 ], "texture": "#texture" },
+		"east":  { "uv": [ 2, 12, 14, 15 ], "texture": "#texture" }
+	  }
+	},
     {
-      "from": [10, 1, 3],
-      "to": [13, 2, 10],
-      "faces": {
-        "north": {"uv": [0, 0, 9, 6], "texture": "#texture"},
-        "south": {"uv": [0, 0, 9, 6], "texture": "#texture"},
-        "west": {"uv": [0, 0, 7, 1], "texture": "#texture"},
-        "up": {"uv": [3, 3, 10, 6], "rotation": 90, "texture": "#texture"},
-        "down": {"uv": [8, 6, 15, 9], "rotation": 90, "texture": "#texture"}
-      }
-    },
+	  "from":  [ 3, 1,  3 ],
+	  "to":    [ 6, 2, 13 ],
+	  "faces": {
+		"up":   { "uv": [ 3, 10, 13, 13 ], "texture": "#texture", "rotation": 90 },
+		"east": { "uv": [ 3, 14, 13, 15 ], "texture": "#texture" }
+	  }
+	},
     {
-      "from": [3, 1, 3],
-      "to": [10, 2, 6],
-      "faces": {
-        "north": {"uv": [0, 0, 15, 6], "texture": "#texture"},
-        "south": {"uv": [0, 0, 6, 1], "texture": "#texture"},
-        "west": {"uv": [0, 0, 9, 6], "texture": "#texture"},
-        "up": {"uv": [3, 6, 6, 13], "rotation": 90, "texture": "#texture"},
-        "down": {"uv": [0, 6, 7, 9], "rotation": 180, "texture": "#texture"}
-      }
-    },
+	  "from":  [  3, 1, 3 ],
+	  "to":    [ 13, 2, 6 ],
+	  "faces": {
+		"up":    { "uv": [ 3,  3,  6, 13 ], "texture": "#texture", "rotation": 90 },
+		"south": { "uv": [ 3, 14, 13, 15 ], "texture": "#texture" }
+	  }
+	},
     {
-      "from": [3, 1, 6],
-      "to": [6, 2, 13],
-      "faces": {
-        "north": {"uv": [0, 0, 9, 6], "texture": "#texture"},
-        "east": {"uv": [0, 2, 7, 3], "texture": "#texture"},
-        "south": {"uv": [0, 0, 9, 6], "texture": "#texture"},
-        "west": {"uv": [0, 0, 15, 6], "texture": "#texture"},
-        "up": {"uv": [6, 10, 13, 13], "rotation": 90, "texture": "#texture"},
-        "down": {"uv": [9, 9, 16, 12], "rotation": 270, "texture": "#texture"}
-      }
-    },
+	  "from":  [ 10, 1,  3 ],
+	  "to":    [ 13, 2, 13 ],
+	  "faces": {
+		"up":   { "uv": [ 3,  3, 13,  6 ], "texture": "#texture", "rotation": 90 },
+		"west": { "uv": [ 3, 14, 13, 15 ], "texture": "#texture" }
+	  }
+	},
     {
-      "from": [2, 1, 3],
-      "to": [3, 4, 14],
-      "faces": {
-        "north": {"uv": [0, 0, 5, 8], "texture": "#texture"},
-        "east": {"uv": [3, 3, 14, 6], "texture": "#texture"},
-        "south": {"uv": [1, 6, 2, 9], "texture": "#texture"},
-        "west": {"uv": [3, 3, 14, 6], "texture": "#texture"},
-        "up": {"uv": [3, 15, 14, 16], "rotation": 90, "texture": "#texture"},
-        "down": {"uv": [3, 14, 14, 15], "rotation": 270, "texture": "#texture"}
-      }
-    },
+	  "from":  [  3, 1, 10 ],
+	  "to":    [ 13, 2, 13 ],
+	  "faces": {
+		"up":    { "uv": [ 10,  3, 13, 13 ], "texture": "#texture", "rotation": 90 },
+		"north": { "uv": [  3, 14, 13, 15 ], "texture": "#texture" }
+	  }
+	},
     {
-      "from": [3, 1, 13],
-      "to": [14, 4, 14],
-      "faces": {
-        "north": {"uv": [5, 6, 16, 9], "texture": "#texture"},
-        "east": {"uv": [1, 2, 2, 5], "texture": "#texture"},
-        "south": {"uv": [5, 6, 16, 9], "texture": "#texture"},
-        "west": {"uv": [0, 0, 5, 8], "texture": "#texture"},
-        "up": {"uv": [3, 15, 14, 16], "texture": "#texture"},
-        "down": {"uv": [5, 2, 16, 3], "texture": "#texture"}
-      }
-    },
+	  "from":  [ 2, 2,  2 ],
+	  "to":    [ 3, 4, 14 ],
+	  "faces": {
+		"up":   { "uv": [ 2,  2,  3, 14 ], "texture": "#texture" },
+		"east": { "uv": [ 2, 12, 14, 14 ], "texture": "#texture" }
+	  }
+	},
     {
-      "from": [13, 1, 2],
-      "to": [14, 4, 13],
-      "faces": {
-        "north": {"uv": [2, 0, 3, 3], "texture": "#texture"},
-        "east": {"uv": [0, 0, 11, 3], "texture": "#texture"},
-        "south": {"uv": [0, 0, 5, 8], "texture": "#texture"},
-        "west": {"uv": [0, 7, 11, 10], "texture": "#texture"},
-        "up": {"uv": [2, 2, 13, 3], "rotation": 270, "texture": "#texture"},
-        "down": {"uv": [0, 3, 11, 4], "rotation": 90, "texture": "#texture"}
-      }
-    },
+	  "from":  [  2, 2, 2 ],
+	  "to":    [ 14, 4, 3 ],
+	  "faces": {
+		"up":    { "uv": [ 2,  2, 14,  3 ], "texture": "#texture" },
+		"south": { "uv": [ 2, 12, 14, 14 ], "texture": "#texture" }
+	  }
+	},
     {
-      "from": [2, 1, 2],
-      "to": [13, 4, 3],
-      "faces": {
-        "north": {"uv": [3, 0, 14, 3], "texture": "#texture"},
-        "south": {"uv": [2, 0, 13, 3], "texture": "#texture"},
-        "west": {"uv": [2, 0, 3, 3], "texture": "#texture"},
-        "up": {"uv": [3, 15, 14, 16], "rotation": 180, "texture": "#texture"},
-        "down": {"uv": [3, 15, 14, 16], "rotation": 180, "texture": "#texture"}
-      }
-    }
+	  "from":  [ 13, 2,  2 ],
+	  "to":    [ 14, 4, 14 ],
+	  "faces": {
+		"up":   { "uv": [ 13,  2, 14, 14 ], "texture": "#texture" },
+		"west": { "uv": [  2, 12, 14, 14 ], "texture": "#texture" }
+	  }
+	},
+    {
+	  "from":  [  2, 2, 13 ],
+	  "to":    [ 14, 4, 14 ],
+	  "faces": {
+		"up":    { "uv": [ 2, 13, 14, 14 ], "texture": "#texture" },
+		"north": { "uv": [ 2, 12, 14, 14 ], "texture": "#texture" }
+	  }
+	}
   ]
 }

--- a/src/main/resources/assets/tfc/models/block/plant/arrowhead_0.json
+++ b/src/main/resources/assets/tfc/models/block/plant/arrowhead_0.json
@@ -1,5 +1,9 @@
 {
     "credit":"Made with Blockbench",
+	"ambientocclusion"
+	:
+	false
+	,
     "textures":{
         "4":"tfc:block/plant/arrowhead/arrowhead_stem",
         "5":"tfc:block/plant/arrowhead/arrowhead_leaf_0",
@@ -27,6 +31,10 @@
                     8
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "east":{
                     "uv":[
@@ -71,6 +79,10 @@
                     8
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "east":{
                     "uv":[
@@ -115,6 +127,10 @@
                     18
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "east":{
                     "uv":[
@@ -160,6 +176,10 @@
                     12
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "east":{
                     "uv":[
@@ -205,6 +225,10 @@
                     21
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "east":{
                     "uv":[
@@ -250,6 +274,10 @@
                     10
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "east":{
                     "uv":[
@@ -295,6 +323,10 @@
                     -4
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "up":{
                     "uv":[
@@ -340,6 +372,10 @@
                     -3
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "north":{
                     "uv":[
@@ -386,6 +422,10 @@
                     9
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "north":{
                     "uv":[
@@ -432,6 +472,10 @@
                     4
                 ]
             },
+			"shade"
+			:
+			false
+			,
             "faces":{
                 "north":{
                     "uv":[

--- a/src/main/resources/assets/tfc/models/block/plant/athyrium_fern.json
+++ b/src/main/resources/assets/tfc/models/block/plant/athyrium_fern.json
@@ -19,7 +19,7 @@
         16,
         16
       ],
-      "shade": true,
+      "shade": false,
       "faces": {
         "east": {
           "uv": [
@@ -62,7 +62,7 @@
         32,
         8
       ],
-      "shade": true,
+      "shade": false,
       "faces": {
         "north": {
           "uv": [
@@ -105,7 +105,7 @@
         32,
         8
       ],
-      "shade": true,
+      "shade": false,
       "faces": {
         "north": {
           "uv": [
@@ -148,7 +148,7 @@
         16,
         16
       ],
-      "shade": true,
+      "shade": false,
       "faces": {
         "east": {
           "uv": [

--- a/src/main/resources/assets/tfc/models/block/plant/flowerpot/barrel_cactus.json
+++ b/src/main/resources/assets/tfc/models/block/plant/flowerpot/barrel_cactus.json
@@ -6,9 +6,7 @@
 		"4": "tfc:block/plant/barrel_cactus/top",
 		"5": "tfc:block/plant/barrel_cactus/spikes_single",
 		"particle": "block/flower_pot",
-		"flowerpot": "block/flower_pot",
-		"dirt": "tfc:block/dirt/loam",
-		"plant": "tfc:block/empty"
+		"flowerpot": "block/flower_pot"
 	},
 	"elements": [
 		{
@@ -16,7 +14,6 @@
 			"to": [6, 6, 11],
 			"faces": {
 				"north": {"uv": [10, 10, 11, 16], "texture": "#flowerpot"},
-				"east": {"uv": [5, 10, 11, 16], "texture": "#flowerpot"},
 				"south": {"uv": [5, 10, 6, 16], "texture": "#flowerpot"},
 				"west": {"uv": [5, 10, 11, 16], "texture": "#flowerpot"},
 				"up": {"uv": [5, 5, 6, 11], "texture": "#flowerpot"},
@@ -30,7 +27,6 @@
 				"north": {"uv": [5, 10, 6, 16], "texture": "#flowerpot"},
 				"east": {"uv": [5, 10, 11, 16], "texture": "#flowerpot"},
 				"south": {"uv": [10, 10, 11, 16], "texture": "#flowerpot"},
-				"west": {"uv": [5, 10, 11, 16], "texture": "#flowerpot"},
 				"up": {"uv": [10, 5, 11, 11], "texture": "#flowerpot"},
 				"down": {"uv": [10, 5, 11, 11], "texture": "#flowerpot", "cullface": "down"}
 			}
@@ -40,7 +36,6 @@
 			"to": [10, 6, 6],
 			"faces": {
 				"north": {"uv": [6, 10, 10, 16], "texture": "#flowerpot"},
-				"south": {"uv": [6, 10, 10, 16], "texture": "#flowerpot"},
 				"up": {"uv": [6, 5, 10, 6], "texture": "#flowerpot"},
 				"down": {"uv": [6, 10, 10, 11], "texture": "#flowerpot", "cullface": "down"}
 			}
@@ -49,7 +44,6 @@
 			"from": [6, 0, 10],
 			"to": [10, 6, 11],
 			"faces": {
-				"north": {"uv": [6, 10, 10, 16], "texture": "#flowerpot"},
 				"south": {"uv": [6, 10, 10, 16], "texture": "#flowerpot"},
 				"up": {"uv": [6, 10, 10, 11], "texture": "#flowerpot"},
 				"down": {"uv": [6, 5, 10, 6], "texture": "#flowerpot", "cullface": "down"}
@@ -59,45 +53,24 @@
 			"from": [6, 0, 6],
 			"to": [10, 4, 10],
 			"faces": {
-				"up": {"uv": [6, 6, 10, 10], "texture": "#dirt"},
 				"down": {"uv": [6, 6, 10, 10], "texture": "#flowerpot", "cullface": "down"}
-			}
-		},
-		{
-			"from": [2.6, 4, 8],
-			"to": [13.4, 16, 8],
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8], "rescale": true},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#plant"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#plant"}
-			}
-		},
-		{
-			"from": [8, 4, 2.6],
-			"to": [8, 16, 13.4],
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8], "rescale": true},
-			"faces": {
-				"east": {"uv": [0, 0, 16, 16], "texture": "#plant"},
-				"west": {"uv": [0, 0, 16, 16], "texture": "#plant"}
 			}
 		},
 		{
 			"from": [6, 6, 6],
 			"to": [10, 16, 10],
-			"rotation": {"angle": 0, "axis": "y", "origin": [16, 14, 16]},
 			"faces": {
 				"north": {"uv": [0, 0, 4, 10], "texture": "#3"},
 				"east": {"uv": [0, 0, 4, 10], "texture": "#3"},
 				"south": {"uv": [0, 0, 4, 10], "texture": "#3"},
 				"west": {"uv": [0, 0, 4, 10], "texture": "#3"},
-				"up": {"uv": [6, 6, 10, 10], "texture": "#4"},
+				"up": {"uv": [6, 6, 10, 10], "texture": "#4", "cullface": "up" },
 				"down": {"uv": [0, 0, 4, 4], "texture": "#3"}
 			}
 		},
 		{
 			"from": [5, 6, 9],
 			"to": [6, 15, 9],
-			"rotation": {"angle": 0, "axis": "y", "origin": [13, 14, 15]},
 			"faces": {
 				"north": {"uv": [0, 5, 1, 14], "texture": "#5"},
 				"south": {"uv": [0, 5, 1, 14], "texture": "#5"}
@@ -106,7 +79,6 @@
 		{
 			"from": [5, 6, 7],
 			"to": [6, 15, 7],
-			"rotation": {"angle": 0, "axis": "y", "origin": [13, 14, 13]},
 			"faces": {
 				"north": {"uv": [0, 5, 1, 14], "texture": "#5"},
 				"south": {"uv": [0, 5, 1, 14], "texture": "#5"}
@@ -115,7 +87,6 @@
 		{
 			"from": [10, 6, 9],
 			"to": [11, 15, 9],
-			"rotation": {"angle": 0, "axis": "y", "origin": [18, 14, 15]},
 			"faces": {
 				"north": {"uv": [0, 5, 1, 14], "texture": "#5"},
 				"south": {"uv": [0, 5, 1, 14], "texture": "#5"}
@@ -124,7 +95,6 @@
 		{
 			"from": [10, 6, 7],
 			"to": [11, 15, 7],
-			"rotation": {"angle": 0, "axis": "y", "origin": [18, 14, 13]},
 			"faces": {
 				"north": {"uv": [0, 5, 1, 14], "texture": "#5"},
 				"south": {"uv": [0, 5, 1, 14], "texture": "#5"}
@@ -133,7 +103,6 @@
 		{
 			"from": [7, 6, 10],
 			"to": [7, 15, 11],
-			"rotation": {"angle": 0, "axis": "y", "origin": [15, 14, 3]},
 			"faces": {
 				"east": {"uv": [0, 5, 1, 14], "texture": "#5"},
 				"west": {"uv": [0, 5, 1, 14], "texture": "#5"}
@@ -142,7 +111,6 @@
 		{
 			"from": [9, 6, 10],
 			"to": [9, 15, 11],
-			"rotation": {"angle": 0, "axis": "y", "origin": [17, 14, 3]},
 			"faces": {
 				"east": {"uv": [0, 5, 1, 14], "texture": "#5"},
 				"west": {"uv": [0, 5, 1, 14], "texture": "#5"}
@@ -151,7 +119,6 @@
 		{
 			"from": [7, 6, 5],
 			"to": [7, 15, 6],
-			"rotation": {"angle": 0, "axis": "y", "origin": [15, 14, -2]},
 			"faces": {
 				"east": {"uv": [0, 5, 1, 14], "texture": "#5"},
 				"west": {"uv": [0, 5, 1, 14], "texture": "#5"}
@@ -160,7 +127,6 @@
 		{
 			"from": [9, 6, 5],
 			"to": [9, 15, 6],
-			"rotation": {"angle": 0, "axis": "y", "origin": [17, 14, -2]},
 			"faces": {
 				"east": {"uv": [0, 5, 1, 14], "texture": "#5"},
 				"west": {"uv": [0, 5, 1, 14], "texture": "#5"}

--- a/src/main/resources/assets/tfc/models/block/plant/flowerpot/moss.json
+++ b/src/main/resources/assets/tfc/models/block/plant/flowerpot/moss.json
@@ -4,8 +4,7 @@
 	"textures": {
 		"3": "tfc:block/plant/moss/moss_layer0",
 		"particle": "block/flower_pot",
-		"flowerpot": "block/flower_pot",
-		"dirt": "tfc:block/dirt/loam"
+		"flowerpot": "block/flower_pot"
 	},
 	"elements": [
 		{
@@ -13,7 +12,6 @@
 			"to": [6, 6, 11],
 			"faces": {
 				"north": {"uv": [10, 10, 11, 16], "texture": "#flowerpot"},
-				"east": {"uv": [5, 10, 11, 16], "texture": "#flowerpot"},
 				"south": {"uv": [5, 10, 6, 16], "texture": "#flowerpot"},
 				"west": {"uv": [5, 10, 11, 16], "texture": "#flowerpot"},
 				"down": {"uv": [5, 5, 6, 11], "texture": "#flowerpot", "cullface": "down"}
@@ -26,7 +24,6 @@
 				"north": {"uv": [5, 10, 6, 16], "texture": "#flowerpot"},
 				"east": {"uv": [5, 10, 11, 16], "texture": "#flowerpot"},
 				"south": {"uv": [10, 10, 11, 16], "texture": "#flowerpot"},
-				"west": {"uv": [5, 10, 11, 16], "texture": "#flowerpot"},
 				"down": {"uv": [10, 5, 11, 11], "texture": "#flowerpot", "cullface": "down"}
 			}
 		},
@@ -35,7 +32,6 @@
 			"to": [10, 6, 6],
 			"faces": {
 				"north": {"uv": [6, 10, 10, 16], "texture": "#flowerpot"},
-				"south": {"uv": [6, 10, 10, 16], "texture": "#flowerpot"},
 				"down": {"uv": [6, 10, 10, 11], "texture": "#flowerpot", "cullface": "down"}
 			}
 		},
@@ -43,7 +39,6 @@
 			"from": [6, 0, 10],
 			"to": [10, 6, 11],
 			"faces": {
-				"north": {"uv": [6, 10, 10, 16], "texture": "#flowerpot"},
 				"south": {"uv": [6, 10, 10, 16], "texture": "#flowerpot"},
 				"down": {"uv": [6, 5, 10, 6], "texture": "#flowerpot", "cullface": "down"}
 			}
@@ -52,7 +47,6 @@
 			"from": [6, 0, 6],
 			"to": [10, 4, 10],
 			"faces": {
-				"up": {"uv": [6, 6, 10, 10], "texture": "#dirt"},
 				"down": {"uv": [6, 6, 10, 10], "texture": "#flowerpot", "cullface": "down"}
 			}
 		},

--- a/src/main/resources/assets/tfc/models/block/plant/flowerpot/reindeer_lichen.json
+++ b/src/main/resources/assets/tfc/models/block/plant/flowerpot/reindeer_lichen.json
@@ -5,9 +5,7 @@
 		"3": "tfc:block/plant/reindeer_lichen/reindeer_lichen_layer0",
 		"4": "tfc:block/plant/reindeer_lichen/reindeer_lichen_layer1",
 		"particle": "block/flower_pot",
-		"flowerpot": "block/flower_pot",
-		"dirt": "tfc:block/dirt/loam",
-		"plant": "tfc:block/empty"
+		"flowerpot": "block/flower_pot"
 	},
 	"elements": [
 		{
@@ -58,7 +56,6 @@
 			"from": [6, 0, 6],
 			"to": [10, 4, 10],
 			"faces": {
-				"up": {"uv": [6, 6, 10, 10], "texture": "#dirt"},
 				"down": {"uv": [6, 6, 10, 10], "texture": "#flowerpot", "cullface": "down"}
 			}
 		},

--- a/src/main/resources/assets/tfc/models/block/plant/lady_fern.json
+++ b/src/main/resources/assets/tfc/models/block/plant/lady_fern.json
@@ -1,44 +1,65 @@
 {
-	"textures": {
-		"0": "tfc:block/plant/lady_fern/fern_single",
-		"particle": "tfc:block/plant/lady_fern/fern_single"
+  "ambientocclusion": false,
+  "textures":         {
+	"plant":    "tfc:block/plant/lady_fern/fern_single",
+	"particle": "tfc:block/plant/lady_fern/fern_single"
+  },
+  "elements":         [
+	{
+	  "from":     [  0, 0,  7 ],
+	  "to":       [ 16, 0, 25 ],
+	  "rotation": {
+		"angle":  -45,
+		"axis":   "x",
+		"origin": [ 8, 0, 8 ]
+	  },
+	  "shade":    false,
+	  "faces":    {
+		"down": { "uv": [ 0, 16, 16,  0 ], "rotation": 180, "texture": "#plant", "tintindex": 0 },
+		"up":   { "uv": [ 0,  0, 16, 16 ], "rotation": 180, "texture": "#plant", "tintindex": 0 }
+	  }
 	},
-	"elements": [
-		{
-			"from": [0, 0, 7],
-			"to": [16, 0, 25],
-			"rotation": {"angle": -45, "axis": "x", "origin": [8, 0, 8]},
-			"faces": {
-				"up": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#0", "tintindex": 0},
-				"down": {"uv": [0, 16, 16, 0], "rotation": 180, "texture": "#0", "tintindex": 0}
-			}
-		},
-		{
-			"from": [8, 0, -1],
-			"to": [24, 0, 17],
-			"rotation": {"angle": 45, "axis": "z", "origin": [8, 0, 8]},
-			"faces": {
-				"up": {"uv": [0, 0, 16, 16], "rotation": 90, "texture": "#0", "tintindex": 0},
-				"down": {"uv": [0, 16, 16, 0], "rotation": 270, "texture": "#0", "tintindex": 0}
-			}
-		},
-		{
-			"from": [0, 0, -9],
-			"to": [16, 0, 9],
-			"rotation": {"angle": 45, "axis": "x", "origin": [8, 0, 8]},
-			"faces": {
-				"up": {"uv": [0, 0, 16, 16], "texture": "#0", "tintindex": 0},
-				"down": {"uv": [0, 16, 16, 0], "texture": "#0", "tintindex": 0}
-			}
-		},
-		{
-			"from": [-8, 0, -1],
-			"to": [8, 0, 17],
-			"rotation": {"angle": -45, "axis": "z", "origin": [8, 0, 8]},
-			"faces": {
-				"up": {"uv": [0, 0, 16, 16], "rotation": 270, "texture": "#0", "tintindex": 0},
-				"down": {"uv": [0, 16, 16, 0], "rotation": 90, "texture": "#0", "tintindex": 0}
-			}
-		}
-	]
+	{
+	  "from":     [  8, 0, -1 ],
+	  "to":       [ 24, 0, 17 ],
+	  "rotation": {
+		"angle": 45,
+		"axis": "z",
+		"origin": [8, 0, 8]
+	  },
+	  "shade":    false,
+	  "faces":    {
+		"down": { "uv": [ 0, 16, 16,  0 ], "rotation": 270, "texture": "#plant", "tintindex": 0 },
+		"up":   { "uv": [ 0,  0, 16, 16 ], "rotation": 90,  "texture": "#plant", "tintindex": 0 }
+	  }
+	},
+	{
+	  "from":     [  0, 0, -9 ],
+	  "to":       [ 16, 0,  9 ],
+	  "rotation": {
+		"angle": 45,
+		"axis": "x",
+		"origin": [ 8, 0, 8 ]
+	  },
+	  "shade":    false,
+	  "faces":    {
+		"down": { "uv": [ 0, 16, 16,  0 ], "texture": "#plant", "tintindex": 0 },
+		"up":   { "uv": [ 0,  0, 16, 16 ], "texture": "#plant", "tintindex": 0 }
+	  }
+	},
+	{
+	  "from":     [ -8, 0, -1 ],
+	  "to":       [  8, 0, 17 ],
+	  "rotation": {
+		"angle":  -45,
+		"axis":   "z",
+		"origin": [ 8, 0, 8 ]
+	  },
+	  "shade":    false,
+	  "faces":    {
+		"down": { "uv": [ 0, 16, 16,  0 ], "rotation": 90,  "texture": "#plant", "tintindex": 0 },
+		"up":   { "uv": [ 0,  0, 16, 16 ], "rotation": 270, "texture": "#plant", "tintindex": 0 }
+	  }
+	}
+  ]
 }

--- a/src/main/resources/assets/tfc/models/block/plant/sword_fern.json
+++ b/src/main/resources/assets/tfc/models/block/plant/sword_fern.json
@@ -1,128 +1,128 @@
 {
-	"credit": "Made with Blockbench",
-	"textures": {
-		"1": "tfc:block/plant/sword_fern/sword_fern",
-		"particle": "tfc:block/plant/sword_fern/sword_fern"
-	},
+  "ambientocclusion": false,
+  "textures": {
+	"plant":    "tfc:block/plant/sword_fern/sword_fern",
+	"particle": "tfc:block/plant/sword_fern/sword_fern"
+  },
 	"elements": [
 		{
-			"name": "lowerN",
 			"from": [-8, 0, 6],
 			"to": [24, 8, 6],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 0, 6]},
+			"shade": false,
 			"faces": {
-				"north": {"uv": [16, 12, 0, 16], "texture": "#1", "tintindex": 0},
-				"south": {"uv": [0, 12, 16, 16], "texture": "#1", "tintindex": 0}
+				"north": {"uv": [16, 12, 0, 16], "texture": "#plant", "tintindex": 0},
+				"south": {"uv": [0, 12, 16, 16], "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "midN",
 			"from": [-8, 7.39, 2.94],
 			"to": [24, 17.39, 2.94],
 			"rotation": {"angle": -45, "axis": "x", "origin": [8, 7.39, 2.94]},
+			"shade": false,
 			"faces": {
-				"north": {"uv": [16, 7, 0, 12], "texture": "#1", "tintindex": 0},
-				"south": {"uv": [0, 7, 16, 12], "texture": "#1", "tintindex": 0}
+				"north": {"uv": [16, 7, 0, 12], "texture": "#plant", "tintindex": 0},
+				"south": {"uv": [0, 7, 16, 12], "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "upperN",
 			"from": [-8, 14.46, -12.13],
 			"to": [24, 14.46, -4.13],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 14.46, -4.13]},
+			"shade": false,
 			"faces": {
-				"up": {"uv": [0, 3, 16, 7], "texture": "#1", "tintindex": 0},
-				"down": {"uv": [16, 3, 0, 7], "rotation": 180, "texture": "#1", "tintindex": 0}
+				"up": {"uv": [0, 3, 16, 7], "texture": "#plant", "tintindex": 0},
+				"down": {"uv": [16, 3, 0, 7], "rotation": 180, "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "lowerS",
 			"from": [-8, 0, 10],
 			"to": [24, 8, 10],
 			"rotation": {"angle": 22.5, "axis": "x", "origin": [8, 0, 10]},
+			"shade": false,
 			"faces": {
-				"north": {"uv": [0, 12, 16, 16], "texture": "#1", "tintindex": 0},
-				"south": {"uv": [16, 12, 0, 16], "texture": "#1", "tintindex": 0}
+				"north": {"uv": [0, 12, 16, 16], "texture": "#plant", "tintindex": 0},
+				"south": {"uv": [16, 12, 0, 16], "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "midS",
 			"from": [-8, 7.39, 13.06],
 			"to": [24, 17.39, 13.06],
 			"rotation": {"angle": 45, "axis": "x", "origin": [8, 7.39, 13.06]},
+			"shade": false,
 			"faces": {
-				"north": {"uv": [0, 7, 16, 12], "texture": "#1", "tintindex": 0},
-				"south": {"uv": [16, 7, 0, 12], "texture": "#1", "tintindex": 0}
+				"north": {"uv": [0, 7, 16, 12], "texture": "#plant", "tintindex": 0},
+				"south": {"uv": [16, 7, 0, 12], "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "upperS",
 			"from": [-8, 14.46, 20.13],
 			"to": [24, 14.46, 28.13],
 			"rotation": {"angle": -22.5, "axis": "x", "origin": [0, 14.46, 20.13]},
+			"shade": false,
 			"faces": {
-				"up": {"uv": [0, 3, 16, 7], "rotation": 180, "texture": "#1", "tintindex": 0},
-				"down": {"uv": [16, 3, 0, 7], "texture": "#1", "tintindex": 0}
+				"up": {"uv": [0, 3, 16, 7], "rotation": 180, "texture": "#plant", "tintindex": 0},
+				"down": {"uv": [16, 3, 0, 7], "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "lowerE",
 			"from": [10, 0, -8],
 			"to": [10, 8, 24],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [10, 0, 8]},
+			"shade": false,
 			"faces": {
-				"east": {"uv": [16, 12, 0, 16], "texture": "#1", "tintindex": 0},
-				"west": {"uv": [0, 12, 16, 16], "texture": "#1", "tintindex": 0}
+				"east": {"uv": [16, 12, 0, 16], "texture": "#plant", "tintindex": 0},
+				"west": {"uv": [0, 12, 16, 16], "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "upperE",
 			"from": [-12.13, 14.46, -8],
 			"to": [-4.13, 14.46, 24],
 			"rotation": {"angle": -22.5, "axis": "z", "origin": [-4.13, 14.46, 0]},
+			"shade": false,
 			"faces": {
-				"up": {"uv": [0, 3, 16, 7], "rotation": 270, "texture": "#1", "tintindex": 0},
-				"down": {"uv": [16, 3, 0, 7], "rotation": 270, "texture": "#1", "tintindex": 0}
+				"up": {"uv": [0, 3, 16, 7], "rotation": 270, "texture": "#plant", "tintindex": 0},
+				"down": {"uv": [16, 3, 0, 7], "rotation": 270, "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "upperE",
 			"from": [20.13, 14.46, -8],
 			"to": [28.13, 14.46, 24],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [20.13, 14.46, 0]},
+			"shade": false,
 			"faces": {
-				"up": {"uv": [0, 3, 16, 7], "rotation": 90, "texture": "#1", "tintindex": 0},
-				"down": {"uv": [16, 3, 0, 7], "rotation": 90, "texture": "#1", "tintindex": 0}
+				"up": {"uv": [0, 3, 16, 7], "rotation": 90, "texture": "#plant", "tintindex": 0},
+				"down": {"uv": [16, 3, 0, 7], "rotation": 90, "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "midE",
 			"from": [13.06, 7.39, -8],
 			"to": [13.06, 17.39, 24],
 			"rotation": {"angle": -45, "axis": "z", "origin": [13.06, 7.39, 0]},
+			"shade": false,
 			"faces": {
-				"east": {"uv": [16, 7, 0, 12], "texture": "#1", "tintindex": 0},
-				"west": {"uv": [0, 7, 16, 12], "texture": "#1", "tintindex": 0}
+				"east": {"uv": [16, 7, 0, 12], "texture": "#plant", "tintindex": 0},
+				"west": {"uv": [0, 7, 16, 12], "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "midW",
 			"from": [2.94, 7.39, -8],
 			"to": [2.94, 17.39, 24],
 			"rotation": {"angle": 45, "axis": "z", "origin": [2.94, 7.39, 0]},
+			"shade": false,
 			"faces": {
-				"east": {"uv": [0, 7, 16, 12], "texture": "#1", "tintindex": 0},
-				"west": {"uv": [16, 7, 0, 12], "texture": "#1", "tintindex": 0}
+				"east": {"uv": [0, 7, 16, 12], "texture": "#plant", "tintindex": 0},
+				"west": {"uv": [16, 7, 0, 12], "texture": "#plant", "tintindex": 0}
 			}
 		},
 		{
-			"name": "lowerW",
 			"from": [6, 0, -8],
 			"to": [6, 8, 24],
 			"rotation": {"angle": 22.5, "axis": "z", "origin": [6, 0, 8]},
+			"shade": false,
 			"faces": {
-				"east": {"uv": [0, 12, 16, 16], "texture": "#1", "tintindex": 0},
-				"west": {"uv": [16, 12, 0, 16], "texture": "#1", "tintindex": 0}
+				"east": {"uv": [0, 12, 16, 16], "texture": "#plant", "tintindex": 0},
+				"west": {"uv": [16, 12, 0, 16], "texture": "#plant", "tintindex": 0}
 			}
 		}
 	]

--- a/src/main/resources/assets/tfc/models/block/plant/trillium_3.json
+++ b/src/main/resources/assets/tfc/models/block/plant/trillium_3.json
@@ -1,41 +1,56 @@
 {
-	"credit": "Made with Blockbench",
-	"textures": {
-		"2": "tfc:block/plant/trillium/trillium_flower_back",
-		"particle": "tfc:block/plant/trillium/trillium_flower_back",
-		"cross": "tfc:block/plant/trillium/trillium",
-		"top": "tfc:block/plant/trillium/trillium_flower"
+  "ambientocclusion": false,
+  "textures":         {
+	"back":     "tfc:block/plant/trillium/trillium_flower_back",
+	"cross":    "tfc:block/plant/trillium/trillium",
+	"top":      "tfc:block/plant/trillium/trillium_flower",
+	"particle": "tfc:block/plant/trillium/trillium_flower_back"
+  },
+  "elements":         [
+	{
+	  "from":     [  0, 0,  8 ],
+	  "to":       [ 16, 16, 8 ],
+	  "rotation": {
+		"angle":   45,
+		"axis":    "y",
+		"origin":  [ 8, 8, 8 ],
+		"rescale": true
+	  },
+	  "shade":    false,
+	  "faces":    {
+		"north": { "uv": [ 0, 0, 16, 16 ], "texture": "#cross" },
+		"south": { "uv": [ 0, 0, 16, 16 ], "texture": "#cross" }
+	  }
 	},
-	"elements": [
-		{
-			"name": "cross",
-			"from": [0, 0, 8],
-			"to": [16, 16, 8],
-			"rotation": {"angle": 45, "axis": "y", "origin": [8, 8, 8]},
-			"faces": {
-				"north": {"uv": [16, 0, 0, 16], "texture": "#cross"},
-				"south": {"uv": [16, 0, 0, 16], "texture": "#cross"}
-			}
-		},
-		{
-			"name": "cross",
-			"from": [0, 0, 8],
-			"to": [16, 16, 8],
-			"rotation": {"angle": -45, "axis": "y", "origin": [8, 8, 8]},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "texture": "#cross"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#cross"}
-			}
-		},
-		{
-			"name": "top",
-			"from": [0, 4, 8],
-			"to": [16, 20, 8],
-			"rotation": {"angle": -22.5, "axis": "x", "origin": [8, 12, 8]},
-			"faces": {
-				"north": {"uv": [0, 0, 16, 16], "rotation": 180, "texture": "#2"},
-				"south": {"uv": [0, 0, 16, 16], "texture": "#top"}
-			}
-		}
-	]
+	{
+	  "from":     [  0,  0, 8 ],
+	  "to":       [ 16, 16, 8 ],
+	  "rotation": {
+		"angle":   -45,
+		"axis":    "y",
+		"origin":  [ 8, 8, 8 ],
+		"rescale": true
+	  },
+	  "shade":    false,
+	  "faces": {
+		"north": { "uv": [ 0, 0, 16, 16 ], "texture": "#cross" },
+		"south": { "uv": [ 0, 0, 16, 16 ], "texture": "#cross" }
+	  }
+	},
+	{
+	  "from":     [  0,  4, 8 ],
+	  "to":       [ 16, 20, 8 ],
+	  "rotation": {
+		"angle":  -22.5,
+		"axis":   "x",
+		"origin": [ 8, 12, 8 ],
+		"rescale": true
+	  },
+	  "shade":    false,
+	  "faces": {
+		"north": { "uv": [ 0, 0, 16, 16 ], "texture": "#back", "rotation": 180 },
+		"south": { "uv": [ 0, 0, 16, 16 ], "texture": "#top"}
+	  }
+	}
+  ]
 }

--- a/src/main/resources/assets/tfc/models/block/scribing_table.json
+++ b/src/main/resources/assets/tfc/models/block/scribing_table.json
@@ -1,169 +1,166 @@
 {
-	"credit": "Made with Blockbench",
-	"ambientocclusion": false,
-	"elements": [
-		{
-			"shade": true,
-			"from": [12, 0, 1],
-			"to": [15, 12, 4],
-			"faces": {
-				"north": {"uv": [6, 4, 9, 16], "texture": "#leg"},
-				"east": {"uv": [0, 4, 3, 16], "texture": "#leg"},
-				"south": {"uv": [9, 4, 12, 16], "texture": "#leg"},
-				"west": {"uv": [3, 4, 6, 16], "texture": "#leg"},
-				"down": {"uv": [0, 0, 3, 3], "texture": "#leg"}
-			}
-		},
-		{
-			"name": "leg",
-			"shade": true,
-			"from": [12, 0, 12],
-			"to": [15, 12, 15],
-			"faces": {
-				"north": {"uv": [3, 0, 6, 12], "texture": "#leg"},
-				"east": {"uv": [0, 4, 3, 16], "texture": "#leg"},
-				"south": {"uv": [0, 0, 3, 12], "texture": "#leg"},
-				"west": {"uv": [3, 4, 6, 16], "texture": "#leg"},
-				"down": {"uv": [0, 0, 3, 3], "texture": "#leg"}
-			}
-		},
-		{
-			"name": "leg",
-			"shade": true,
-			"from": [1, 0, 1],
-			"to": [4, 12, 4],
-			"faces": {
-				"north": {"uv": [9, 4, 12, 16], "texture": "#leg"},
-				"east": {"uv": [0, 4, 3, 16], "texture": "#leg"},
-				"south": {"uv": [6, 4, 9, 16], "texture": "#leg"},
-				"west": {"uv": [3, 4, 6, 16], "texture": "#leg"},
-				"down": {"uv": [0, 0, 3, 3], "texture": "#leg"}
-			}
-		},
-		{
-			"name": "leg",
-			"shade": true,
-			"from": [1, 0, 12],
-			"to": [4, 12, 15],
-			"faces": {
-				"north": {"uv": [3, 0, 6, 12], "texture": "#leg"},
-				"east": {"uv": [0, 4, 3, 16], "texture": "#leg"},
-				"south": {"uv": [0, 0, 3, 12], "texture": "#leg"},
-				"west": {"uv": [3, 4, 6, 16], "texture": "#leg"},
-				"down": {"uv": [0, 0, 3, 3], "texture": "#leg"}
-			}
-		},
-		{
-			"shade": true,
-			"from": [0, 12, 0],
-			"to": [16, 16, 16],
-			"faces": {
-				"north": {"uv": [0, 0, 16, 4], "texture": "#top"},
-				"east": {"uv": [0, 4, 16, 8], "texture": "#top"},
-				"south": {"uv": [0, 8, 16, 12], "texture": "#top"},
-				"west": {"uv": [0, 12, 16, 16], "texture": "#top"},
-				"up": {"uv": [0, 0, 16, 16], "texture": "#top"},
-				"down": {"uv": [0, 0, 16, 16], "texture": "#top"}
-			}
-		},
-		{
-			"name": "side",
-			"shade": true,
-			"from": [12, 5, 4],
-			"to": [14, 12, 12],
-			"faces": {
-				"east": {"uv": [0, 3, 8, 10], "texture": "#side"},
-				"west": {"uv": [0, 3, 8, 10], "texture": "#side"},
-				"down": {"uv": [0, 0, 2, 8], "texture": "#top"}
-			}
-		},
-		{
-			"name": "side",
-			"shade": true,
-			"from": [2, 5, 4],
-			"to": [4, 12, 12],
-			"faces": {
-				"east": {"uv": [8, 3, 16, 10], "texture": "#side"},
-				"west": {"uv": [8, 3, 16, 10], "texture": "#side"},
-				"down": {"uv": [0, 0, 2, 8], "texture": "#top"}
-			}
-		},
-		{
-			"name": "inkwell",
-			"shade": true,
-			"from": [1, 16, 10],
-			"to": [4, 19, 13],
-			"rotation": {"angle": 0, "axis": "y", "origin": [0, 0, -2]},
-			"faces": {
-				"north": {"uv": [0, 0, 3, 3], "texture": "#misc"},
-				"east": {"uv": [3, 0, 6, 3], "texture": "#misc"},
-				"south": {"uv": [6, 0, 9, 3], "texture": "#misc"},
-				"west": {"uv": [9, 0, 12, 3], "texture": "#misc"},
-				"up": {"uv": [12, 0, 15, 3], "texture": "#misc"}
-			}
-		},
-		{
-			"name": "feather",
-			"from": [2.5, 19, 10.5],
-			"to": [2.5, 27, 14.5],
-			"rotation": {"angle": -45, "axis": "y", "origin": [2.5, 19, 11.5]},
-			"faces": {
-				"east": {"uv": [16, 8, 12, 16], "texture": "#misc"},
-				"west": {"uv": [12, 8, 16, 16], "texture": "#misc"}
-			}
-		},
-		{
-			"name": "cover",
-			"shade": true,
-			"from": [1, 15.8, 3],
-			"to": [12, 16.8, 10],
-			"rotation": {"angle": 22.5, "axis": "y", "origin": [5, 22, 0]},
-			"faces": {
-				"north": {"uv": [0, 9, 11, 10], "texture": "#misc"},
-				"east": {"uv": [0, 15, 7, 16], "texture": "#misc"},
-				"south": {"uv": [0, 9, 11, 10], "texture": "#misc"},
-				"west": {"uv": [0, 15, 7, 16], "texture": "#misc"},
-				"up": {"uv": [0, 9, 11, 16], "rotation": 180, "texture": "#misc"}
-			}
-		},
-		{
-			"name": "pages",
-			"shade": true,
-			"from": [2, 16.55, 4],
-			"to": [11, 17.55, 9],
-			"rotation": {"angle": 22.5, "axis": "y", "origin": [5, 22, 0]},
-			"faces": {
-				"north": {"uv": [1, 10, 10, 11], "texture": "#misc"},
-				"east": {"uv": [1, 10, 6, 11], "texture": "#misc"},
-				"south": {"uv": [1, 10, 10, 11], "texture": "#misc"},
-				"west": {"uv": [5, 14, 10, 15], "texture": "#misc"},
-				"up": {"uv": [1, 10, 10, 15], "rotation": 180, "texture": "#misc"}
-			}
-		}
-	],
-	"display": {
-		"thirdperson_righthand": {
-			"scale": [0.35, 0.35, 0.35]
-		},
-		"thirdperson_lefthand": {
-			"scale": [0.35, 0.35, 0.35]
-		},
-		"firstperson_righthand": {
-			"rotation": [0, 45, 0],
-			"scale": [0.4, 0.4, 0.4]
-		},
-		"firstperson_lefthand": {
-			"rotation": [0, -45, 0],
-			"scale": [0.4, 0.4, 0.4]
-		},
-		"ground": {
-			"translation": [0, 1, 0],
-			"scale": [0.3, 0.3, 0.3]
-		},
-		"gui": {
-			"rotation": [25, -45, 0],
-			"translation": [0, -1.75, 0],
-			"scale": [0.55, 0.55, 0.55]
-		}
+  "ambientocclusion": false,
+  "display":          {
+	"ground":                {
+	  "translation": [   0,   1,   0 ],
+	  "scale":       [ 0.3, 0.3, 0.3 ]
+	},
+	"gui":                   {
+	  "rotation":    [   25,   -45,    0 ],
+	  "translation": [    0, -1.75,    0 ],
+	  "scale":       [ 0.55,  0.55, 0.55 ]
+	},
+	"thirdperson_lefthand":  {
+	  "scale": [ 0.35, 0.35, 0.35 ]
+	},
+	"thirdperson_righthand": {
+	  "scale": [ 0.35, 0.35, 0.35 ]
+	},
+	"firstperson_lefthand":  {
+	  "rotation": [   0, -45,   0 ],
+	  "scale":    [ 0.4, 0.4, 0.4 ]
+	},
+	"firstperson_righthand": {
+	  "rotation": [   0,  45,   0 ],
+	  "scale":    [ 0.4, 0.4, 0.4 ]
 	}
+  },
+  "elements":         [
+    {
+	  "from":  [ 12,  0, 1 ],
+	  "to":    [ 15, 12, 4 ],
+	  "faces": {
+		"down":  { "uv": [ 0, 0,  3,  3 ], "texture": "#leg", "cullface": "down" },
+		"north": { "uv": [ 6, 4,  9, 16 ], "texture": "#leg" },
+		"south": { "uv": [ 9, 4, 12, 16 ], "texture": "#leg" },
+		"west":  { "uv": [ 3, 4,  6, 16 ], "texture": "#leg" },
+		"east":  { "uv": [ 0, 4,  3, 16 ], "texture": "#leg" }
+	  }
+	},
+	{
+	  "from":  [ 12,  0, 12 ],
+	  "to":    [ 15, 12, 15 ],
+	  "faces": {
+		"down":  { "uv": [ 0, 0, 3,  3 ], "texture": "#leg", "cullface": "down" },
+		"north": { "uv": [ 3, 0, 6, 12 ], "texture": "#leg" },
+		"south": { "uv": [ 0, 0, 3, 12 ], "texture": "#leg" },
+		"west":  { "uv": [ 3, 4, 6, 16 ], "texture": "#leg" },
+		"east":  { "uv": [ 0, 4, 3, 16 ], "texture": "#leg" }
+	  }
+	},
+	{
+	  "from":  [ 1,  0, 1 ],
+	  "to":    [ 4, 12, 4 ],
+	  "faces": {
+		"down":  { "uv": [ 0, 0,  3,  3 ], "texture": "#leg", "cullface": "down" },
+		"north": { "uv": [ 9, 4, 12, 16 ], "texture": "#leg" },
+		"south": { "uv": [ 6, 4,  9, 16 ], "texture": "#leg" },
+		"west":  { "uv": [ 3, 4,  6, 16 ], "texture": "#leg" },
+		"east":  { "uv": [ 0, 4,  3, 16 ], "texture": "#leg" }
+	  }
+	},
+	{
+	  "from":  [ 1,  0, 12 ],
+	  "to":    [ 4, 12, 15 ],
+	  "faces": {
+		"down":  { "uv": [ 0, 0, 3,  3 ], "texture": "#leg", "cullface": "down" },
+		"north": { "uv": [ 3, 0, 6, 12 ], "texture": "#leg" },
+		"south": { "uv": [ 0, 0, 3, 12 ], "texture": "#leg" },
+		"west":  { "uv": [ 3, 4, 6, 16 ], "texture": "#leg" },
+		"east":  { "uv": [ 0, 4, 3, 16 ], "texture": "#leg" }
+	  }
+	},
+	{
+	  "from":  [  0, 12,  0 ],
+	  "to":    [ 16, 16, 16 ],
+	  "faces": {
+		"down":  { "uv": [ 0,  0, 16, 16 ], "texture": "#top" },
+		"up":    { "uv": [ 0,  0, 16, 16 ], "texture": "#top", "cullface": "up" },
+		"north": { "uv": [ 0,  0, 16,  4 ], "texture": "#top", "cullface": "north" },
+		"south": { "uv": [ 0,  8, 16, 12 ], "texture": "#top", "cullface": "south" },
+		"west":  { "uv": [ 0, 12, 16, 16 ], "texture": "#top", "cullface": "west" },
+		"east":  { "uv": [ 0,  4, 16,  8 ], "texture": "#top", "cullface": "east" }
+	  }
+	},
+	{
+	  "from":  [ 12,  5,  4 ],
+	  "to":    [ 14, 12, 12 ],
+	  "faces": {
+		"down": {"uv": [ 0, 0, 2,  8 ], "texture": "#top" },
+		"west": {"uv": [ 0, 3, 8, 10 ], "texture": "#side" },
+		"east": {"uv": [ 0, 3, 8, 10 ], "texture": "#side" }
+	  }
+	},
+	{
+	  "from":  [ 2,  5,  4 ],
+	  "to":    [ 4, 12, 12 ],
+	  "faces": {
+		"down": { "uv": [ 0, 0,  2,  8 ], "texture": "#top" },
+		"west": { "uv": [ 8, 3, 16, 10 ], "texture": "#side" },
+		"east": { "uv": [ 8, 3, 16, 10 ], "texture": "#side" }
+	  }
+	},
+	{
+	  "from":     [ 1, 16, 10 ],
+	  "to":       [ 4, 19, 13 ],
+	  "rotation": {
+		"angle":  0,
+		"axis":   "y",
+		"origin": [ 0, 0, -2 ]
+	  },
+	  "faces":    {
+		"up":    { "uv": [ 12, 0, 15, 3 ], "texture": "#misc", "cullface": "up" },
+		"north": { "uv": [  0, 0,  3, 3 ], "texture": "#misc", "cullface": "up" },
+		"south": { "uv": [  6, 0,  9, 3 ], "texture": "#misc", "cullface": "up" },
+		"west":  { "uv": [  9, 0, 12, 3 ], "texture": "#misc", "cullface": "up" },
+		"east":  { "uv": [  3, 0,  6, 3 ], "texture": "#misc", "cullface": "up" }
+	  }
+	},
+	{
+	  "from":     [ 2.5, 19, 10.5 ],
+	  "to":       [ 2.5, 27, 14.5 ],
+	  "rotation": {
+		"angle":  -45,
+		"axis":   "y",
+		"origin": [ 2.5, 19, 11.5 ]
+	  },
+	  "shade":    false,
+	  "faces":    {
+		"west": { "uv": [ 12, 8, 16, 16 ], "texture": "#misc", "cullface": "up" },
+		"east": { "uv": [ 16, 8, 12, 16 ], "texture": "#misc", "cullface": "up" }
+	  }
+	},
+	{
+	  "from":     [  1, 15.8,  3 ],
+	  "to":       [ 12, 16.8, 10 ],
+	  "rotation": {
+		"angle":  22.5,
+		"axis":   "y",
+		"origin": [ 5, 22, 0 ]
+	  },
+	  "faces": {
+		"north": { "uv": [ 0,  9, 11, 10 ], "texture": "#misc", "cullface": "up" },
+		"east":  { "uv": [ 0, 15,  7, 16 ], "texture": "#misc", "cullface": "up" },
+		"south": { "uv": [ 0,  9, 11, 10 ], "texture": "#misc", "cullface": "up" },
+		"west":  { "uv": [ 0, 15,  7, 16 ], "texture": "#misc", "cullface": "up" },
+		"up":    { "uv": [ 0,  9, 11, 16 ], "texture": "#misc", "rotation": 180, "cullface": "up" }
+	  }
+	},
+	{
+	  "from":     [  2, 16.55, 4 ],
+	  "to":       [ 11, 17.55, 9 ],
+	  "rotation": {
+		"angle": 22.5,
+		"axis": "y",
+		"origin": [5, 22, 0]
+	  },
+	  "faces":    {
+		"north": { "uv": [ 1, 10, 10, 11 ], "texture": "#misc", "cullface": "up" },
+		"east":  { "uv": [ 1, 10,  6, 11 ], "texture": "#misc", "cullface": "up" },
+		"south": { "uv": [ 1, 10, 10, 11 ], "texture": "#misc", "cullface": "up" },
+		"west":  { "uv": [ 5, 14, 10, 15 ], "texture": "#misc", "cullface": "up" },
+		"up":    { "uv": [ 1, 10, 10, 15 ], "texture": "#misc", "rotation": 180, "cullface": "up" }
+	  }
+	}
+  ]
 }

--- a/src/main/resources/assets/tfc/models/block/scribing_table.json
+++ b/src/main/resources/assets/tfc/models/block/scribing_table.json
@@ -3,7 +3,6 @@
 	"ambientocclusion": false,
 	"elements": [
 		{
-			"name": "leg",
 			"shade": true,
 			"from": [12, 0, 1],
 			"to": [15, 12, 4],


### PR DESCRIPTION
- Faces which can never be seen without clipping into the block have now been removed from three potted plants (barrel cacti, moss and reindeer lichen)
- Shading has been disabled for arrowheads, athyrium ferns, lady ferns and sword ferns as they appeared darker in-game than they were probably intended to; they should now look more in line with other plants as a result
- The default trillium model has been fixed to now look more like the others
- The large tinted cross model (used by tall fescue grass) has also been changed to fit in line with other crosses: no shading, no AO
- Optimized versions of the default ceramic vessel model (both open and closed) have been added - these look identical to the current models, but require less triangles to render and should therefore contribute less to render lag
- The crucible model has also been optimized, looking identical to how it did previously (except for on the bottom, since the mapping was strange previously - this is a very minor change and almost impossible to not miss)
- The nest box model has also been optimized, removing a bunch of redundant interior planes in the process; they will now look different from how they did previously but still retain the same shape (and should be easier to texture)
- Scribing tables now use cullface to remove unwanted faces when next to blocks

I tried reformatting some of the model files for easier readability, but gave up since many of them had very strange formatting standards which would be very time-consuming to convert. This would not affect the in-game appearances of the blocks themselves anyway.