### PR TITLE
Fixes some minor custom TFC patchouli component bugs when multiple are used in a page

### DIFF
--- a/src/main/java/net/dries007/tfc/compat/patchouli/component/BarrelComponent.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/component/BarrelComponent.java
@@ -8,16 +8,13 @@ package net.dries007.tfc.compat.patchouli.component;
 
 import java.util.Collections;
 import java.util.List;
-
-import net.minecraft.world.item.ItemStack;
-
-import net.minecraftforge.fluids.FluidStack;
-
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+import vazkii.patchouli.api.IComponentRenderContext;
+
 import net.dries007.tfc.common.recipes.BarrelRecipe;
 import net.dries007.tfc.compat.patchouli.PatchouliIntegration;
-
-import vazkii.patchouli.api.IComponentRenderContext;
 
 public abstract class BarrelComponent<T extends BarrelRecipe> extends RecipeComponent<T>
 {
@@ -31,20 +28,20 @@ public abstract class BarrelComponent<T extends BarrelRecipe> extends RecipeComp
 
         renderSetup(graphics);
 
-        graphics.blit(PatchouliIntegration.TEXTURE, 9, 0, 0, 116, 98, 26, 256, 256);
+        graphics.blit(PatchouliIntegration.TEXTURE, x + 9, y, 0, 116, 98, 26, 256, 256);
 
-        renderItemStacks(context, graphics, 14, 5, mouseX, mouseY, inputItems);
-        renderFluidStacks(context, graphics, 14 + 28, 5, mouseX, mouseY, inputFluids);
+        renderItemStacks(context, graphics, x + 14, y + 5, mouseX, mouseY, inputItems);
+        renderFluidStacks(context, graphics, x + 14 + 28, y + 5, mouseX, mouseY, inputFluids);
 
         // This only works for barrel recipes with a single output, and no complex item stack providers
         // If we need more, we can fix it, but for now this should be good enough
         if (!recipe.getResultItem(null).isEmpty())
         {
-            context.renderItemStack(graphics, 86, 5, mouseX, mouseY, recipe.getResultItem(null));
+            context.renderItemStack(graphics, x + 86, y + 5, mouseX, mouseY, recipe.getResultItem(null));
         }
         else if (!recipe.getOutputFluid().isEmpty())
         {
-            renderFluidStack(context, graphics, 86, 5, mouseX, mouseY, recipe.getOutputFluid());
+            renderFluidStack(context, graphics, x + 86, y + 5, mouseX, mouseY, recipe.getOutputFluid());
         }
 
         renderAdditional(graphics, context, partialTicks, mouseX, mouseY);

--- a/src/main/java/net/dries007/tfc/compat/patchouli/component/CustomComponent.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/component/CustomComponent.java
@@ -83,7 +83,6 @@ public abstract class CustomComponent implements ICustomComponent
     protected void renderSetup(GuiGraphics graphics)
     {
         graphics.pose().pushPose();
-        graphics.pose().translate(x, y, 0);
 
         RenderSystem.enableBlend();
         RenderSystem.setShaderColor(1f, 1f, 1f, 1f);

--- a/src/main/java/net/dries007/tfc/compat/patchouli/component/HeatingComponent.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/component/HeatingComponent.java
@@ -8,17 +8,17 @@ package net.dries007.tfc.compat.patchouli.component;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeType;
+import vazkii.patchouli.api.IComponentRenderContext;
 
-import net.minecraft.client.gui.GuiGraphics;
 import net.dries007.tfc.common.recipes.HeatingRecipe;
 import net.dries007.tfc.common.recipes.TFCRecipeTypes;
 import net.dries007.tfc.compat.patchouli.PatchouliIntegration;
 import net.dries007.tfc.config.TFCConfig;
-import vazkii.patchouli.api.IComponentRenderContext;
 
 public class HeatingComponent extends InputOutputComponent<HeatingRecipe>
 {
@@ -30,18 +30,18 @@ public class HeatingComponent extends InputOutputComponent<HeatingRecipe>
         renderSetup(graphics);
 
         final int v = !recipe.getDisplayOutputFluid().isEmpty() ? 116 : 90;
-        graphics.blit(PatchouliIntegration.TEXTURE, 9, 0, 0, v, 98, 26, 256, 256);
+        graphics.blit(PatchouliIntegration.TEXTURE, x + 9, y, 0, v, 98, 26, 256, 256);
 
-        context.renderIngredient(graphics, 14, 5, mouseX, mouseY, getIngredient(recipe));
-        context.renderItemStack(graphics, 86, 5, mouseX, mouseY, getOutput(recipe));
-        renderFluidStack(context, graphics, 64, 5, mouseX, mouseY, recipe.getDisplayOutputFluid());
+        context.renderIngredient(graphics, x + 14, y + 5, mouseX, mouseY, getIngredient(recipe));
+        context.renderItemStack(graphics, x + 86, y + 5, mouseX, mouseY, getOutput(recipe));
+        renderFluidStack(context, graphics, x + 64, y + 5, mouseX, mouseY, recipe.getDisplayOutputFluid());
 
         final MutableComponent tooltip = TFCConfig.CLIENT.heatTooltipStyle.get().format(recipe.getTemperature());
         if (tooltip != null)
         {
             final Font font = Minecraft.getInstance().font;
             final int centerX = 64 - 8 - font.width(tooltip.getString()) / 2; // Page width = 64, Offset = 8,
-            graphics.drawString(font, tooltip, centerX, 28, 0x404040, false);
+            graphics.drawString(font, tooltip, x + centerX, y + 28, 0x404040, false);
         }
 
         graphics.pose().popPose();

--- a/src/main/java/net/dries007/tfc/compat/patchouli/component/InputOutputComponent.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/component/InputOutputComponent.java
@@ -6,11 +6,10 @@
 
 package net.dries007.tfc.compat.patchouli.component;
 
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.Recipe;
-
-import net.minecraft.client.gui.GuiGraphics;
 import vazkii.patchouli.api.IComponentRenderContext;
 
 import net.dries007.tfc.compat.patchouli.PatchouliIntegration;
@@ -24,10 +23,9 @@ public abstract class InputOutputComponent<T extends Recipe<?>> extends RecipeCo
 
         renderSetup(graphics);
 
-        graphics.blit(PatchouliIntegration.TEXTURE, 9, 0, 0, 90, 98, 26, 256, 256);
-
-        context.renderIngredient(graphics, 14, 5, mouseX, mouseY, getIngredient(recipe));
-        context.renderItemStack(graphics, 86, 5, mouseX, mouseY, getOutput(recipe));
+        graphics.blit(PatchouliIntegration.TEXTURE, x + 9, y, 0, 90, 98, 26, 256, 256);
+        context.renderIngredient(graphics, x + 14, y + 5, mouseX, mouseY, getIngredient(recipe));
+        context.renderItemStack(graphics, x + 86, y + 5, mouseX, mouseY, getOutput(recipe));
 
         graphics.pose().popPose();
     }

--- a/src/main/java/net/dries007/tfc/compat/patchouli/component/LoomComponent.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/component/LoomComponent.java
@@ -8,17 +8,15 @@ package net.dries007.tfc.compat.patchouli.component;
 
 import java.util.Collections;
 import java.util.List;
-
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.RecipeType;
+import vazkii.patchouli.api.IComponentRenderContext;
 
-import net.minecraft.client.gui.GuiGraphics;
 import net.dries007.tfc.common.recipes.LoomRecipe;
 import net.dries007.tfc.common.recipes.TFCRecipeTypes;
 import net.dries007.tfc.common.recipes.ingredients.ItemStackIngredient;
 import net.dries007.tfc.compat.patchouli.PatchouliIntegration;
-
-import vazkii.patchouli.api.IComponentRenderContext;
 
 public class LoomComponent extends RecipeComponent<LoomRecipe>
 {
@@ -31,10 +29,10 @@ public class LoomComponent extends RecipeComponent<LoomRecipe>
 
         renderSetup(graphics);
 
-        graphics.blit(PatchouliIntegration.TEXTURE, 9, 0, 0, 90, 98, 26, 256, 256);
+        graphics.blit(PatchouliIntegration.TEXTURE, x + 9, y, 0, 90, 98, 26, 256, 256);
 
-        renderItemStacks(context, graphics, 14, 5, mouseX, mouseY, inputItems);
-        context.renderItemStack(graphics, 86, 5, mouseX, mouseY, recipe.getResultItem(null));
+        renderItemStacks(context, graphics, x + 14, y + 5, mouseX, mouseY, inputItems);
+        context.renderItemStack(graphics, x + 86, y + 5, mouseX, mouseY, recipe.getResultItem(null));
 
         graphics.pose().popPose();
     }

--- a/src/main/java/net/dries007/tfc/compat/patchouli/component/SealedBarrelComponent.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/component/SealedBarrelComponent.java
@@ -8,15 +8,14 @@ package net.dries007.tfc.compat.patchouli.component;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.crafting.RecipeType;
+import vazkii.patchouli.api.IComponentRenderContext;
 
-import net.minecraft.client.gui.GuiGraphics;
 import net.dries007.tfc.common.recipes.SealedBarrelRecipe;
 import net.dries007.tfc.common.recipes.TFCRecipeTypes;
 import net.dries007.tfc.util.calendar.Calendars;
-import net.dries007.tfc.util.calendar.ICalendar;
-import vazkii.patchouli.api.IComponentRenderContext;
 
 public class SealedBarrelComponent extends BarrelComponent<SealedBarrelRecipe>
 {
@@ -30,7 +29,7 @@ public class SealedBarrelComponent extends BarrelComponent<SealedBarrelRecipe>
             final Component tooltip = Calendars.CLIENT.getTimeDelta(recipe.getDuration());
             final Font font = Minecraft.getInstance().font;
             final int centerX = 64 - 8 - font.width(tooltip.getString()) / 2; // Page width = 64, Offset = 8,
-            graphics.drawString(font, tooltip, centerX, 28, 0x404040, false);
+            graphics.drawString(font, tooltip, x + centerX, y + 28, 0x404040, false);
         }
     }
 

--- a/src/main/java/net/dries007/tfc/compat/patchouli/component/TableComponent.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/component/TableComponent.java
@@ -130,6 +130,7 @@ public class TableComponent extends CustomComponent
         if (entries != null && !entries.isEmpty())
         {
             renderSetup(graphics);
+            graphics.pose().translate(x, y, 0);
 
             final Font font = Minecraft.getInstance().font;
             final int leftStart = leftBuffer;

--- a/src/main/java/net/dries007/tfc/compat/patchouli/component/WeldingComponent.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/component/WeldingComponent.java
@@ -6,14 +6,13 @@
 
 package net.dries007.tfc.compat.patchouli.component;
 
-import net.minecraft.world.item.crafting.RecipeType;
-
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.crafting.RecipeType;
+import vazkii.patchouli.api.IComponentRenderContext;
+
 import net.dries007.tfc.common.recipes.TFCRecipeTypes;
 import net.dries007.tfc.common.recipes.WeldingRecipe;
 import net.dries007.tfc.compat.patchouli.PatchouliIntegration;
-
-import vazkii.patchouli.api.IComponentRenderContext;
 
 public class WeldingComponent extends RecipeComponent<WeldingRecipe>
 {
@@ -24,11 +23,11 @@ public class WeldingComponent extends RecipeComponent<WeldingRecipe>
 
         renderSetup(graphics);
 
-        graphics.blit(PatchouliIntegration.TEXTURE, 9, 0, 0, 116, 98, 26, 256, 256);
+        graphics.blit(PatchouliIntegration.TEXTURE, x + 9, y, 0, 116, 98, 26, 256, 256);
 
-        context.renderIngredient(graphics, 14, 5, mouseX, mouseY, recipe.getFirstInput());
-        context.renderIngredient(graphics, 42, 5, mouseX, mouseY, recipe.getSecondInput());
-        context.renderItemStack(graphics, 86, 5, mouseX, mouseY, recipe.getResultItem(null));
+        context.renderIngredient(graphics, x + 14, y + 5, mouseX, mouseY, recipe.getFirstInput());
+        context.renderIngredient(graphics, x + 42, y + 5, mouseX, mouseY, recipe.getSecondInput());
+        context.renderItemStack(graphics, x + 86, y + 5, mouseX, mouseY, recipe.getResultItem(null));
 
         graphics.pose().popPose();
     }


### PR DESCRIPTION
The TLDR of the conversation on Discord is that Patchouli uses the provided x & y values directly in methods like `IComponentRenderContext#renderItemStack` for where the "slot" is located on the page for tooltip rendering purposes. Translating the `PoseStack` by the x & y translates the rendered `ItemStack` but the tooltip for the stack is unmoved, meaning a second component on a page like the `AnvilComponent` will have overlapping tooltip areas, despite the graphics for the stack looking correct. This also makes the tooltips correctly follow the graphics, previously they were in static positions