### PR TITLE
Remove Erroneous Missing Model Particle Self Test Errors

### DIFF
--- a/src/main/java/net/dries007/tfc/util/SelfTests.java
+++ b/src/main/java/net/dries007/tfc/util/SelfTests.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
 import com.mojang.logging.LogUtils;
+import net.dries007.tfc.common.blocks.plant.*;
 import net.minecraft.SharedConstants;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.block.BlockModelShaper;
@@ -66,10 +67,6 @@ import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.common.blocks.devices.IngotPileBlock;
 import net.dries007.tfc.common.blocks.devices.ScrapingBlock;
 import net.dries007.tfc.common.blocks.devices.SheetPileBlock;
-import net.dries007.tfc.common.blocks.plant.BodyPlantBlock;
-import net.dries007.tfc.common.blocks.plant.BranchingCactusBlock;
-import net.dries007.tfc.common.blocks.plant.GrowingBranchingCactusBlock;
-import net.dries007.tfc.common.blocks.plant.Plant;
 import net.dries007.tfc.common.blocks.plant.fruit.GrowingFruitTreeBranchBlock;
 import net.dries007.tfc.common.blocks.rock.RockDisplayCategory;
 import net.dries007.tfc.common.component.food.Nutrient;
@@ -298,7 +295,7 @@ public final class SelfTests
             .toList();
         final List<BlockState> missingParticleErrors = TFCBlocks.BLOCKS.getEntries()
             .stream()
-            .flatMap(states(s -> !s.isAir() && !(s.getBlock() instanceof IngotPileBlock) && !(s.getBlock() instanceof SheetPileBlock) && !(s.getBlock() instanceof ScrapingBlock) && shaper.getParticleIcon(s) == missingParticle))
+            .flatMap(states(s -> !s.isAir() && !(s.getBlock() instanceof IngotPileBlock) && !(s.getBlock() instanceof SheetPileBlock) && !(s.getBlock() instanceof PlantBlock) && !(s.getBlock() instanceof ScrapingBlock) && shaper.getParticleIcon(s) == missingParticle))
             .toList();
 
         return logErrors("{} block states with missing models:", missingModelErrors, LOGGER)


### PR DESCRIPTION
"Fixes" the issue by just not checking plants

This is good because I'll actually notice when I forget to add a block to creative, etc. It is also consistent with how we handle sheet and ingot piles

This is bad because it still won't give us a warning for plants missing breaking particles, it applies to all plants regardless of whether they actually use dynamic models