### PR TITLE
Fix random crashes caused by `getTicker`

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/ExtendedProperties.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/ExtendedProperties.java
@@ -233,9 +233,11 @@ public class ExtendedProperties
     <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockEntityType<T> givenType)
     {
         assert blockEntityType != null;
-        if (givenType == blockEntityType.get())
-        {
-            return (BlockEntityTicker<T>) (level.isClientSide() ? clientTicker : serverTicker);
+        if (blockEntityType != null){            
+            if (givenType == blockEntityType.get())
+            {
+                return (BlockEntityTicker<T>) (level.isClientSide() ? clientTicker : serverTicker);
+            }
         }
         return null;
     }


### PR DESCRIPTION
I recently started a server using the Allthemod-Gravitas2 modpack, and certain chunks in the debug world are crashing in TFC in an irregular manner. I believe this may be caused by a certain addon.

BUT...

After inspection, I found that there is only one assert for null checks in a critical area but no if-check.

Given that TFC will have more and more addons in the future, Maybe it's necessary to implement NULL handling in this method to enhance robustness.

After patching this, the game can run smoothly in the debug world.

[crash-2024-10-30_07.24.16-server.txt](https://github.com/user-attachments/files/17567387/crash-2024-10-30_07.24.16-server.txt)