### PR TITLE
(1.21) Fix kill command being horribly broken

### DIFF
--- a/src/main/java/net/dries007/tfc/ForgeEventHandler.java
+++ b/src/main/java/net/dries007/tfc/ForgeEventHandler.java
@@ -825,6 +825,11 @@ public final class ForgeEventHandler
     public static void onLivingHurt(LivingIncomingDamageEvent event)
     {
         float amount = event.getAmount();
+        
+        // Vanilla kill command uses Float.MAX_VALUE, possibly others
+        if (amount == Float.MAX_VALUE) {
+            return;
+        }
 
         // Forging Bonus
         final Entity attackerEntity = event.getSource().getEntity();

--- a/src/main/java/net/dries007/tfc/ForgeEventHandler.java
+++ b/src/main/java/net/dries007/tfc/ForgeEventHandler.java
@@ -827,7 +827,8 @@ public final class ForgeEventHandler
         float amount = event.getAmount();
         
         // Vanilla kill command uses Float.MAX_VALUE, possibly others
-        if (amount == Float.MAX_VALUE) {
+        if (amount == Float.MAX_VALUE)
+        {
             return;
         }
 


### PR DESCRIPTION
TFC's health system breaks when a player is damaged by extremely large values, such as when vanilla's /kill command damages a player by Float.MAX_VALUE. This adds a check for it.