### PR TITLE
Fix river groundwater influence applying for underground rivers

### DIFF
--- a/src/main/java/net/dries007/tfc/world/TFCChunkGenerator.java
+++ b/src/main/java/net/dries007/tfc/world/TFCChunkGenerator.java
@@ -434,7 +434,7 @@ public class TFCChunkGenerator extends ChunkGenerator implements ChunkGeneratorE
             chunkData.generateFull(filler.surfaceHeight(), filler.aquifer().surfaceHeights());
             chunkData.getRockData().useCache(chunkPos);
             filler.fillFromNoise();
-            chunkData.modifyBaseGroundwater(filler.surfaceHeight(), chunk);
+            chunkData.modifyBaseGroundwater(filler.surfaceHeight());
 
             aquiferCache.set(chunkPos.x, chunkPos.z, filler.aquifer());
 

--- a/src/main/java/net/dries007/tfc/world/TFCChunkGenerator.java
+++ b/src/main/java/net/dries007/tfc/world/TFCChunkGenerator.java
@@ -434,6 +434,7 @@ public class TFCChunkGenerator extends ChunkGenerator implements ChunkGeneratorE
             chunkData.generateFull(filler.surfaceHeight(), filler.aquifer().surfaceHeights());
             chunkData.getRockData().useCache(chunkPos);
             filler.fillFromNoise();
+            chunkData.modifyBaseGroundwater(filler.surfaceHeight(), chunk);
 
             aquiferCache.set(chunkPos.x, chunkPos.z, filler.aquifer());
 

--- a/src/main/java/net/dries007/tfc/world/chunkdata/ChunkData.java
+++ b/src/main/java/net/dries007/tfc/world/chunkdata/ChunkData.java
@@ -224,21 +224,19 @@ public sealed class ChunkData
         this.status = Status.FULL;
     }
 
-    public void modifyBaseGroundwater(int[] surfaceHeight, ChunkAccess chunk)
+    public void modifyBaseGroundwater(int[] surfaceHeight)
     {
         assert this.baseGroundwaterLayer != null;
-        float groundwater00 = modifyBaseGroundwaterPoint(surfaceHeight[0], this.baseGroundwaterLayer.value00());
-        float groundwater10 = modifyBaseGroundwaterPoint(surfaceHeight[15], this.baseGroundwaterLayer.value10());
-        float groundwater01 = modifyBaseGroundwaterPoint(surfaceHeight[240], this.baseGroundwaterLayer.value01());
-        float groundwater11 = modifyBaseGroundwaterPoint(surfaceHeight[255], this.baseGroundwaterLayer.value11());
+        float groundwater00 = modifyBaseGroundwaterPoint(surfaceHeight[0], this.baseGroundwaterLayer.value00()); // Constant = x + 16z, x=0, z=0
+        float groundwater10 = modifyBaseGroundwaterPoint(surfaceHeight[15], this.baseGroundwaterLayer.value10()); // Constant = x + 16z, x=15, z=0
+        float groundwater01 = modifyBaseGroundwaterPoint(surfaceHeight[240], this.baseGroundwaterLayer.value01()); // Constant = x + 16z, x=0, z=15
+        float groundwater11 = modifyBaseGroundwaterPoint(surfaceHeight[255], this.baseGroundwaterLayer.value11()); // Constant = x + 16z, x=15, z=15
         this.baseGroundwaterLayer = new LerpFloatLayer(groundwater00, groundwater01, groundwater10, groundwater11);
-
-        chunk.setUnsaved(true);
     }
 
     public float modifyBaseGroundwaterPoint(int height, float startingWater)
     {
-        return startingWater * Mth.clampedMap(height, SEA_LEVEL_Y, SEA_LEVEL_Y + 25, 1, 0);
+        return startingWater * Mth.clampedMap(height, SEA_LEVEL_Y + 10, SEA_LEVEL_Y + 25, 1, 0);
     }
 
     /**

--- a/src/main/java/net/dries007/tfc/world/chunkdata/ChunkData.java
+++ b/src/main/java/net/dries007/tfc/world/chunkdata/ChunkData.java
@@ -9,6 +9,7 @@ package net.dries007.tfc.world.chunkdata;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.Mth;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.chunk.ChunkAccess;
@@ -20,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import net.dries007.tfc.common.TFCAttachments;
 import net.dries007.tfc.network.ChunkWatchPacket;
 
+import static net.dries007.tfc.world.TFCChunkGenerator.SEA_LEVEL_Y;
 
 public sealed class ChunkData
 {
@@ -220,6 +222,23 @@ public sealed class ChunkData
         this.rockData.setSurfaceHeight(surfaceHeight);
         this.aquiferSurfaceHeight = aquiferSurfaceHeight;
         this.status = Status.FULL;
+    }
+
+    public void modifyBaseGroundwater(int[] surfaceHeight, ChunkAccess chunk)
+    {
+        assert this.baseGroundwaterLayer != null;
+        float groundwater00 = modifyBaseGroundwaterPoint(surfaceHeight[0], this.baseGroundwaterLayer.value00());
+        float groundwater10 = modifyBaseGroundwaterPoint(surfaceHeight[15], this.baseGroundwaterLayer.value10());
+        float groundwater01 = modifyBaseGroundwaterPoint(surfaceHeight[240], this.baseGroundwaterLayer.value01());
+        float groundwater11 = modifyBaseGroundwaterPoint(surfaceHeight[255], this.baseGroundwaterLayer.value11());
+        this.baseGroundwaterLayer = new LerpFloatLayer(groundwater00, groundwater01, groundwater10, groundwater11);
+
+        chunk.setUnsaved(true);
+    }
+
+    public float modifyBaseGroundwaterPoint(int height, float startingWater)
+    {
+        return startingWater * Mth.clampedMap(height, SEA_LEVEL_Y, SEA_LEVEL_Y + 25, 1, 0);
     }
 
     /**


### PR DESCRIPTION
Works by modifying the groundwater map based on the final surface heights at corners, so also makes rivers in canyons not moisten the surrounding plateau as much. Not sure if going and modifying the chunkdata this late in the game is kosher, but from my testing it works ok.

Probably best if @alcatrazEscapee takes a quick peep at this.