### PR TITLE
Replace Biome.getPrecipitationAt() redirects with an inject

### DIFF
--- a/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
@@ -13,7 +13,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.biome.Biome;
-
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
 import net.dries007.tfc.util.climate.Climate;
 import net.dries007.tfc.world.biome.BiomeBridge;
 import net.dries007.tfc.world.biome.BiomeExtension;
@@ -71,7 +72,9 @@ public abstract class BiomeMixin implements BiomeBridge
      * <p>
      * This is better than redirecting known calls to getPrecipitationAt because other mods sometimes
      * use this method to get weather information.
+     * This is only done on the client, where we can get the client level.
      */
+    @OnlyIn(Dist.CLIENT)
     @Inject(method = "getPrecipitationAt", at = @At("HEAD"), cancellable = true)
     private void getPrecipitationFromClimate(BlockPos pos, CallbackInfoReturnable<Biome.Precipitation> cir) {
         Minecraft minecraft = Minecraft.getInstance();

--- a/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
@@ -9,6 +9,7 @@ package net.dries007.tfc.mixin;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.biome.Biome;
@@ -20,7 +21,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Biome.class)
 public abstract class BiomeMixin implements BiomeBridge
@@ -61,5 +64,18 @@ public abstract class BiomeMixin implements BiomeBridge
     private boolean shouldFreezeWithClimate(Biome biome, BlockPos pos, LevelReader level)
     {
         return Climate.warmEnoughToRain(level, pos, biome);
+    }
+
+    /**
+     * Replace {@link Biome#getPrecipitationAt(BlockPos)} with a method that takes our climate model into account
+     * <p>
+     * This is better than redirecting known calls to getPrecipitationAt because other mods sometimes
+     * use this method to get weather information.
+     */
+    @Inject(method = "getPrecipitationAt", at = @At("HEAD"), cancellable = true)
+    private void getPrecipitationFromClimate(BlockPos pos, CallbackInfoReturnable<Biome.Precipitation> cir) {
+        Minecraft minecraft = Minecraft.getInstance();
+        cir.setReturnValue(Climate.getPrecipitation(minecraft.level, pos));
+        cir.cancel();
     }
 }

--- a/src/main/java/net/dries007/tfc/mixin/client/LevelRendererMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/client/LevelRendererMixin.java
@@ -6,51 +6,25 @@
 
 package net.dries007.tfc.mixin.client;
 
-import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.biome.Biome;
 
 import net.dries007.tfc.common.blocks.IBlockRain;
-import net.dries007.tfc.util.climate.Climate;
 
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(LevelRenderer.class)
 public abstract class LevelRendererMixin
 {
-    @Shadow private ClientLevel level;
-
-    /**
-     * Redirect the call to {@link Biome#getPrecipitationAt(BlockPos)}.
-     */
-    @Redirect(method = "renderSnowAndRain", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/biome/Biome;getPrecipitationAt(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/biome/Biome$Precipitation;"))
-    private Biome.Precipitation renderSnowAndRainUseClimate(Biome biome, BlockPos pos)
-    {
-        return Climate.getPrecipitation(level, pos);
-    }
-
-    /**
-     * Redirect the call to {@link Biome#getPrecipitationAt(BlockPos)}.
-     */
-    @Redirect(method = "tickRain", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/biome/Biome;getPrecipitationAt(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/biome/Biome$Precipitation;"))
-    private Biome.Precipitation tickRainUseClimate(Biome biome, BlockPos pos)
-    {
-        return Climate.getPrecipitation(level, pos);
-    }
-
     @Redirect(method = "tickRain", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/state/BlockState;getCollisionShape(Lnet/minecraft/world/level/BlockGetter;Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/phys/shapes/VoxelShape;"))
     private VoxelShape getCollisionShapeIgnoreLeaves(BlockState state, BlockGetter level, BlockPos pos)
     {
         return state.getBlock() instanceof IBlockRain ? Shapes.block() : state.getCollisionShape(level, pos);
     }
-
 }


### PR DESCRIPTION
1.20 TFC currently bypasses the Biome.getPrecipitationAt() method using mixin redirects, which breaks compatibility with other mods. For example, the mod Particle Rain calls Biome.getPrecipitationAt() to figure out if it's raining or snowing at a specific location. Using an inject instead makes these mods compatible with each other, and removes the need for multiple redirects of getPrecipitationAt.