### PR TITLE
Fix eating animation of the rat.

### DIFF
--- a/src/main/java/net/dries007/tfc/common/entities/prey/Pest.java
+++ b/src/main/java/net/dries007/tfc/common/entities/prey/Pest.java
@@ -97,7 +97,7 @@ public class Pest extends Prey
     public void tick()
     {
         final ItemStack held = getMainHandItem();
-        if (!held.isEmpty())
+        if (!held.isEmpty() || eatingAnimation.isStarted())
         {
             dragTicks++;
             if (dragTicks < DRAG_TIME)
@@ -119,7 +119,7 @@ public class Pest extends Prey
                         playSound(SoundEvents.GENERIC_EAT, getSoundVolume(), getVoicePitch());
                     }
                 }
-                if (dragTicks > DRAG_TIME + EAT_TIME)
+                if (dragTicks > (DRAG_TIME + EAT_TIME))
                 {
                     setItemSlot(EquipmentSlot.MAINHAND, ItemStack.EMPTY);
                     if (level.isClientSide)


### PR DESCRIPTION
The root cause of the problem was that the eating animation was not being stopped when the server thread removed the item from the mouse's hand. This was due to the fact that the code logic relied solely on the condition if (!held.isEmpty()) to determine whether the mouse was holding an item. Consequently, when the item was removed by the server thread, the animation was not being halted by the Render Thread as intended.

To rectify this, I made the necessary changes to the code. By including an additional check, || eatingAnimation.isStarted(), in the condition of the if statement, I ensured that the eating animation would continue to be stopped even if the mouse's hand became empty due to server-side actions.

Fixes #2295