### PR TITLE
Fix squid spawning partially inside walls

### DIFF
--- a/src/main/java/net/dries007/tfc/common/entities/aquatic/TFCSquid.java
+++ b/src/main/java/net/dries007/tfc/common/entities/aquatic/TFCSquid.java
@@ -90,16 +90,6 @@ public class TFCSquid extends Squid implements AquaticMob
     }
 
     @Override
-    public void refreshDimensions()
-    {
-        final double x = getX();
-        final double y = getY();
-        final double z = getZ();
-        super.refreshDimensions();
-        setPos(x, y, z);
-    }
-
-    @Override
     public void onSyncedDataUpdated(EntityDataAccessor<?> data)
     {
         super.onSyncedDataUpdated(data);
@@ -137,7 +127,7 @@ public class TFCSquid extends Squid implements AquaticMob
 
         if (spawnType == MobSpawnType.NATURAL || spawnType == MobSpawnType.CHUNK_GENERATION)
         {
-            while (!checkSpawnObstruction(level))
+            while (level.collidesWithSuffocatingBlock(this, getBoundingBox()))
             {
                 setSize((int) (getSize() * 0.8), true);
                 if (getSize() < pair.getFirst())


### PR DESCRIPTION
Should fix #2580

Apparently `checkSpawnObstruction()` only checks for entities, not blocks. This causes squid to spawn in places not big enough for them and suffocate. This call was replaced with `collidesWithSuffocatingBlock()`, which correctly handles blocks in the entity's bounding box. In addition, the `refreshDimensions()` override was removed, since that was causing problems spawning squid on the seabed.