### PR TITLE
(1.21) Make jam in jars inedible

### DIFF
--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinFoods.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinFoods.java
@@ -195,7 +195,7 @@ public class BuiltinFoods extends DataManagerProvider<FoodDefinition> implements
         add(Food.COOKED_CAMELIDAE, ofFood(2, 0, 2.25f).protein(2.5f));
 
         add(TFCTags.Items.SEALED_PRESERVES, ofFood(0, 0, 0, 5f), false);
-        add(TFCTags.Items.PRESERVES, ofFood(0, 0, 0, 5f).fruit(0.75f), true);
+        add(TFCTags.Items.PRESERVES, ofFood(0, 0, 0, 5f).fruit(0.75f), false);
         add(TFCTags.Items.JAM, ofFood(1, 0, 5).fruit(0.75f), true);
         add(TFCTags.Items.SALADS, of(4.5f), true);
         add(TFCTags.Items.SOUPS, of(4.5f), true);

--- a/src/generated/resources/data/tfc/tfc/food/preserves.json
+++ b/src/generated/resources/data/tfc/tfc/food/preserves.json
@@ -1,5 +1,6 @@
 {
   "decay_modifier": 5.0,
+  "edible": false,
   "fruit": 0.75,
   "ingredient": {
     "tag": "tfc:foods/preserves"


### PR DESCRIPTION
Unsealed jam jars are currently edible in 1.21, which is an unintentional change from 1.20. They don't give any hunger or saturation, and they don't give back the glass jar when eaten.