### PR TITLE
2 Snow Tweaks

### DIFF
--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinBlockTags.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinBlockTags.java
@@ -406,6 +406,7 @@ public class BuiltinBlockTags extends TagsProvider<Block> implements Accessors
         tag(STONES_LOOSE)
             .add(TFCBlocks.ROCK_BLOCKS, Rock.BlockType.LOOSE)
             .add(TFCBlocks.ROCK_BLOCKS, Rock.BlockType.MOSSY_LOOSE);
+        tag(SMOKES_IN_RAIN).add(TFCBlocks.MAGMA_BLOCKS).add(Blocks.MAGMA_BLOCK);
         tag(INSULATION)
             .addTags(Tags.Blocks.STONES, STONES_SMOOTH, BlockTags.STONE_BRICKS, Tags.Blocks.COBBLESTONES)
             .add(Blocks.BRICKS)

--- a/src/generated/resources/data/c/tags/block/smokes_in_rain.json
+++ b/src/generated/resources/data/c/tags/block/smokes_in_rain.json
@@ -1,0 +1,12 @@
+{
+  "values": [
+    "tfc:rock/magma/granite",
+    "tfc:rock/magma/diorite",
+    "tfc:rock/magma/gabbro",
+    "tfc:rock/magma/rhyolite",
+    "tfc:rock/magma/basalt",
+    "tfc:rock/magma/andesite",
+    "tfc:rock/magma/dacite",
+    "minecraft:magma_block"
+  ]
+}

--- a/src/main/java/net/dries007/tfc/client/overworld/LevelRendererExtension.java
+++ b/src/main/java/net/dries007/tfc/client/overworld/LevelRendererExtension.java
@@ -21,6 +21,11 @@ import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexBuffer;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.mojang.math.Axis;
+import net.dries007.tfc.common.TFCTags;
+import net.dries007.tfc.common.blocks.MoltenBlock;
+import net.dries007.tfc.common.blocks.TFCBlocks;
+import net.dries007.tfc.common.blocks.devices.CharcoalForgeBlock;
+import net.dries007.tfc.common.blocks.devices.FirepitBlock;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.ParticleStatus;
@@ -65,6 +70,8 @@ import net.dries007.tfc.util.calendar.Calendars;
 import net.dries007.tfc.util.climate.Climate;
 import net.dries007.tfc.util.climate.ClimateModel;
 import net.dries007.tfc.util.tracker.WeatherHelpers;
