### PR TITLE
`BarrelRecipeWrapper` to not enforce people extend `BarrelBlockEntity.BarrelInventory`

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
@@ -60,7 +60,6 @@ import net.dries007.tfc.common.capabilities.size.Weight;
 import net.dries007.tfc.common.container.BarrelContainer;
 import net.dries007.tfc.common.fluids.FluidHelpers;
 import net.dries007.tfc.common.recipes.BarrelRecipe;
-import net.dries007.tfc.common.recipes.BarrelRecipeWrapper;
 import net.dries007.tfc.common.recipes.SealedBarrelRecipe;
 import net.dries007.tfc.common.recipes.TFCRecipeTypes;
 import net.dries007.tfc.common.recipes.inventory.EmptyInventory;
@@ -198,7 +197,7 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
 
     public BarrelBlockEntity(BlockPos pos, BlockState state)
     {
-        super(TFCBlockEntities.BARREL.get(), pos, state, BarrelInventory::new, NAME);
+        super(TFCBlockEntities.BARREL.get(), pos, state, BarrelBlockEntity.BarrelInventory::new, NAME);
 
         sidedFluidInventory = new SidedHandler.Builder<>(inventory);
 
@@ -555,7 +554,7 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
         return 0;
     }
 
-    public static class BarrelInventory implements DelegateItemHandler, DelegateFluidHandler, INBTSerializable<CompoundTag>, EmptyInventory, FluidTankCallback, BarrelRecipeWrapper
+    public static class BarrelInventory implements DelegateItemHandler, DelegateFluidHandler, INBTSerializable<CompoundTag>, EmptyInventory, FluidTankCallback, net.dries007.tfc.common.recipes.inventory.BarrelInventory
     {
         private final BarrelInventoryCallback callback;
         private final InventoryItemHandler inventory;

--- a/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
@@ -60,6 +60,7 @@ import net.dries007.tfc.common.capabilities.size.Weight;
 import net.dries007.tfc.common.container.BarrelContainer;
 import net.dries007.tfc.common.fluids.FluidHelpers;
 import net.dries007.tfc.common.recipes.BarrelRecipe;
+import net.dries007.tfc.common.recipes.BarrelRecipeWrapper;
 import net.dries007.tfc.common.recipes.SealedBarrelRecipe;
 import net.dries007.tfc.common.recipes.TFCRecipeTypes;
 import net.dries007.tfc.common.recipes.inventory.EmptyInventory;
@@ -554,7 +555,7 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
         return 0;
     }
 
-    public static class BarrelInventory implements DelegateItemHandler, DelegateFluidHandler, INBTSerializable<CompoundTag>, EmptyInventory, FluidTankCallback
+    public static class BarrelInventory implements DelegateItemHandler, DelegateFluidHandler, INBTSerializable<CompoundTag>, EmptyInventory, FluidTankCallback, BarrelRecipeWrapper
     {
         private final BarrelInventoryCallback callback;
         private final InventoryItemHandler inventory;
@@ -575,6 +576,7 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
             tank = new InventoryFluidTank(Helpers.getValueOrDefault(TFCConfig.SERVER.barrelCapacity), stack -> Helpers.isFluid(stack.getFluid(), TFCTags.Fluids.USABLE_IN_BARREL), this);
         }
 
+        @Override
         public void whileMutable(Runnable action)
         {
             try
@@ -593,6 +595,7 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
             return tank.getFluid().isEmpty() && excess.isEmpty() && Helpers.isEmpty(inventory);
         }
 
