### PR TITLE
Fix shading on jar shelf model

### DIFF
--- a/src/main/resources/assets/tfc/models/block/jar_shelf.json
+++ b/src/main/resources/assets/tfc/models/block/jar_shelf.json
@@ -9,7 +9,6 @@
 		{
 			"from": [0, 15, 0],
 			"to": [16, 16, 16],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [0, 0, 16, 1], "texture": "#0"},
 				"east": {"uv": [0, 0, 16, 1], "texture": "#0"},
@@ -22,7 +21,6 @@
 		{
 			"from": [1, 14, 0],
 			"to": [3, 15, 12],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [13, 1, 15, 2], "texture": "#0"},
 				"east": {"uv": [4, 1, 16, 2], "texture": "#0"},
@@ -35,7 +33,6 @@
 		{
 			"from": [1, 13, 0],
 			"to": [3, 14, 4],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [13, 2, 15, 3], "texture": "#0"},
 				"east": {"uv": [12, 2, 16, 3], "texture": "#0"},
@@ -48,7 +45,6 @@
 		{
 			"from": [1, 9, 0],
 			"to": [3, 13, 2],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [13, 3, 15, 7], "texture": "#0"},
 				"east": {"uv": [14, 3, 16, 7], "texture": "#0"},
@@ -61,7 +57,6 @@
 		{
 			"from": [13, 9, 0],
 			"to": [15, 13, 2],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [1, 3, 3, 7], "texture": "#0"},
 				"east": {"uv": [14, 3, 16, 7], "texture": "#0"},
@@ -74,7 +69,6 @@
 		{
 			"from": [13, 13, 0],
 			"to": [15, 14, 4],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [1, 2, 3, 3], "texture": "#0"},
 				"east": {"uv": [12, 2, 16, 3], "texture": "#0"},
@@ -87,7 +81,6 @@
 		{
 			"from": [13, 14, 0],
 			"to": [15, 15, 12],
-			"rotation": {"angle": 0, "axis": "y", "origin": [8, 0, 8]},
 			"faces": {
 				"north": {"uv": [1, 1, 3, 2], "texture": "#0"},
 				"east": {"uv": [4, 1, 16, 2], "texture": "#0"},


### PR DESCRIPTION
Fixes: #2585

Turns out having rotations, even 0° ones, messes up ambient occlusion on block models.