### PR TITLE
Add [47.1.81,) to the list of valid versions

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -36,7 +36,7 @@ issueTrackerURL = "https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues"
     # NeoForge crashes on [47.1.51, 47.1.81) due to issue #256, but we can support later versions with the backported fix
     # We build against 47.1.3, which is the 'last known stable' version of Forge before the fork
     # So the version range here is restricted to only known versions where there are no issues.
-    versionRange = "[47.1.3,47.1.6),[47.1.81,),[47.2.6,)"
+    versionRange = "[47.1.3,47.1.6),[47.1.81,47.2.0),[47.2.6,)"
     ordering = "AFTER"
     side = "BOTH"
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -33,10 +33,10 @@ issueTrackerURL = "https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues"
     mandatory = true
     # Forge crashes on [47.1.36, 47.2.6) due to issue #9774
     # Forge also fails to spawn entities on at least [47.1.6, 47.1.30) due to issue #9788
-    # NeoForge crashes on [47.1.51, ) due to issue #256 (as far as I'm aware, not fixed in 1.20.1). It's also unlikely they release a 47.2.x version.
+    # NeoForge crashes on [47.1.51, 47.1.81) due to issue #256, but we can support later versions with the backported fix
     # We build against 47.1.3, which is the 'last known stable' version of Forge before the fork
     # So the version range here is restricted to only known versions where there are no issues.
-    versionRange = "[47.1.3,47.1.6),[47.2.6,)"
+    versionRange = "[47.1.3,47.1.6),[47.1.81,),[47.2.6,)"
     ordering = "AFTER"
     side = "BOTH"
 

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -33,7 +33,7 @@ issueTrackerURL = "https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues"
     mandatory = true
     # Forge crashes on [47.1.36, 47.2.6) due to issue #9774
     # Forge also fails to spawn entities on at least [47.1.6, 47.1.30) due to issue #9788
-    # NeoForge crashes on [47.1.51, 47.1.81) due to issue #256, but we can support later versions with the backported fix
+    # NeoForge crashes on [47.1.51, 47.1.81) due to issue #256. It's unlikely they release a 47.2.x version, and Forge didn't reach 47.1.81, so any versions [47.1.81,47.2.0) should be strictly NeoForge
     # We build against 47.1.3, which is the 'last known stable' version of Forge before the fork
     # So the version range here is restricted to only known versions where there are no issues.
     versionRange = "[47.1.3,47.1.6),[47.1.81,47.2.0),[47.2.6,)"


### PR DESCRIPTION
The NeoForged issue got backported in https://github.com/neoforged/NeoForge/pull/308, so support *should* work for any version after that. Tested on Linux and 47.1.81 works, as well as 47.1.84.