### PR TITLE
Don't collapse caves if broken block is supported

### DIFF
--- a/src/main/java/net/dries007/tfc/common/recipes/CollapseRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/CollapseRecipe.java
@@ -72,6 +72,11 @@ public class CollapseRecipe extends SimpleBlockRecipe
         final RandomSource random = level.getRandom();
         if (!level.isClientSide() && level.isAreaLoaded(pos, 32))
         {
+
+            // Don't trigger a collapse if mined block is supported
+            if (Support.isSupported(level, pos))
+                return false;
+
             final boolean realCollapse = random.nextFloat() < TFCConfig.SERVER.collapseTriggerChance.get(),
                 fakeCollapse = !realCollapse && random.nextFloat() < TFCConfig.SERVER.collapseFakeTriggerChance.get();
             if (realCollapse || fakeCollapse)


### PR DESCRIPTION
This PR changes the collapsing behavior so that blocks that are already supported don't trigger collapses when broken.

Breaking blocks that are already supported shouldn't have an effect on the others collapsing, it can make mining frustrating and unfair.
For example, breaking a block while mining while you're near a cave (that you might not even be able to see) would cause a collapse. Collapsing a cave once can make it pretty much irrecoverable, which can become pretty frustrating and generally not fun.