+
+import static net.dries007.tfc.common.blocks.devices.FirepitBlock.LIT;
 
 /**
  * Overrides {@link DimensionSpecialEffects.OverworldEffects} in order to provide additional features and modifications of the weather
@@ -601,8 +608,10 @@ public class LevelRendererExtension extends DimensionSpecialEffects.OverworldEff
                         );
 
                         final ParticleOptions options = !fluid.is(FluidTags.LAVA)
-                            && !state.is(Blocks.MAGMA_BLOCK)
+                            && !state.is(TFCTags.Blocks.SMOKES_IN_RAIN)
                             && !CampfireBlock.isLitCampfire(state)
+                            && !(state.is(TFCBlocks.FIREPIT.get()) && state.getValue(FirepitBlock.LIT))
+                            && !(state.is(TFCBlocks.CHARCOAL_FORGE.get()) && state.getValue(CharcoalForgeBlock.HEAT) > 0)
                             ? ParticleTypes.RAIN
                             : ParticleTypes.SMOKE;
                         level.addParticle(options, cursor.getX() + offsetX, cursor.getY() + offsetY, cursor.getZ() + offsetZ, 0.0, 0.0, 0.0);

--- a/src/main/java/net/dries007/tfc/client/overworld/LevelRendererExtension.java
+++ b/src/main/java/net/dries007/tfc/client/overworld/LevelRendererExtension.java
@@ -541,6 +541,7 @@ public class LevelRendererExtension extends DimensionSpecialEffects.OverworldEff
     {
         final Minecraft minecraft = Minecraft.getInstance();
         final float rainLevel = ClimateRenderCache.INSTANCE.getRainLevel(0f);
+        final boolean isSnowing = ClimateRenderCache.INSTANCE.getTemperature() < 0;
         if (rainLevel > 0.0F)
         {
             final RandomSource random = RandomSource.create(ticks * 312987231L);
@@ -555,58 +556,61 @@ public class LevelRendererExtension extends DimensionSpecialEffects.OverworldEff
                 * Mth.clampedMap(rainIntensity, 0, 0.3f, 0, 1)
                 * (Minecraft.useFancyGraphics() ? 1f : 0.5f)
                 * (minecraft.options.particles().get() == ParticleStatus.DECREASED ? 0.7f : 1f);
-            final int particleAmount = (int) (100f * adjustedRainIntensity * adjustedRainIntensity);
+            final int particleAmount = isSnowing ? 0 : (int) (100f * adjustedRainIntensity * adjustedRainIntensity);
 
             // Modification from vanilla, since we are using a cursor, we track if we added any particles rather than checking
             // if the position is not null, so we can make sounds for them
             boolean addedAnyParticles = false;
 
-            for (int n = 0; n < particleAmount; n++)
+            if (!isSnowing) // If snowing no particles/sound
             {
-                final int dx = random.nextInt(21) - 10;
-                final int dz = random.nextInt(21) - 10;
-
-                cursor.setWithOffset(cameraPos, dx, 0, dz);
-                cursor.setY(level.getHeight(Heightmap.Types.MOTION_BLOCKING, cursor.getX(), cursor.getZ()));
-
-                if (cursor.getY() > level.getMinBuildHeight() && cursor.getY() <= cameraPos.getY() + 10 && cursor.getY() >= cameraPos.getY() - 10)
+                for (int n = 0; n < particleAmount; n++)
                 {
-                    cursor.move(Direction.DOWN);
-                    addedAnyParticles = true;
+                    final int dx = random.nextInt(21) - 10;
+                    final int dz = random.nextInt(21) - 10;
 
-                    // Don't check the biome, as all overworld biomes should support rain, and we checked that above
+                    cursor.setWithOffset(cameraPos, dx, 0, dz);
+                    cursor.setY(level.getHeight(Heightmap.Types.MOTION_BLOCKING, cursor.getX(), cursor.getZ()));
 
-                    // With minimal particle options, we still search for a position (as we use it to determine if we need to play rain sounds), but we
-                    // stop at the first one, before spawning any particles for it.
-                    if (minecraft.options.particles().get() == ParticleStatus.MINIMAL)
+                    if (cursor.getY() > level.getMinBuildHeight() && cursor.getY() <= cameraPos.getY() + 10 && cursor.getY() >= cameraPos.getY() - 10)
                     {
-                        break;
+                        cursor.move(Direction.DOWN);
+                        addedAnyParticles = true;
+
+                        // Don't check the biome, as all overworld biomes should support rain, and we checked that above
+
+                        // With minimal particle options, we still search for a position (as we use it to determine if we need to play rain sounds), but we
+                        // stop at the first one, before spawning any particles for it.
+                        if (minecraft.options.particles().get() == ParticleStatus.MINIMAL)
+                        {
+                            break;
+                        }
+
+                        final double offsetX = random.nextDouble();
+                        final double offsetZ = random.nextDouble();
+                        final BlockState state = level.getBlockState(cursor);
+                        final FluidState fluid = level.getFluidState(cursor);
+
+                        // Handle `IBlockRain`, which needs to pretend the block is a solid block.
+                        final VoxelShape shape = state.getBlock() instanceof IBlockRain
+                            ? Shapes.block()
+                            : state.getCollisionShape(level, cursor);
+                        final double offsetY = Math.max(
+                            shape.max(Direction.Axis.Y, offsetX, offsetZ),
+                            fluid.getHeight(level, cursor)
+                        );
+
+                        final ParticleOptions options = !fluid.is(FluidTags.LAVA)
+                            && !state.is(Blocks.MAGMA_BLOCK)
+                            && !CampfireBlock.isLitCampfire(state)
+                            ? ParticleTypes.RAIN
+                            : ParticleTypes.SMOKE;
+                        level.addParticle(options, cursor.getX() + offsetX, cursor.getY() + offsetY, cursor.getZ() + offsetZ, 0.0, 0.0, 0.0);
                     }
-
-                    final double offsetX = random.nextDouble();
-                    final double offsetZ = random.nextDouble();
-                    final BlockState state = level.getBlockState(cursor);
-                    final FluidState fluid = level.getFluidState(cursor);
-
-                    // Handle `IBlockRain`, which needs to pretend the block is a solid block.
-                    final VoxelShape shape = state.getBlock() instanceof IBlockRain
-                        ? Shapes.block()
-                        : state.getCollisionShape(level, cursor);
-                    final double offsetY = Math.max(
-                        shape.max(Direction.Axis.Y, offsetX, offsetZ),
-                        fluid.getHeight(level, cursor)
-                    );
-
-                    final ParticleOptions options = !fluid.is(FluidTags.LAVA)
-                        && !state.is(Blocks.MAGMA_BLOCK)
-                        && !CampfireBlock.isLitCampfire(state)
-                        ? ParticleTypes.RAIN
-                        : ParticleTypes.SMOKE;
-                    level.addParticle(options, cursor.getX() + offsetX, cursor.getY() + offsetY, cursor.getZ() + offsetZ, 0.0, 0.0, 0.0);
                 }
             }
 
-            if (addedAnyParticles && random.nextInt(3) < rainSoundTime++)
+            if (!isSnowing && addedAnyParticles && random.nextInt(3) < rainSoundTime++)
             {
                 rainSoundTime = 0;
 

--- a/src/main/java/net/dries007/tfc/common/TFCTags.java
+++ b/src/main/java/net/dries007/tfc/common/TFCTags.java
@@ -137,6 +137,7 @@ public class TFCTags
          */
         public static final TagKey<Block> LIT_BY_DROPPED_TORCH = tag("lit_by_dropped_torch");
 
