### PR TITLE
Fix jar shelf block outline

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/JarShelfBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/JarShelfBlock.java
@@ -9,6 +9,9 @@ package net.dries007.tfc.common.blocks;
 import java.util.Map;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -27,13 +30,18 @@ import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.DirectionProperty;
 import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
+import net.dries007.tfc.client.IHighlightHandler;
+import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blockentities.JarsBlockEntity;
+import net.dries007.tfc.common.blockentities.PlacedItemBlockEntity;
 import net.dries007.tfc.common.blocks.devices.BottomSupportedDeviceBlock;
+import net.dries007.tfc.util.Helpers;
 
 public class JarShelfBlock extends JarsBlock
 {
@@ -125,5 +133,26 @@ public class JarShelfBlock extends JarsBlock
             jars.clearContent();
         }
         return facing == state.getValue(FACING) && !facingState.isFaceSturdy(level, facingPos, facing.getOpposite()) ? Blocks.AIR.defaultBlockState() : updateStateValues(level, currentPos, state);
+    }
+
+    @Override
+    public boolean drawHighlight(Level level, BlockPos pos, Player player, BlockHitResult rayTrace, PoseStack stack, MultiBufferSource buffers, Vec3 rendererPosition)
+    {
+        final int slot = PlacedItemBlockEntity.getSlotSelected(rayTrace);
+        final boolean lookingAtJar = BOUNDS[slot].move(pos).contains(rayTrace.getLocation());
+        if (lookingAtJar) {
+            super.drawHighlight(level, pos, player, rayTrace, stack, buffers, rendererPosition);
+        }
+
+        final BlockPos above = pos.above();
+        final BlockState aboveState = level.getBlockState(above);
+        final boolean notHoldingJar = !Helpers.isItem(player.getItemInHand(InteractionHand.MAIN_HAND), TFCTags.Items.JARS) && !Helpers.isItem(player.getItemInHand(InteractionHand.OFF_HAND), TFCTags.Items.JARS);
+        final boolean filledSlotAbove = aboveState.getBlock() instanceof JarsBlock && aboveState.getValue(ITEM_PROPERTIES[slot]);
+        if (notHoldingJar || filledSlotAbove) {
+            IHighlightHandler.drawBox(stack, TOP_SHAPE, buffers, pos, rendererPosition, 0f, 0f, 0f, 0.4f);
+            return true;
+        }
+        IHighlightHandler.drawBox(stack, SHAPES[slot], buffers, above, rendererPosition, 1f, 0f, 0f, 1f);
+        return lookingAtJar;
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/JarShelfBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/JarShelfBlock.java
@@ -142,6 +142,7 @@ public class JarShelfBlock extends JarsBlock
         final boolean lookingAtJar = BOUNDS[slot].move(pos).contains(rayTrace.getLocation());
         if (lookingAtJar) {
             super.drawHighlight(level, pos, player, rayTrace, stack, buffers, rendererPosition);
+            return true;
         }
 
         final BlockPos above = pos.above();

--- a/src/main/java/net/dries007/tfc/common/blocks/JarShelfBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/JarShelfBlock.java
@@ -141,8 +141,7 @@ public class JarShelfBlock extends JarsBlock
         final int slot = PlacedItemBlockEntity.getSlotSelected(rayTrace);
         final boolean lookingAtJar = BOUNDS[slot].move(pos).contains(rayTrace.getLocation());
         if (lookingAtJar) {
-            super.drawHighlight(level, pos, player, rayTrace, stack, buffers, rendererPosition);
-            return true;
+            return super.drawHighlight(level, pos, player, rayTrace, stack, buffers, rendererPosition);
         }
 
         final BlockPos above = pos.above();

--- a/src/main/java/net/dries007/tfc/common/blocks/JarShelfBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/JarShelfBlock.java
@@ -146,13 +146,14 @@ public class JarShelfBlock extends JarsBlock
 
         final BlockPos above = pos.above();
         final BlockState aboveState = level.getBlockState(above);
-        final boolean notHoldingJar = !Helpers.isItem(player.getItemInHand(InteractionHand.MAIN_HAND), TFCTags.Items.JARS) && !Helpers.isItem(player.getItemInHand(InteractionHand.OFF_HAND), TFCTags.Items.JARS);
+        final boolean holdingJar = Helpers.isItem(player.getItemInHand(InteractionHand.MAIN_HAND), TFCTags.Items.JARS) || Helpers.isItem(player.getItemInHand(InteractionHand.OFF_HAND), TFCTags.Items.JARS);
         final boolean filledSlotAbove = aboveState.getBlock() instanceof JarsBlock && aboveState.getValue(ITEM_PROPERTIES[slot]);
-        if (notHoldingJar || filledSlotAbove) {
-            IHighlightHandler.drawBox(stack, TOP_SHAPE, buffers, pos, rendererPosition, 0f, 0f, 0f, 0.4f);
-            return true;
+        
+        IHighlightHandler.drawBox(stack, TOP_SHAPE, buffers, pos, rendererPosition, 0f, 0f, 0f, 0.4f);
+        if (holdingJar && !filledSlotAbove) {
+            IHighlightHandler.drawBox(stack, SHAPES[slot], buffers, above, rendererPosition, 1f, 0f, 0f, 1f);
         }
-        IHighlightHandler.drawBox(stack, SHAPES[slot], buffers, above, rendererPosition, 1f, 0f, 0f, 1f);
-        return lookingAtJar;
+
+        return true;
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/JarsBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/JarsBlock.java
@@ -158,11 +158,13 @@ public class JarsBlock extends BottomSupportedDeviceBlock implements IHighlightH
     {
         if (!Helpers.isItem(player.getItemInHand(InteractionHand.MAIN_HAND), TFCTags.Items.JARS) && !Helpers.isItem(player.getItemInHand(InteractionHand.OFF_HAND), TFCTags.Items.JARS))
         {
-            return true;
+            return false;
         }
         final int slot = PlacedItemBlockEntity.getSlotSelected(rayTrace);
-        IHighlightHandler.drawBox(stack, SHAPES[slot], buffers, pos, rendererPosition, 1f, 0f, 0f, 1f);
-        return BOUNDS[slot].move(pos).contains(rayTrace.getLocation());
+        final boolean lookingAtJar = BOUNDS[slot].move(pos).contains(rayTrace.getLocation());
+        final BlockPos adjustedPos = lookingAtJar ? pos : pos.above();
+        IHighlightHandler.drawBox(stack, SHAPES[slot], buffers, adjustedPos, rendererPosition, 1f, 0f, 0f, 1f);
+        return lookingAtJar;
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/blocks/JarsBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/JarsBlock.java
@@ -156,15 +156,9 @@ public class JarsBlock extends BottomSupportedDeviceBlock implements IHighlightH
     @Override
     public boolean drawHighlight(Level level, BlockPos pos, Player player, BlockHitResult rayTrace, PoseStack stack, MultiBufferSource buffers, Vec3 rendererPosition)
     {
-        if (!Helpers.isItem(player.getItemInHand(InteractionHand.MAIN_HAND), TFCTags.Items.JARS) && !Helpers.isItem(player.getItemInHand(InteractionHand.OFF_HAND), TFCTags.Items.JARS))
-        {
-            return false;
-        }
         final int slot = PlacedItemBlockEntity.getSlotSelected(rayTrace);
-        final boolean lookingAtJar = BOUNDS[slot].move(pos).contains(rayTrace.getLocation());
-        final BlockPos adjustedPos = lookingAtJar ? pos : pos.above();
-        IHighlightHandler.drawBox(stack, SHAPES[slot], buffers, adjustedPos, rendererPosition, 1f, 0f, 0f, 1f);
-        return lookingAtJar;
+        IHighlightHandler.drawBox(stack, SHAPES[slot], buffers, pos, rendererPosition, 0f, 0f, 0f, 0.4f);
+        return true;
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/blocks/JarsBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/JarsBlock.java
@@ -122,7 +122,7 @@ public class JarsBlock extends BottomSupportedDeviceBlock implements IHighlightH
     public JarsBlock(ExtendedProperties properties, boolean buildCache)
     {
         super(properties, InventoryRemoveBehavior.DROP, SHAPE_1);
-        registerDefaultState(getStateDefinition().any().setValue(ITEM_0, true).setValue(ITEM_1, true).setValue(ITEM_2, true).setValue(ITEM_3, true));
+        registerDefaultState(getStateDefinition().any().setValue(ITEM_0, false).setValue(ITEM_1, false).setValue(ITEM_2, false).setValue(ITEM_3, false));
         this.cachedShapes = buildCache ? makeShapes(getStateDefinition().getPossibleStates()) : new HashMap<>();
     }
 


### PR DESCRIPTION
This fixes #2756, as well as various other issues with the jar shelf outline rendering, such as not being able to see the standard outline. It also lets you select individual jars, and prevents jars from being highlighted when looking at the shelf itself.

Jar shelves also default to having all 4 items slots filled by default, which causes nonexistent jars to become highlighted. I made the shelves have all 4 slots marked as unfilled by default instead.

Attached is a video of the working shelf highlighting.

https://github.com/user-attachments/assets/3d8012d6-0216-46df-9d96-807979629a3b

