### PR TITLE
Finite continent world generation setting

### DIFF
--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinWorldPreset.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinWorldPreset.java
@@ -57,7 +57,7 @@ public final class BuiltinWorldPreset
                     new TFCChunkGenerator(
                         new RegionBiomeSource(context.lookup(Registries.BIOME)),
                         noiseSettings.getOrThrow(NoiseGeneratorSettings.OVERWORLD),
-                        new Settings(false, 4_000, 0, 0, 20_000, 0, 20_000, 0, rockLayerSettings(), 0.5f, 0.5f)
+                        new Settings(false, 4_000, 0, 0, 20_000, 0, 20_000, 0, rockLayerSettings(), 0.5f, 0.5f, false)
                     )
                 ),
                 LevelStem.NETHER, new LevelStem(
@@ -79,7 +79,7 @@ public final class BuiltinWorldPreset
 
     public static Settings defaultSettings()
     {
-        return new Settings(false, 4_000, 0, 0, 20_000, 0, 20_000, 0, rockLayerSettings(), 0.5f, 0.5f);
+        return new Settings(false, 4_000, 0, 0, 20_000, 0, 20_000, 0, rockLayerSettings(), 0.5f, 0.5f, false);
     }
 
     private static final Map<Rock, SandBlockType> ROCK_TO_SAND_COLOR = ImmutableMap.<Rock, SandBlockType>builder()

--- a/src/main/java/net/dries007/tfc/client/screen/CreateTFCWorldScreen.java
+++ b/src/main/java/net/dries007/tfc/client/screen/CreateTFCWorldScreen.java
@@ -49,7 +49,7 @@ public class CreateTFCWorldScreen extends Screen
     private final WorldCreationContext context;
 
     private OptionsList options;
-    private OptionInstance<Boolean> flatBedrock;
+    private OptionInstance<Boolean> flatBedrock, finiteContinents;
     private OptionInstance<Integer> spawnDistance, spawnCenterX, spawnCenterZ, temperatureScale, rainfallScale;
     private OptionInstance<Double> temperatureConstant, rainfallConstant, continentalness, grassDensity;
 
@@ -135,7 +135,8 @@ public class CreateTFCWorldScreen extends Screen
                 (float) (rainfallConstant.get() * 2.0 - 1.0),
                 old.rockLayerSettings(),
                 continentalness.get().floatValue(),
-                grassDensity.get().floatValue()
+                grassDensity.get().floatValue(),
+                finiteContinents.get()
             ));
         }
     }

