### PR TITLE
Fix getToolModifiedState in ConnectedGrassBlock and DirtBlock

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/soil/ConnectedGrassBlock.java
@@ -194,9 +194,7 @@ public class ConnectedGrassBlock extends Block implements IGrassBlock
             }
             if (action == ToolActions.HOE_TILL && farmland != null && TFCConfig.SERVER.enableFarmlandCreation.get() && HoeItem.onlyIfAirAbove(context))
             {
-                final BlockState farmlandState = farmland.get().defaultBlockState();
-                HoeItem.changeIntoState(farmlandState).accept(context);
-                return farmlandState;
+                return farmland.get().defaultBlockState();
             }
         }
         return null;

--- a/src/main/java/net/dries007/tfc/common/blocks/soil/DirtBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/soil/DirtBlock.java
@@ -75,9 +75,7 @@ public class DirtBlock extends Block implements IDirtBlock
             }
             if (action == ToolActions.HOE_TILL && farmland != null && TFCConfig.SERVER.enableFarmlandCreation.get() && DirtBlock.emptyBlockAbove(context))
             {
-                final BlockState farmlandState = farmland.get().defaultBlockState();
-                HoeItem.changeIntoState(farmlandState).accept(context);
-                return farmlandState;
+                return farmland.get().defaultBlockState();
             }
         }
         return null;


### PR DESCRIPTION
When you try to get a blockstate after using a hoe on a block of grass or dirt, this block replaces it before blockstate returns, which is incorrect and does not allow some hoes from other mods to work correctly. Also, this method logically should not do anything with the block, but only return the modified blockstate.

After the fix, I checked the operation of hoes from some mods (GTCEu) (now works fine), as well as the operation of vanilla hoes and tfc hoes, everything works as before.