### PR TITLE
Change /clearworld NOT_ORE preset to clear everything that isn't ore

### DIFF
--- a/src/main/java/net/dries007/tfc/common/commands/ClearWorldCommand.java
+++ b/src/main/java/net/dries007/tfc/common/commands/ClearWorldCommand.java
@@ -6,6 +6,8 @@
 
 package net.dries007.tfc.common.commands;
 
+import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -113,16 +115,14 @@ public final class ClearWorldCommand
             return state -> blocks.contains(state.getBlock());
         }),
         NOT_ORE(server -> {
-            final Registry<ConfiguredFeature<?, ?>> registry = server.registryAccess().registryOrThrow(Registries.CONFIGURED_FEATURE);
-            Set<Block> blocks = registry.stream()
-                .filter(feature -> feature.feature() instanceof VeinFeature<?, ?>)
-                .flatMap(feature -> ((IVeinConfig) feature.config()).config()
-                    .states()
-                    .values()
-                    .stream()
-                    .flatMap(weighted -> weighted.values().stream()))
-                .map(BlockBehaviour.BlockStateBase::getBlock)
-                .collect(Collectors.toSet());
+            final Set<Block> blocks = Stream.of(
+                TFCBlocks.ORES.values().stream().flatMap(map -> map.values().stream().map(Supplier::get)),
+                TFCBlocks.GRADED_ORES.values().stream()
+                    .flatMap(oreMap -> oreMap.values().stream()
+                        .flatMap(gradeMap -> gradeMap.values().stream().map(Supplier::get))),
+                TFCBlocks.ORE_DEPOSITS.values().stream().flatMap(map -> map.values().stream().map(Supplier::get))
+            ).flatMap(t -> t).collect(Collectors.toSet());
+
             return state -> !blocks.contains(state.getBlock());
         });
 


### PR DESCRIPTION
Before, the NOT_ORE preset cleared everything generated by veins. This worked mostly fine, but unfortunately dikes also use the vein system. This means a bunch of igneous rocks like diorite, gabbro, granite, etc. don't get cleared properly. Often, when I do use the /clearworld command I just want to expose all ore, which makes the NOT_ORE preset a little annoying. This PR makes that preset work for my purposes (checking oregen) which I'm assuming was its original intention.