### PR TITLE
Fix some item names having a leading space

### DIFF
--- a/resources/constants.py
+++ b/resources/constants.py
@@ -853,7 +853,7 @@ OXIDIZED_METAL_NAMES: dict[str, str] = {
 
 # This is here because it's used all over, and it's easier to import with all constants
 def lang(key: str, *args) -> str:
-    return ((key % args) if len(args) > 0 else key).replace('_', ' ').replace('/', ' ').title()
+    return ((key % args) if len(args) > 0 else key).replace('_', ' ').replace('/', ' ').strip().title()
 
 
 def lang_enum(name: str, values: Sequence[str]) -> Dict[str, str]:


### PR DESCRIPTION
This small patch fixes some items having an extra leading space.
For example " Copper Plated Stairs" becomes "Copper Plated Stairs" as shown in the attached screenshot:

![patch_diff](https://github.com/user-attachments/assets/0cce3678-e07f-44f1-b3ba-324f5d0b941a)