+        @Override
         public void insertItemWithOverflow(ItemStack stack)
         {
             final ItemStack remainder = inventory.insertItem(SLOT_ITEM, stack, false);

--- a/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipe.java
@@ -30,7 +30,7 @@ import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.JsonHelpers;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class BarrelRecipe implements ISimpleRecipe<BarrelBlockEntity.BarrelInventory>
+public abstract class BarrelRecipe implements ISimpleRecipe<BarrelRecipeWrapper>
 {
     private final ResourceLocation id;
 
@@ -50,7 +50,7 @@ public abstract class BarrelRecipe implements ISimpleRecipe<BarrelBlockEntity.Ba
         this.sound = builder.sound;
     }
 
-    public void assembleOutputs(BarrelBlockEntity.BarrelInventory inventory)
+    public void assembleOutputs(BarrelRecipeWrapper inventory)
     {
         // Require the inventory to be mutable, as we use insert/extract methods, but will expect it to be modifiable despite being sealed.
         inventory.whileMutable(() -> {
@@ -129,7 +129,7 @@ public abstract class BarrelRecipe implements ISimpleRecipe<BarrelBlockEntity.Ba
     }
 
     @Override
-    public boolean matches(BarrelBlockEntity.BarrelInventory container, @Nullable Level level)
+    public boolean matches(BarrelRecipeWrapper container, @Nullable Level level)
     {
         return inputItem.test(container.getStackInSlot(BarrelBlockEntity.SLOT_ITEM)) && inputFluid.test(container.getFluidInTank(0));
     }

--- a/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipe.java
@@ -24,13 +24,14 @@ import net.minecraftforge.registries.ForgeRegistries;
 import net.dries007.tfc.common.blockentities.BarrelBlockEntity;
 import net.dries007.tfc.common.recipes.ingredients.FluidStackIngredient;
 import net.dries007.tfc.common.recipes.ingredients.ItemStackIngredient;
+import net.dries007.tfc.common.recipes.inventory.BarrelInventory;
 import net.dries007.tfc.common.recipes.outputs.ItemStackProvider;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.JsonHelpers;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class BarrelRecipe implements ISimpleRecipe<BarrelRecipeWrapper>
+public abstract class BarrelRecipe implements ISimpleRecipe<BarrelInventory>
 {
     private final ResourceLocation id;
 
@@ -50,7 +51,7 @@ public abstract class BarrelRecipe implements ISimpleRecipe<BarrelRecipeWrapper>
         this.sound = builder.sound;
     }
 
-    public void assembleOutputs(BarrelRecipeWrapper inventory)
+    public void assembleOutputs(BarrelInventory inventory)
     {
         // Require the inventory to be mutable, as we use insert/extract methods, but will expect it to be modifiable despite being sealed.
         inventory.whileMutable(() -> {
@@ -129,7 +130,7 @@ public abstract class BarrelRecipe implements ISimpleRecipe<BarrelRecipeWrapper>
     }
 
     @Override
-    public boolean matches(BarrelRecipeWrapper container, @Nullable Level level)
+    public boolean matches(BarrelInventory container, @Nullable Level level)
     {
         return inputItem.test(container.getStackInSlot(BarrelBlockEntity.SLOT_ITEM)) && inputFluid.test(container.getFluidInTank(0));
     }

--- a/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipeWrapper.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipeWrapper.java
@@ -1,0 +1,22 @@
+package net.dries007.tfc.common.recipes;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fluids.capability.IFluidHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
+
+import net.dries007.tfc.common.recipes.inventory.EmptyInventory;
+
+public interface BarrelRecipeWrapper extends IItemHandlerModifiable, IFluidHandler, EmptyInventory
+{
+    /**
+     * Must be mutable to perform recipes despite sealed status
+     */
+    void whileMutable(Runnable action);
+
+    /**
+     * Insert ItemStacks with overflow storage
+     *
+     * @param stack stack to insert
+     */
+    void insertItemWithOverflow(ItemStack stack);
+}

--- a/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipeWrapper.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipeWrapper.java
@@ -1,3 +1,9 @@
+/*
+ * Licensed under the EUPL, Version 1.2.
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
 package net.dries007.tfc.common.recipes;
 
 import net.minecraft.world.item.ItemStack;

--- a/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipeWrapper.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/BarrelRecipeWrapper.java
@@ -6,13 +6,12 @@
 
 package net.dries007.tfc.common.recipes;
 
+import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-import net.dries007.tfc.common.recipes.inventory.EmptyInventory;
-
-public interface BarrelRecipeWrapper extends IItemHandlerModifiable, IFluidHandler, EmptyInventory
+public interface BarrelRecipeWrapper extends IItemHandlerModifiable, IFluidHandler, Container
 {
     /**
      * Must be mutable to perform recipes despite sealed status

--- a/src/main/java/net/dries007/tfc/common/recipes/InstantBarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/InstantBarrelRecipe.java
@@ -24,7 +24,7 @@ public class InstantBarrelRecipe extends BarrelRecipe
     }
 
     @Override
-    public boolean matches(BarrelBlockEntity.BarrelInventory container, @Nullable Level level)
+    public boolean matches(BarrelRecipeWrapper container, @Nullable Level level)
     {
         // Instant recipes change behavior depending on the fluid content. If the recipe has no input fluid, or has no output fluid, it behaves as normal.
         // Otherwise, it must have enough input items to fully consume all input fluid.

--- a/src/main/java/net/dries007/tfc/common/recipes/InstantBarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/InstantBarrelRecipe.java
@@ -14,6 +14,8 @@ import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 
 import net.dries007.tfc.common.blockentities.BarrelBlockEntity;
+import net.dries007.tfc.common.recipes.inventory.BarrelInventory;
+
 import org.jetbrains.annotations.Nullable;
 
 public class InstantBarrelRecipe extends BarrelRecipe
@@ -24,7 +26,7 @@ public class InstantBarrelRecipe extends BarrelRecipe
     }
 
     @Override
-    public boolean matches(BarrelRecipeWrapper container, @Nullable Level level)
+    public boolean matches(BarrelInventory container, @Nullable Level level)
     {
         // Instant recipes change behavior depending on the fluid content. If the recipe has no input fluid, or has no output fluid, it behaves as normal.
         // Otherwise, it must have enough input items to fully consume all input fluid.

--- a/src/main/java/net/dries007/tfc/common/recipes/InstantFluidBarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/InstantFluidBarrelRecipe.java
@@ -47,7 +47,7 @@ public class InstantFluidBarrelRecipe extends BarrelRecipe
     }
 
     @Override
-    public boolean matches(BarrelBlockEntity.BarrelInventory container, @Nullable Level level)
+    public boolean matches(BarrelRecipeWrapper container, @Nullable Level level)
     {
         // Must match the input with either the item slot, or fluid IO slot.
         return matches(container.getStackInSlot(BarrelBlockEntity.SLOT_ITEM), container.getFluidInTank(0)) || matches(container.getStackInSlot(BarrelBlockEntity.SLOT_FLUID_CONTAINER_IN), container.getFluidInTank(0));
@@ -63,7 +63,7 @@ public class InstantFluidBarrelRecipe extends BarrelRecipe
     }
 
     @Override
-    public void assembleOutputs(BarrelBlockEntity.BarrelInventory inventory)
+    public void assembleOutputs(BarrelRecipeWrapper inventory)
     {
         // Require the inventory to be mutable, as we use insert/extract methods, but will expect it to be modifiable despite being sealed.
         inventory.whileMutable(() -> {

--- a/src/main/java/net/dries007/tfc/common/recipes/InstantFluidBarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/InstantFluidBarrelRecipe.java
@@ -25,6 +25,7 @@ import net.dries007.tfc.common.capabilities.Capabilities;
 import net.dries007.tfc.common.fluids.FluidHelpers;
 import net.dries007.tfc.common.recipes.ingredients.FluidStackIngredient;
 import net.dries007.tfc.common.recipes.ingredients.ItemStackIngredient;
+import net.dries007.tfc.common.recipes.inventory.BarrelInventory;
 import net.dries007.tfc.common.recipes.outputs.ItemStackProvider;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
@@ -47,7 +48,7 @@ public class InstantFluidBarrelRecipe extends BarrelRecipe
     }
 
     @Override
-    public boolean matches(BarrelRecipeWrapper container, @Nullable Level level)
+    public boolean matches(BarrelInventory container, @Nullable Level level)
     {
         // Must match the input with either the item slot, or fluid IO slot.
         return matches(container.getStackInSlot(BarrelBlockEntity.SLOT_ITEM), container.getFluidInTank(0)) || matches(container.getStackInSlot(BarrelBlockEntity.SLOT_FLUID_CONTAINER_IN), container.getFluidInTank(0));
@@ -63,7 +64,7 @@ public class InstantFluidBarrelRecipe extends BarrelRecipe
     }
 
     @Override
-    public void assembleOutputs(BarrelRecipeWrapper inventory)
+    public void assembleOutputs(BarrelInventory inventory)
     {
         // Require the inventory to be mutable, as we use insert/extract methods, but will expect it to be modifiable despite being sealed.
         inventory.whileMutable(() -> {

--- a/src/main/java/net/dries007/tfc/common/recipes/SealedBarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/SealedBarrelRecipe.java
@@ -37,7 +37,7 @@ public class SealedBarrelRecipe extends BarrelRecipe
     }
 
     @Override
-    public boolean matches(BarrelBlockEntity.BarrelInventory container, @Nullable Level level)
+    public boolean matches(BarrelRecipeWrapper container, @Nullable Level level)
     {
         // Sealed barrel recipes match as long as both ingredients meet the minimum requirements (this is the call to super)
         // However, if the barrel recipe is infinite, it should only match as long as there is more fluid than items
@@ -68,7 +68,7 @@ public class SealedBarrelRecipe extends BarrelRecipe
         return onUnseal;
     }
 
-    public void onSealed(BarrelBlockEntity.BarrelInventory inventory)
+    public void onSealed(BarrelRecipeWrapper inventory)
     {
         if (onSeal != null)
         {
@@ -79,7 +79,7 @@ public class SealedBarrelRecipe extends BarrelRecipe
         }
     }
 
-    public void onUnsealed(BarrelBlockEntity.BarrelInventory inventory)
+    public void onUnsealed(BarrelRecipeWrapper inventory)
     {
         if (onUnseal != null)
         {

--- a/src/main/java/net/dries007/tfc/common/recipes/SealedBarrelRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/SealedBarrelRecipe.java
@@ -16,6 +16,7 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.blockentities.BarrelBlockEntity;
+import net.dries007.tfc.common.recipes.inventory.BarrelInventory;
 import net.dries007.tfc.common.recipes.outputs.ItemStackProvider;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.JsonHelpers;
@@ -37,7 +38,7 @@ public class SealedBarrelRecipe extends BarrelRecipe
     }
 
     @Override
-    public boolean matches(BarrelRecipeWrapper container, @Nullable Level level)
+    public boolean matches(BarrelInventory container, @Nullable Level level)
     {
         // Sealed barrel recipes match as long as both ingredients meet the minimum requirements (this is the call to super)
         // However, if the barrel recipe is infinite, it should only match as long as there is more fluid than items
@@ -68,7 +69,7 @@ public class SealedBarrelRecipe extends BarrelRecipe
         return onUnseal;
     }
 
-    public void onSealed(BarrelRecipeWrapper inventory)
+    public void onSealed(BarrelInventory inventory)
     {
         if (onSeal != null)
         {
@@ -79,7 +80,7 @@ public class SealedBarrelRecipe extends BarrelRecipe
         }
     }
 
-    public void onUnsealed(BarrelRecipeWrapper inventory)
+    public void onUnsealed(BarrelInventory inventory)
     {
         if (onUnseal != null)
         {

--- a/src/main/java/net/dries007/tfc/common/recipes/inventory/BarrelInventory.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/inventory/BarrelInventory.java
@@ -14,7 +14,9 @@ import net.minecraftforge.items.IItemHandlerModifiable;
 public interface BarrelInventory extends IItemHandlerModifiable, IFluidHandler, Container
 {
     /**
-     * Must be mutable to perform recipes despite sealed status
+     * Run an action while forcing the barrel's underlying state to be mutable, despite the sealed status. This should
+     * only be used for updating the outputs on recipe completion, not for interacting with the barrel inventory via
+     * external means - that should respect the sealed state.
      */
     void whileMutable(Runnable action);
 

--- a/src/main/java/net/dries007/tfc/common/recipes/inventory/BarrelInventory.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/inventory/BarrelInventory.java
@@ -4,14 +4,14 @@
  * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 
-package net.dries007.tfc.common.recipes;
+package net.dries007.tfc.common.recipes.inventory;
 
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
-public interface BarrelRecipeWrapper extends IItemHandlerModifiable, IFluidHandler, Container
+public interface BarrelInventory extends IItemHandlerModifiable, IFluidHandler, Container
 {
     /**
      * Must be mutable to perform recipes despite sealed status


### PR DESCRIPTION
Extracts the needed interface for barrel recipe containers into an interface that `BarrelBlockEntity.BarrelInventory` impliments. This is to allow people to easily support barrel recipes in things that aren't TFC  barrels such as the Barrel Compartments in the FirmaCiv addon

Edit: Typo