### PR TITLE
Fix crash when dispenser activates gunpowder bowl

### DIFF
--- a/src/main/java/net/dries007/tfc/util/DispenserBehaviors.java
+++ b/src/main/java/net/dries007/tfc/util/DispenserBehaviors.java
@@ -161,25 +161,45 @@ public final class DispenserBehaviors
         }
     };
 
-    public static final OptionalDispenseItemBehavior TFC_FLINT_AND_STEEL_BEHAVIOR = new OptionalDispenseItemBehavior() {
+    public static final DispenseItemBehavior TFC_FLINT_AND_STEEL_BEHAVIOR = new DispenseItemBehavior()
+    {
+        private final DispenseItemBehavior fallbackBehavior = DispenserBlockAccessor.accessor$getDispenserRegistry().get(Items.FLINT_AND_STEEL);
 
         @Override
-        protected ItemStack execute(BlockSource source, ItemStack stack)
+        public ItemStack dispense(BlockSource source, ItemStack stack)
         {
             final Level level = source.getLevel();
             final Direction facing = source.getBlockState().getValue(DispenserBlock.FACING);
             final BlockPos pos = source.getPos().relative(facing);
             final BlockState state = level.getBlockState(pos);
+
+            // Must get the dispenser facing before executing, in case it triggers an explosion that removes the dispenser
+            Direction dir = source.getBlockState().getValue(DispenserBlock.FACING);
             if (TFCConfig.SERVER.dispenserEnableLighting.get() && StartFireEvent.startFire(level, pos, state, facing.getOpposite(), null, stack, StartFireEvent.FireStrength.STRONG))
             {
                 if (stack.hurt(1, level.getRandom(), null))
                 {
                     stack.setCount(0);
                 }
+                this.playSound(source);
+                this.playAnimation(source, dir);
                 return stack;
             }
-            setSuccess(false);
-            return stack;
+            return fallbackBehavior.dispense(source, stack);
+        }
+
+        /**
+         * Taken from {@link DefaultDispenseItemBehavior#playSound} since we can't inherit it
+         */
+        private void playSound(BlockSource source) {
+            source.getLevel().levelEvent(1000, source.getPos(), 0);
+        }
+
+        /**
+         * Taken from {@link DefaultDispenseItemBehavior#playAnimation} since we can't inherit it
+         */
+        private void playAnimation(BlockSource source, Direction dir) {
+            source.getLevel().levelEvent(2000, source.getPos(), dir.get3DDataValue());
         }
     };
 
@@ -222,30 +242,7 @@ public final class DispenserBehaviors
         TFCItems.CHEST_MINECARTS.values().forEach(reg -> DispenserBlock.registerBehavior(reg.get(), MINECART_BEHAVIOR));
 
         DispenserBlock.registerBehavior(Items.EGG, new DefaultDispenseItemBehavior());
-        DispenserBlock.registerBehavior(Items.FLINT_AND_STEEL, new MultipleItemBehavior(TFC_FLINT_AND_STEEL_BEHAVIOR, DispenserBlockAccessor.accessor$getDispenserRegistry().get(Items.FLINT_AND_STEEL)));
+        DispenserBlock.registerBehavior(Items.FLINT_AND_STEEL, TFC_FLINT_AND_STEEL_BEHAVIOR);
         DispenserBlock.registerBehavior(TFCItems.HANDSTONE.get(), HANDSTONE_BEHAVIOR);
-    }
-
-    public static class MultipleItemBehavior implements DispenseItemBehavior
-    {
-        private final OptionalDispenseItemBehavior primary;
-        private final DispenseItemBehavior defaultBehavior;
-
-        public MultipleItemBehavior(OptionalDispenseItemBehavior first, DispenseItemBehavior second)
-        {
-            primary = first;
-            defaultBehavior = second;
-        }
-
-        @Override
-        public ItemStack dispense(BlockSource source, ItemStack stack)
-        {
-            ItemStack result = primary.dispense(source, stack);
-            if (primary.isSuccess())
-            {
-                return result;
-            }
-            return defaultBehavior.dispense(source, stack);
-        }
     }
 }


### PR DESCRIPTION
This fixes a crash that occurs when a dispenser uses a flint and steel to explode a gunpowder filled ceramic bowl (issue #2884). The problem occurs because the dispenser activates the ceramic bowl immediately, which destroys the dispenser before it can finish the dispensing code. It then tries to query the facing direction of the dispenser in order to show particles in the correct direction, but the dispenser was already replaced with air, causing a game crash.

The fix is to check the orientation of the dispenser _before_ triggering the start fire event. I wanted to do this by overriding the `.dispense()` method of `DefaultDispenseItemBehavior`, but the method is marked as final. I got around this by making the TFC flint and steel behavior directly extend `DispenseItemBehavior` and have a field for the default behavior. This removed the need to use the `MultipleItemBehavior` class.

Since the flint and steel dispensing was the only use of the multiple item behavior class, I removed it. This is technically a breaking change since it was a public class, but I think it's very unlikely any addons used it. I searched in the code of every addon referenced in the TFC field guide (artisanal, beneath, firmalife, lithiccoins, rnr, afc, firma:civ) and didn't find any references to `MultipleItemBehavior`.