### PR TITLE
Fixed incompability with TACZ weapon mod

### DIFF
--- a/src/main/java/net/dries007/tfc/common/capabilities/food/FoodCapability.java
+++ b/src/main/java/net/dries007/tfc/common/capabilities/food/FoodCapability.java
@@ -189,6 +189,14 @@ public final class FoodCapability
                 TerraFirmaCraft.LOGGER.warn("Other mod issue: makeIcon() is annotated @OnlyIn(Dist.CLIENT), in tab {}", tab.getRecipeFolderName());
                 continue;
             }
+            catch (IllegalArgumentException e) {
+                TerraFirmaCraft.LOGGER.warn(
+                        "Other mod issue: makeIcon() is "
+                        + "annotated @OnlyIn(Dist.CLIENT), in tab {}",
+                        tab.getRecipeFolderName());
+
+                continue;
+            }
             setStackNonDecaying(stack);
         }
     }


### PR DESCRIPTION
[TACZ issue 142](https://github.com/MCModderAnchor/TACZ/issues/142)

Added an exception handler that allows TerraFirmaCraft to operate with TACZ, as it raises an IllegalArgumentException when used together.