### PR TITLE
Check getLightPos() in IGlow#tryRemoveLight() rather than Entity#blockPosition()

### DIFF
--- a/src/main/java/net/dries007/tfc/common/entities/IGlow.java
+++ b/src/main/java/net/dries007/tfc/common/entities/IGlow.java
@@ -98,11 +98,11 @@ public interface IGlow
     {
         final Entity entity = getEntity();
         final Level level = entity.level();
-        if (!level.isLoaded(entity.blockPosition()))
+        final BlockPos light = getLightPos();
+        if (!level.isLoaded(light))
         {
             return;
         }
-        final BlockPos light = getLightPos();
         final BlockState state = level.getBlockState(light);
         if (Helpers.isBlock(state, TFCBlocks.LIGHT.get()))
         {


### PR DESCRIPTION
Using `blockPosition` may lead to `tryRemoveLight` loading chunks, which is not good.