### PR TITLE
1.20 - Fix building TFC mod

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,6 @@ repositories {
     mavenLocal()
     maven(url = "https://dvs1.progwml6.com/files/maven/") // JEI
     maven(url = "https://modmaven.k-4u.nl") // Mirror for JEI
-    maven(url = "https://alcatrazescapee.jfrog.io/artifactory/mods") // Cyanide
     maven(url = "https://maven.blamejared.com") // Patchouli
     maven(url = "https://www.cursemaven.com") {
         content {


### PR DESCRIPTION
The alcatrazescapee jfrog repo is dead, and not needed for TFC to compille sucessfully.

Furthermore building with this repo cause persistent corruptions to forge gradle.

Can be fixed by deleting `.gradle/caches/forge_gradle/maven_downloader`

The only case where it won't cause corruption is if you already downloaded the files from another project.