### PR TITLE
Fix for lamps remaining lit when emptying them with a bucket

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/LampBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/LampBlockEntity.java
@@ -41,6 +41,11 @@ public class LampBlockEntity extends TickCounterBlockEntity implements FluidTank
     @Override
     public void fluidTankChanged()
     {
+        assert level != null;
+        if (!level.isClientSide && tank.isEmpty() && getBlockState().getValue(LampBlock.LIT) && level.getBlockEntity(getBlockPos(), TFCBlockEntities.LAMP.get()).isPresent())
+        {
+            level.setBlockAndUpdate(getBlockPos(), getBlockState().setValue(LampBlock.LIT, false));
+        }
         markForSync();
     }
 

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/LampBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/LampBlock.java
@@ -119,10 +119,6 @@ public class LampBlock extends ExtendedBlock implements EntityBlockExtension
                     {
                         TFCAdvancements.LAVA_LAMP.trigger(serverPlayer);
                     }
-                    if (lamp.getFuel() == null)
-                    {
-                        level.setBlockAndUpdate(pos, state.setValue(LIT, false));
-                    }
                     return InteractionResult.SUCCESS;
                 }
                 return InteractionResult.sidedSuccess(level.isClientSide);


### PR DESCRIPTION
When using an empty bucket or barrel on a lit lamp, the fuel gets transferred to the bucket/barrel but the lamp remains lit.

While attempting a fix for this issue I noticed a few other inconsistencies.
- emptying an unlit lamp causes the fuel to get dumped on the ground and the lamp breaks (holding shift prevents this from happening, transferring the fuel successfully)
- adding fuel to a lit lamp causes the fuel to get dumped on the ground and breaks the lamp (adding fuel to an unlit lamp works successfully)

The changes in this commit fixes these issues as well