### PR TITLE
Fix crash with Create mod's deployer

### DIFF
--- a/src/main/java/net/dries007/tfc/util/Drinkable.java
+++ b/src/main/java/net/dries007/tfc/util/Drinkable.java
@@ -70,6 +70,13 @@ public class Drinkable extends FluidDefinition
      */
     public static InteractionResult attemptDrink(Level level, Player player, boolean doDrink)
     {
+        // Create mod sometimes fakes player interactions with an
+        // entity that has already been removed, see issue #2971
+        if (player.isRemoved())
+        {
+            return InteractionResult.PASS;
+        }   
+
         final BlockHitResult hit = Helpers.rayTracePlayer(level, player, ClipContext.Fluid.SOURCE_ONLY);
         if (hit.getType() == HitResult.Type.BLOCK)
         {


### PR DESCRIPTION
Fixes issue #2971. Create mod's deployer sometimes simulates a right click action with a player entity that has already been marked as removed. This causes a game crash when trying the drink water right click action, because you can't get the player data of a player marked as removed. I added a check for this, preventing the crash.

This could be a bug with create mod, since it seems strange to right click with an already removed player, but I figured it was worth it to fix it from TFC's end since it's so simple.