### PR TITLE
(1.21) Reduce vertical offset of placed item models

### DIFF
--- a/src/main/java/net/dries007/tfc/client/render/blockentity/PlacedItemBlockEntityRenderer.java
+++ b/src/main/java/net/dries007/tfc/client/render/blockentity/PlacedItemBlockEntityRenderer.java
@@ -113,7 +113,7 @@ public class PlacedItemBlockEntityRenderer<T extends PlacedItemBlockEntity> impl
             {
                 pose.translate(slotX * 0.5, 0, slotZ * 0.5);
             }
-            pose.translate(0, -0.05, 0);
+            pose.translate(0, -0.0001, 0);
 
             blockRenderer.tesselateWithAO(entity.getLevel(), baked, entity.getBlockState(), entity.getBlockPos(), pose, buffer, true, random, packedLight, packedOverlay, ModelData.EMPTY, RenderType.translucent());
         }


### PR DESCRIPTION
Custom placed item models are noticeably clipped into the ground currently, with the intention of preventing z-fighting. I made the offset a much smaller distance, which is still sufficient to prevent z-fighting.