### PR TITLE
Fix snow piles forgetting contents when broken without a shovel

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/SnowPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/SnowPileBlock.java
@@ -24,6 +24,7 @@ import net.minecraft.world.level.block.SnowLayerBlock;
 import net.minecraft.world.level.block.SnowyDirtBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.HitResult;
 import org.jetbrains.annotations.Nullable;
 
@@ -162,6 +163,14 @@ public class SnowPileBlock extends SnowLayerBlock implements IForgeBlockExtensio
     {
         super.playerDestroy(level, player, pos, state, entity, stack);
         removePileOrSnow(level, pos, state, -1, entity instanceof PileBlockEntity pile ? Optional.of(pile) : Optional.empty());
+    }
+
+    @Override
+    public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid)
+    {
+        playerWillDestroy(level, pos, state, player);
+        removePileOrSnow(level, pos, state);
+        return true; // Cause drops and other stuff to occur
     }
 
     @Override


### PR DESCRIPTION
As described in issue #2960, snow piles don't place the block they conceal unless broken using a shovel in survival mode. Breaking them with an open hand or other item, or breaking them in creative deletes the snow pile and its contents. This happens because the snow pile block currently places the concealed item back by overriding the `playerDestroy()` method, which I found was not called when the block is broken in creative or without a shovel.

To fix this, I re-added a previously removed override of `onDestroyedByPlayer()`. This is always called when the block is broken, fixing the problem. The `playerDestroy()` override is still needed, because it prevents the player from instamining both the snow pile and the plant it conceals in the same tick (issue #2759).