### PR TITLE
 Added nutrition after death config

### DIFF
--- a/src/main/java/net/dries007/tfc/ForgeEventHandler.java
+++ b/src/main/java/net/dries007/tfc/ForgeEventHandler.java
@@ -258,6 +258,7 @@ public final class ForgeEventHandler
         bus.addListener(ForgeEventHandler::onItemExpire);
         bus.addListener(ForgeEventHandler::onPlayerLoggedIn);
         bus.addListener(ForgeEventHandler::onPlayerRespawn);
+        bus.addListener(ForgeEventHandler::onPlayerDeath);
         bus.addListener(ForgeEventHandler::onPlayerChangeDimension);
         bus.addListener(ForgeEventHandler::onServerChat);
         bus.addListener(ForgeEventHandler::onPlayerRightClickBlock);
@@ -1157,6 +1158,15 @@ public final class ForgeEventHandler
     public static void onPlayerRespawn(PlayerEvent.PlayerRespawnEvent event)
     {
         onNewPlayerInWorld(event.getPlayer());
+    }
+
+    public static void onPlayerDeath(PlayerEvent.Clone event)
+    {
+        if (TFCConfig.SERVER.keepNutritionAfterDeath.get())
+        {
+            Player oldPlayer = event.getOriginal();
+            TFCFoodData.restoreFoodStatsAfterDeath(oldPlayer, event.getPlayer());
+        }
     }
 
     public static void onPlayerChangeDimension(PlayerEvent.PlayerChangedDimensionEvent event)

--- a/src/main/java/net/dries007/tfc/common/capabilities/food/TFCFoodData.java
+++ b/src/main/java/net/dries007/tfc/common/capabilities/food/TFCFoodData.java
@@ -82,6 +82,21 @@ public class TFCFoodData extends net.minecraft.world.food.FoodData
         }
     }
 
+    public static void restoreFoodStatsAfterDeath(Player oldPlayer, Player newPlayer)
+    {
+        // get old and new Player's stats
+        final net.minecraft.world.food.FoodData oldFoodStats = oldPlayer.getFoodData();
+        final net.minecraft.world.food.FoodData newFoodStats = newPlayer.getFoodData();
+
+        // don't know how this check actually works, but I guess I'm just checking if we got TFCFoodData from player.getFoodData()
+        if (oldFoodStats instanceof TFCFoodData)
+        {
+            final TFCFoodData newStats = new TFCFoodData(oldPlayer, newFoodStats, ((TFCFoodData) oldFoodStats).getNutrition());
+            ((PlayerAccessor) newPlayer).accessor$setFoodData(newStats);
+            newPlayer.getCapability(PlayerDataCapability.CAPABILITY).ifPresent(cap -> cap.writeTo(newStats));
+        }
+    }
+
     private final Player sourcePlayer;
     private final net.minecraft.world.food.FoodData delegate; // We keep this here to do normal vanilla tracking (rather than using super). This is also friendlier to other mods if they replace this
     private final NutritionData nutritionData; // Separate handler for nutrition, because it's a bit complex
@@ -93,6 +108,14 @@ public class TFCFoodData extends net.minecraft.world.food.FoodData
         this.sourcePlayer = sourcePlayer;
         this.delegate = delegate;
         this.nutritionData = new NutritionData(0.5f, 0.0f);
+        this.thirst = MAX_THIRST;
+    }
+
+    public TFCFoodData(Player sourcePlayer, net.minecraft.world.food.FoodData delegate, NutritionData oldNutritionData)
+    {
+        this.sourcePlayer = sourcePlayer;
+        this.delegate = delegate;
+        this.nutritionData = oldNutritionData;
         this.thirst = MAX_THIRST;
     }
 

--- a/src/main/java/net/dries007/tfc/config/ServerConfig.java
+++ b/src/main/java/net/dries007/tfc/config/ServerConfig.java
@@ -205,6 +205,7 @@ public class ServerConfig
     public final ForgeConfigSpec.DoubleValue thirstGainedFromDrinkingInTheRain;
     public final ForgeConfigSpec.DoubleValue naturalRegenerationModifier;
     public final ForgeConfigSpec.IntValue nutritionRotationHungerWindow;
+    public final ForgeConfigSpec.BooleanValue keepNutritionAfterDeath;
     public final ForgeConfigSpec.IntValue foodDecayStackWindow;
     public final ForgeConfigSpec.DoubleValue foodDecayModifier;
     public final ForgeConfigSpec.BooleanValue enableOverburdening;
@@ -555,6 +556,8 @@ public class ServerConfig
         nutritionRotationHungerWindow = builder.apply("nutritionRotationHungerWindow").comment(
             "How much total hunger consumed is required to completely refresh the player's nutrition.",
             "Player nutrition in TFC is calculated based on nutrition of the last few foods eaten - this is how many foods are used to calculate nutrition. By default, all TFC foods restore 4 hunger.").defineInRange("nutritionRotationHungerWindow", 80, 1, Integer.MAX_VALUE);
+        keepNutritionAfterDeath = builder.apply("keepNutritionAfterDeath").comment(
+            "If player's nutrition should be kept even after death. Hunger and thirst are not affected and will be reset.").define("keepNutritionAfterDeath", false);
         foodDecayStackWindow = builder.apply("foodDecayStackWindow").comment(
             "How many hours should different foods ignore when trying to stack together automatically?",
             "Food made with different creation dates doesn't stack by default, unless it's within a specific window. This is the number of hours that different foods will try and stack together at the loss of a little extra expiry time.").defineInRange("foodDecayStackWindow", 6, 1, 100);


### PR DESCRIPTION
Added configuration option to keep player nutrition not reset after death.
Addressing the suggestion from #1495 