--- a/src/main/java/net/dries007/tfc/world/region/AddContinents.java
+++ b/src/main/java/net/dries007/tfc/world/region/AddContinents.java
@@ -21,16 +21,18 @@ public enum AddContinents implements RegionTask
         {
             double continent = context.generator().continentNoise.noise(point.x, point.z);
 
-            // keep temperature and rainfall falloff as independent functions since it won't always be square
+            if (context.generator().settings.finiteContinents()){
+                // keep temperature and rainfall falloff as independent functions since it won't always be square
 
-            float tempDistance = (float) Math.abs(gridToBlock(point.z) - context.generator().settings.temperatureScale() / 2) / (context.generator().settings.temperatureScale() * 1.2f);
-            float rainfallDistance = (float) Math.abs(gridToBlock(point.x)) / (context.generator().settings.rainfallScale() * 1.2f);
+                float tempDistance = (float) Math.abs(gridToBlock(point.z) - context.generator().settings.temperatureScale() / 2) / (context.generator().settings.temperatureScale() * 1.2f);
+                float rainfallDistance = (float) Math.abs(gridToBlock(point.x)) / (context.generator().settings.rainfallScale() * 1.2f);
 
-            // little logarithmic falloff function
+                // little logarithmic falloff function
 
-            float falloff = falloff(tempDistance) * falloff(rainfallDistance);
+                float falloff = falloff(tempDistance) * falloff(rainfallDistance);
 
-            continent *= falloff;
+                continent *= falloff;
+            }
 
             if (continent > 4.4)
             {

--- a/src/main/java/net/dries007/tfc/world/region/AddContinents.java
+++ b/src/main/java/net/dries007/tfc/world/region/AddContinents.java
@@ -21,7 +21,8 @@ public enum AddContinents implements RegionTask
         {
             double continent = context.generator().continentNoise.noise(point.x, point.z);
 
-            if (context.generator().settings.finiteContinents()){
+            if (context.generator().settings.finiteContinents())
+            {
 
                 final int rainfallScale = context.generator().settings.rainfallConstant() != 0 ? 20000 : context.generator().settings.rainfallScale();
                 final int temperatureScale = context.generator().settings.temperatureConstant() != 0 ? 20000 : context.generator().settings.temperatureScale();
@@ -45,8 +46,9 @@ public enum AddContinents implements RegionTask
         }
     }
 
-    public static float falloff(float distance)
+    private static float falloff(float distance)
     {
-        return (float) Mth.clamp(Math.pow(-distance,15.0f)+1f,0f,1f);
+        int order = 5;
+        return (float) Mth.clamp(Math.pow(-distance, order) + 1f, 0f, 1f);
     }
 }

--- a/src/main/java/net/dries007/tfc/world/region/AddContinents.java
+++ b/src/main/java/net/dries007/tfc/world/region/AddContinents.java
@@ -22,10 +22,14 @@ public enum AddContinents implements RegionTask
             double continent = context.generator().continentNoise.noise(point.x, point.z);
 
             if (context.generator().settings.finiteContinents()){
+
+                final int rainfallScale = context.generator().settings.rainfallConstant() != 0 ? 20000 : context.generator().settings.rainfallScale();
+                final int temperatureScale = context.generator().settings.temperatureConstant() != 0 ? 20000 : context.generator().settings.temperatureScale();
+
                 // keep temperature and rainfall falloff as independent functions since it won't always be square
 
-                float tempDistance = (float) Math.abs(gridToBlock(point.z) - context.generator().settings.temperatureScale() / 2) / (context.generator().settings.temperatureScale() * 1.2f);
-                float rainfallDistance = (float) Math.abs(gridToBlock(point.x)) / (context.generator().settings.rainfallScale() * 1.2f);
+                float tempDistance = (Math.abs(gridToBlock(point.z) - temperatureScale / 2) / (temperatureScale * 1.2f));
+                float rainfallDistance = (Math.abs(gridToBlock(point.x)) / (rainfallScale * 1.2f));
 
                 // little logarithmic falloff function
 
@@ -43,6 +47,6 @@ public enum AddContinents implements RegionTask
 
     public static float falloff(float distance)
     {
-        return Math.abs(Mth.clamp((0.16f * (float) Math.log((-(distance) + 1.02f)) + 1f), 0, 1));
+        return (float) Mth.clamp(Math.pow(-distance,15.0f)+1f,0f,1f);
     }
 }

--- a/src/main/java/net/dries007/tfc/world/region/AddContinents.java
+++ b/src/main/java/net/dries007/tfc/world/region/AddContinents.java
@@ -29,12 +29,10 @@ public enum AddContinents implements RegionTask
 
                 // keep temperature and rainfall falloff as independent functions since it won't always be square
 
-                float tempDistance = (Math.abs(gridToBlock(point.z) - temperatureScale / 2) / (temperatureScale * 1.2f));
-                float rainfallDistance = (Math.abs(gridToBlock(point.x)) / (rainfallScale * 1.2f));
+                final float tempDistance = (Math.abs(gridToBlock(point.z) - temperatureScale / 2) / (temperatureScale * 1.2f));
+                final float rainfallDistance = (Math.abs(gridToBlock(point.x)) / (rainfallScale * 1.2f));
 
-                // little logarithmic falloff function
-
-                float falloff = falloff(tempDistance) * falloff(rainfallDistance);
+                final float falloff = falloff(tempDistance) * falloff(rainfallDistance);
 
                 continent *= falloff;
             }

--- a/src/main/java/net/dries007/tfc/world/region/AddContinents.java
+++ b/src/main/java/net/dries007/tfc/world/region/AddContinents.java
@@ -6,6 +6,10 @@
 
 package net.dries007.tfc.world.region;
 
+import net.minecraft.util.Mth;
+
+import static net.dries007.tfc.world.region.Units.*;
+
 public enum AddContinents implements RegionTask
 {
     INSTANCE;
@@ -15,11 +19,28 @@ public enum AddContinents implements RegionTask
     {
         for (final var point : context.region.points())
         {
-            final double continent = context.generator().continentNoise.noise(point.x, point.z);
+            double continent = context.generator().continentNoise.noise(point.x, point.z);
+
+            // keep temperature and rainfall falloff as independent functions since it won't always be square
+
+            float tempDistance = (float) Math.abs(gridToBlock(point.z) - context.generator().settings.temperatureScale() / 2) / (context.generator().settings.temperatureScale() * 1.2f);
+            float rainfallDistance = (float) Math.abs(gridToBlock(point.x)) / (context.generator().settings.rainfallScale() * 1.2f);
+
+            // little logarithmic falloff function
+
+            float falloff = falloff(tempDistance) * falloff(rainfallDistance);
+
+            continent *= falloff;
+
             if (continent > 4.4)
             {
                 point.setLand();
             }
         }
+    }
+
+    public static float falloff(float distance)
+    {
+        return Math.abs(Mth.clamp((0.16f * (float) Math.log((-(distance) + 1.02f)) + 1f), 0, 1));
     }
 }

--- a/src/main/java/net/dries007/tfc/world/region/AddIslands.java
+++ b/src/main/java/net/dries007/tfc/world/region/AddIslands.java
@@ -28,19 +28,23 @@ public enum AddIslands implements RegionTask
             {
                 continue;
             }
-            final int maxX = context.generator().settings.rainfallScale() + context.generator().settings.rainfallScale() / 8;
 
-            final int maxZ = context.generator().settings.temperatureScale() + context.generator().settings.temperatureScale() / 2 + context.generator().settings.temperatureScale() / 8;
-            final int minX = -context.generator().settings.rainfallScale() - context.generator().settings.rainfallScale() / 8;
-            final int minZ = -(context.generator().settings.temperatureScale() - context.generator().settings.temperatureScale() / 2) - context.generator().settings.temperatureScale() / 8;
-            final int pointX = gridToBlock(point.x);
-            final int pointZ = gridToBlock(point.z);
+            if (context.generator().settings.finiteContinents()){
+                final int maxX = context.generator().settings.rainfallScale() + context.generator().settings.rainfallScale() / 8;
 
-            if (!(pointX < maxX && pointX > minX
-                && pointZ < maxZ && pointZ > minZ))
-            {
-                continue;
+                final int maxZ = context.generator().settings.temperatureScale() + context.generator().settings.temperatureScale() / 2 + context.generator().settings.temperatureScale() / 8;
+                final int minX = -context.generator().settings.rainfallScale() - context.generator().settings.rainfallScale() / 8;
+                final int minZ = -(context.generator().settings.temperatureScale() - context.generator().settings.temperatureScale() / 2) - context.generator().settings.temperatureScale() / 8;
+                final int pointX = gridToBlock(point.x);
+                final int pointZ = gridToBlock(point.z);
+
+                if (!(pointX < maxX && pointX > minX
+                    && pointZ < maxZ && pointZ > minZ))
+                {
+                    continue;
+                }
             }
+
             if (!point.land() && !point.shore() && point.distanceToEdge > 2)
             {
                 // Place a small island chain

--- a/src/main/java/net/dries007/tfc/world/region/AddIslands.java
+++ b/src/main/java/net/dries007/tfc/world/region/AddIslands.java
@@ -8,6 +8,9 @@ package net.dries007.tfc.world.region;
 
 import net.minecraft.util.RandomSource;
 
+import static net.dries007.tfc.world.region.AddContinents.*;
+import static net.dries007.tfc.world.region.Units.*;
+
 public enum AddIslands implements RegionTask
 {
     INSTANCE;
@@ -21,7 +24,24 @@ public enum AddIslands implements RegionTask
         for (int attempt = 0, placed = 0; attempt < 130 && placed < 15; attempt++)
         {
             Region.Point point = region.random(random);
-            if (point != null && !point.land() && !point.shore() && point.distanceToEdge > 2)
+            if (point == null)
+            {
+                continue;
+            }
+            final int maxX = context.generator().settings.rainfallScale() + context.generator().settings.rainfallScale() / 8;
+
+            final int maxZ = context.generator().settings.temperatureScale() + context.generator().settings.temperatureScale() / 2 + context.generator().settings.temperatureScale() / 8;
+            final int minX = -context.generator().settings.rainfallScale() - context.generator().settings.rainfallScale() / 8;
+            final int minZ = -(context.generator().settings.temperatureScale() - context.generator().settings.temperatureScale() / 2) - context.generator().settings.temperatureScale() / 8;
+            final int pointX = gridToBlock(point.x);
+            final int pointZ = gridToBlock(point.z);
+
+            if (!(pointX < maxX && pointX > minX
+                && pointZ < maxZ && pointZ > minZ))
+            {
+                continue;
+            }
+            if (!point.land() && !point.shore() && point.distanceToEdge > 2)
             {
                 // Place a small island chain
                 for (int island = 0; island < 12; island++)

--- a/src/main/java/net/dries007/tfc/world/region/AddIslands.java
+++ b/src/main/java/net/dries007/tfc/world/region/AddIslands.java
@@ -29,12 +29,16 @@ public enum AddIslands implements RegionTask
                 continue;
             }
 
-            if (context.generator().settings.finiteContinents()){
-                final int maxX = context.generator().settings.rainfallScale() + context.generator().settings.rainfallScale() / 8;
+            if (context.generator().settings.finiteContinents())
+            {
+                final int rainfallScale = context.generator().settings.rainfallConstant() != 0 ? 20000 : context.generator().settings.rainfallScale();
+                final int temperatureScale = context.generator().settings.temperatureConstant() != 0 ? 20000 : context.generator().settings.temperatureScale();
 
-                final int maxZ = context.generator().settings.temperatureScale() + context.generator().settings.temperatureScale() / 2 + context.generator().settings.temperatureScale() / 8;
-                final int minX = -context.generator().settings.rainfallScale() - context.generator().settings.rainfallScale() / 8;
-                final int minZ = -(context.generator().settings.temperatureScale() - context.generator().settings.temperatureScale() / 2) - context.generator().settings.temperatureScale() / 8;
+                final float maxX = rainfallScale;
+                final float maxZ = temperatureScale + temperatureScale * 0.5f;
+                final float minX = -rainfallScale;
+                final float minZ = -(temperatureScale - temperatureScale * 0.5f);
+
                 final int pointX = gridToBlock(point.x);
                 final int pointZ = gridToBlock(point.z);
 

--- a/src/main/java/net/dries007/tfc/world/settings/Settings.java
+++ b/src/main/java/net/dries007/tfc/world/settings/Settings.java
@@ -29,7 +29,8 @@ public record Settings(
     float rainfallConstant,
     RockLayerSettings rockLayerSettings,
     float continentalness,
-    float grassDensity)
+    float grassDensity,
+    boolean finiteContinents)
 {
     public static final MapCodec<Settings> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
         Codec.BOOL.fieldOf("flat_bedrock").forGetter(c -> c.flatBedrock),
@@ -42,6 +43,7 @@ public record Settings(
         Codec.FLOAT.optionalFieldOf("rainfall_constant", 0f).forGetter(c -> c.rainfallConstant),
         RockLayerSettings.CODEC.fieldOf("rock_layer_settings").forGetter(c -> c.rockLayerSettings),
         Codec.FLOAT.fieldOf("continentalness").forGetter(c -> c.continentalness),
-        Codec.FLOAT.optionalFieldOf("grassDensity", 0.5f).forGetter(c -> c.grassDensity)
+        Codec.FLOAT.optionalFieldOf("grassDensity", 0.5f).forGetter(c -> c.grassDensity),
+        Codec.BOOL.optionalFieldOf("finiteContinents", true).forGetter(c -> c.finiteContinents)
     ).apply(instance, Settings::new));
 }

--- a/src/test/java/net/dries007/tfc/test/drawing/RegionGeneratorTests.java
+++ b/src/test/java/net/dries007/tfc/test/drawing/RegionGeneratorTests.java
@@ -36,7 +36,6 @@ import net.dries007.tfc.world.settings.Settings;
 
 import static net.dries007.tfc.world.layer.TFCLayers.*;
 
-@Disabled
 @SuppressWarnings("SameParameterValue")
 public class RegionGeneratorTests implements TestSetup
 {
@@ -60,7 +59,7 @@ public class RegionGeneratorTests implements TestSetup
     public void testRegionGenerator()
     {
         // Coordinates are given in grid scale, so 1 px = 128 blocks, 150 ~ 20km
-        drawStitchedRegions("", EnumSet.allOf(DrawnTask.class), RandomSupport.generateUniqueSeed(), 0, 0, 150);
+        drawStitchedRegions("", EnumSet.allOf(DrawnTask.class), RandomSupport.generateUniqueSeed(), 0, 75, 200);
     }
 
     private void drawStitchedRegions(String name, Set<DrawnTask> tasksToDraw, long seed, int centerX, int centerZ, int radius)


### PR DESCRIPTION
- Add a worldgen setting for finite continents:
- Continents falloff with no more continents generating after 1.2x the climate scale distance on either axis
- Islands cease to generate at 1.0x the climate scale distance