### PR TITLE
Make mobs able to pathfind around stalagmites

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/rock/RockSpikeBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/rock/RockSpikeBlock.java
@@ -124,7 +124,7 @@ public class RockSpikeBlock extends Block implements IFluidLoggable, IFallableBl
     @Override
     public @Nullable BlockPathTypes getBlockPathType(BlockState state, BlockGetter level, BlockPos pos, @Nullable Mob mob)
     {
-        return BlockPathTypes.TRAPDOOR;
+        return BlockPathTypes.BLOCKED;
     }
 
     @Override


### PR DESCRIPTION
Currently, mobs will walk into stalagmites and not realize they need go around them. This PR fixes it (issue #2397).

Mob pathing around stalagmites was already fixed in 1.21, this fix is identical.