+        public static final TagKey<Block> SMOKES_IN_RAIN = commonTag("smokes_in_rain");
 
         /** Both these are empty by default, but provided for potential compatibility */
         public static final TagKey<Block> MINEABLE_WITH_PROPICK = tag("mineable/propick");

--- a/src/main/java/net/dries007/tfc/util/tracker/WeatherHelpers.java
+++ b/src/main/java/net/dries007/tfc/util/tracker/WeatherHelpers.java
@@ -217,13 +217,14 @@ public final class WeatherHelpers
         final ChunkPos chunkPos = chunk.getPos();
         final BlockPos surfacePos = getRandomSurfacePos(level, chunkPos);
         final float rainfall = model.getRainfall(level, surfacePos);
+        final int daysInMonth = Calendars.SERVER.getCalendarDaysInMonth();
 
         if (timeSinceTick > 1_000)
         {
             // We have not ticked this chunk in a short while, so run catch-up ticks to see if we missed anything
             // First, we need to check for what we might've missed
-            final int daysInMonth = Calendars.SERVER.getCalendarDaysInMonth();
 
+            // Iterates for maximum of two days of weather
             long calendarTick = currentCalendarTick - Math.min(48_000, timeSinceTick);
             int netChangeInSnow = 0; // >0 indicates melting, <0 indicates freezing
 
@@ -253,7 +254,10 @@ public final class WeatherHelpers
             }
             else if (netChangeInSnow < 0)
             {
-                handleSnowMelting(level, chunkPos, -netChangeInSnow);
+                // If it has been more than two days since the chunk was ticked,
+                // apply a multiplier to the melt based on how long it has been
+                final int meltFactor = (int) (Math.max(timeSinceTick / 48_000, 1));
+                handleSnowMelting(level, chunkPos, -netChangeInSnow * meltFactor);
             }
         }
         else if (level.random.nextInt(TICKS_PER_SNOW_ACCUMULATION) == 0)
@@ -299,7 +303,7 @@ public final class WeatherHelpers
 
     /**
      * Snow melting, including ice and icicles, is done randomly per POI chunk section. It can do up to {@code amount} removals,
-     * which simulates snow melting at a consistent rate (snow/tick), rather than random ticks which would be poportional to
+     * which simulates snow melting at a consistent rate (snow/tick), rather than random ticks which would be proportional to
      * the amount of snow in the chunk.
      */
     private static void handleSnowMelting(ServerLevel level, ChunkPos chunkPos, int amount)


### PR DESCRIPTION
- Fixed rain sounds/particles playing during heavy snow
- Added a multiplier to snow melting over large timescales. Comes into effect when time skip >4 days. Basically, this fixes the catchup algorithm not always deleting all of the snow when you load a chunk in July that hasn't been loaded since January. I found this behaved a little better (closer to parity w/ skipping 1 day at a time) than scaling it when temperatures were well above 0