### PR TITLE
(1.21) Fix snow and charcoal pile breaking

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/CharcoalPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/CharcoalPileBlock.java
@@ -53,13 +53,12 @@ public class CharcoalPileBlock extends Block
     @Override
     public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid)
     {
-        int prevLayers = state.getValue(LAYERS);
-        if (prevLayers == 1 || player.isCreative())
+        final int prevLayers = state.getValue(LAYERS);
+        if (prevLayers > 1 && !player.isCreative())
         {
-            return super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
+            return level.setBlock(pos, state.setValue(LAYERS, prevLayers - 1), level.isClientSide() ? 11 : 3);
         }
-        
-        return level.setBlock(pos, state.setValue(LAYERS, prevLayers - 1), 3);
+        return super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/blocks/CharcoalPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/CharcoalPileBlock.java
@@ -53,19 +53,13 @@ public class CharcoalPileBlock extends Block
     @Override
     public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid)
     {
-        playerWillDestroy(level, pos, state, player);
-
-        if (player.isCreative())
-        {
-            return level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
-        }
-
         int prevLayers = state.getValue(LAYERS);
-        if (prevLayers == 1)
+        if (prevLayers == 1 || player.isCreative())
         {
-            return level.setBlockAndUpdate(pos, Blocks.AIR.defaultBlockState());
+            return super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
         }
-        return level.setBlock(pos, state.setValue(LAYERS, prevLayers - 1), level.isClientSide ? 11 : 3);
+        
+        return level.setBlock(pos, state.setValue(LAYERS, prevLayers - 1), 3);
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/blocks/SnowPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/SnowPileBlock.java
@@ -74,14 +74,13 @@ public class SnowPileBlock extends SnowLayerBlock implements IForgeBlockExtensio
 
     public static void removePileOrSnow(LevelAccessor level, BlockPos pos, BlockState state)
     {
-        removePileOrSnow(level, pos, state, Optional.empty());
+        removePileOrSnow(level, pos, state, level.getBlockEntity(pos, TFCBlockEntities.PILE.get()).orElse(null));
     }
 
     /**
-     * @param snowPile If {@code null}, then there is no provided block entity and one should be queried from the world. If not-null, this
-     *                 represents the block entity present in the world, possibly empty.
+     * @param snowPile The snow pile block entity present in the world, possibly null.
      */
-    public static void removePileOrSnow(LevelAccessor level, BlockPos pos, BlockState state, @Nullable Optional<PileBlockEntity> snowPile)
+    public static void removePileOrSnow(LevelAccessor level, BlockPos pos, BlockState state, @Nullable PileBlockEntity snowPile)
     {
         final int layers = state.getValue(SnowLayerBlock.LAYERS);
         if (layers > 1)
@@ -94,30 +93,27 @@ public class SnowPileBlock extends SnowLayerBlock implements IForgeBlockExtensio
             // Remove a single snow layer block
             level.removeBlock(pos, false);
         }
-        else
+        else if (snowPile != null)
         {
             // Otherwise, remove a snow pile, restoring the internal states
-            if (snowPile == null) snowPile = level.getBlockEntity(pos, TFCBlockEntities.PILE.get());
-            snowPile.ifPresent(pile -> {
-                final BlockPos above = pos.above();
+            final BlockPos above = pos.above();
 
-                level.setBlock(pos, pile.getInternalState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE);
-                if (pile.getAboveState() != null && level.isEmptyBlock(above))
-                {
-                    level.setBlock(above, pile.getAboveState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE);
-                }
+            level.setBlock(pos, snowPile.getInternalState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE);
+            if (snowPile.getAboveState() != null && level.isEmptyBlock(above))
+            {
+                level.setBlock(above, snowPile.getAboveState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE);
+            }
 
-                // Update neighbors shapes from the bottom block (this is important to get grass blocks to adjust to snowy/non-snowy states)
-                pile.getInternalState().updateNeighbourShapes(level, pos, Block.UPDATE_CLIENTS);
-                level.getBlockState(above).updateNeighbourShapes(level, above, Block.UPDATE_CLIENTS);
+            // Update neighbors shapes from the bottom block (this is important to get grass blocks to adjust to snowy/non-snowy states)
+            snowPile.getInternalState().updateNeighbourShapes(level, pos, Block.UPDATE_CLIENTS);
+            level.getBlockState(above).updateNeighbourShapes(level, above, Block.UPDATE_CLIENTS);
 
-                // Block ticks after both blocks are placed
-                level.blockUpdated(pos, pile.getInternalState().getBlock());
-                if (pile.getAboveState() != null)
-                {
-                    level.blockUpdated(above, pile.getAboveState().getBlock());
-                }
-            });
+            // Block ticks after both blocks are placed
+            level.blockUpdated(pos, snowPile.getInternalState().getBlock());
+            if (snowPile.getAboveState() != null)
+            {
+                level.blockUpdated(above, snowPile.getAboveState().getBlock());
+            }
         }
     }
 
@@ -144,7 +140,8 @@ public class SnowPileBlock extends SnowLayerBlock implements IForgeBlockExtensio
     @Override
     public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid)
     {
-        final Optional<PileBlockEntity> snowPile = level.getBlockEntity(pos, TFCBlockEntities.PILE.get()); // Store the blockentity before it is removed
+        @Nullable final PileBlockEntity snowPile =
+            level.getBlockEntity(pos, TFCBlockEntities.PILE.get()).orElse(null); // Store the blockentity before it is removed
         super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
         removePileOrSnow(level, pos, state, snowPile);
         return true; // Cause drops and other stuff to occur

--- a/src/main/java/net/dries007/tfc/common/blocks/SnowPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/SnowPileBlock.java
@@ -146,11 +146,7 @@ public class SnowPileBlock extends SnowLayerBlock implements IForgeBlockExtensio
     {
         final Optional<PileBlockEntity> snowPile = level.getBlockEntity(pos, TFCBlockEntities.PILE.get()); // Store the blockentity before it is removed
         super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
-
-        if (!level.isClientSide())
-        {
-            removePileOrSnow(level, pos, state, snowPile);
-        }
+        removePileOrSnow(level, pos, state, snowPile);
         return true; // Cause drops and other stuff to occur
     }
 

--- a/src/main/java/net/dries007/tfc/common/blocks/SnowPileBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/SnowPileBlock.java
@@ -6,6 +6,7 @@
 
 package net.dries007.tfc.common.blocks;
 
+import java.util.Optional;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.player.Player;
@@ -21,6 +22,7 @@ import net.minecraft.world.level.material.FluidState;
 import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.TFCTags;
+import net.dries007.tfc.common.blockentities.PileBlockEntity;
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.util.Helpers;
 
@@ -72,25 +74,20 @@ public class SnowPileBlock extends SnowLayerBlock implements IForgeBlockExtensio
 
     public static void removePileOrSnow(LevelAccessor level, BlockPos pos, BlockState state)
     {
-        removePileOrSnow(level, pos, state, -1);
+        removePileOrSnow(level, pos, state, Optional.empty());
     }
 
-
     /**
-     * @param expectedLayers The expected number of snow layers. -1 = no expectation, just remove a single layer. 0 = remove all snow layers.
+     * @param snowPile If {@code null}, then there is no provided block entity and one should be queried from the world. If not-null, this
+     *                 represents the block entity present in the world, possibly empty.
      */
-    public static void removePileOrSnow(LevelAccessor level, BlockPos pos, BlockState state, int expectedLayers)
+    public static void removePileOrSnow(LevelAccessor level, BlockPos pos, BlockState state, @Nullable Optional<PileBlockEntity> snowPile)
     {
         final int layers = state.getValue(SnowLayerBlock.LAYERS);
-        if (expectedLayers >= layers)
-        {
-            // If we expect more layers than actually exist, don't remove anything
-            return;
-        }
-        if (layers > 1 && expectedLayers != 0)
+        if (layers > 1)
         {
             // Remove layers, but keep the snow block intact
-            level.setBlock(pos, state.setValue(SnowLayerBlock.LAYERS, expectedLayers == -1 ? layers - 1 : expectedLayers), Block.UPDATE_ALL);
+            level.setBlock(pos, state.setValue(SnowLayerBlock.LAYERS, layers - 1), Block.UPDATE_ALL);
         }
         else if (state.getBlock() == Blocks.SNOW)
         {
@@ -100,27 +97,25 @@ public class SnowPileBlock extends SnowLayerBlock implements IForgeBlockExtensio
         else
         {
             // Otherwise, remove a snow pile, restoring the internal states
-            level.getBlockEntity(pos, TFCBlockEntities.PILE.get()).ifPresent(pile -> {
-                if (!level.isClientSide())
+            if (snowPile == null) snowPile = level.getBlockEntity(pos, TFCBlockEntities.PILE.get());
+            snowPile.ifPresent(pile -> {
+                final BlockPos above = pos.above();
+
+                level.setBlock(pos, pile.getInternalState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE);
+                if (pile.getAboveState() != null && level.isEmptyBlock(above))
                 {
-                    final BlockPos above = pos.above();
+                    level.setBlock(above, pile.getAboveState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE);
+                }
 
-                    level.setBlock(pos, pile.getInternalState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE);
-                    if (pile.getAboveState() != null && level.isEmptyBlock(above))
-                    {
-                        level.setBlock(above, pile.getAboveState(), Block.UPDATE_CLIENTS | Block.UPDATE_KNOWN_SHAPE);
-                    }
+                // Update neighbors shapes from the bottom block (this is important to get grass blocks to adjust to snowy/non-snowy states)
+                pile.getInternalState().updateNeighbourShapes(level, pos, Block.UPDATE_CLIENTS);
+                level.getBlockState(above).updateNeighbourShapes(level, above, Block.UPDATE_CLIENTS);
 
-                    // Update neighbors shapes from the bottom block (this is important to get grass blocks to adjust to snowy/non-snowy states)
-                    pile.getInternalState().updateNeighbourShapes(level, pos, Block.UPDATE_CLIENTS);
-                    level.getBlockState(above).updateNeighbourShapes(level, above, Block.UPDATE_CLIENTS);
-
-                    // Block ticks after both blocks are placed
-                    level.blockUpdated(pos, pile.getInternalState().getBlock());
-                    if (pile.getAboveState() != null)
-                    {
-                        level.blockUpdated(above, pile.getAboveState().getBlock());
-                    }
+                // Block ticks after both blocks are placed
+                level.blockUpdated(pos, pile.getInternalState().getBlock());
+                if (pile.getAboveState() != null)
+                {
+                    level.blockUpdated(above, pile.getAboveState().getBlock());
                 }
             });
         }
@@ -149,8 +144,13 @@ public class SnowPileBlock extends SnowLayerBlock implements IForgeBlockExtensio
     @Override
     public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid)
     {
-        playerWillDestroy(level, pos, state, player);
-        removePileOrSnow(level, pos, state);
+        final Optional<PileBlockEntity> snowPile = level.getBlockEntity(pos, TFCBlockEntities.PILE.get()); // Store the blockentity before it is removed
+        super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
+
+        if (!level.isClientSide())
+        {
+            removePileOrSnow(level, pos, state, snowPile);
+        }
         return true; // Cause drops and other stuff to occur
     }
 

--- a/src/main/java/net/dries007/tfc/mixin/SnowLayerBlockMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/SnowLayerBlockMixin.java
@@ -48,13 +48,12 @@ public abstract class SnowLayerBlockMixin extends Block
     @Override
     public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid)
     {
-        playerWillDestroy(level, pos, state, player);
         final int prevLayers = state.getValue(SnowLayerBlock.LAYERS);
         if (prevLayers > 1 && !player.isCreative())
         {
-            return level.setBlock(pos, state.setValue(SnowLayerBlock.LAYERS, prevLayers - 1), level.isClientSide ? 11 : 3);
+            return level.setBlock(pos, state.setValue(SnowLayerBlock.LAYERS, prevLayers - 1), level.isClientSide() ? 11 : 3);
         }
-        return level.setBlock(pos, fluid.createLegacyBlock(), level.isClientSide ? 11 : 3);
+        return super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
     }
 
     @Inject(method = "canSurvive", at = @At(value = "RETURN"), cancellable = true)

--- a/src/main/java/net/dries007/tfc/mixin/client/MinecraftMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/client/MinecraftMixin.java
@@ -35,6 +35,10 @@ public abstract class MinecraftMixin
     @Shadow @Nullable
     public MultiPlayerGameMode gameMode;
 
+    /**
+     * Prevents the client from trying to instantly break the same block twice in a tick. This would cause
+     * issues with blocks that turn into another block when broken, such as snow piles and charcoal piles.
+     */
     @ModifyExpressionValue(method = "startAttack", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/state/BlockState;isAir()Z", ordinal = 1))
     private boolean startAttackPreventDoubleBreaking(boolean original)
     {

--- a/src/main/java/net/dries007/tfc/mixin/client/MinecraftMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/client/MinecraftMixin.java
@@ -7,10 +7,16 @@
 package net.dries007.tfc.mixin.client;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 
 import net.dries007.tfc.util.SelfTests;
 
@@ -24,5 +30,14 @@ public abstract class MinecraftMixin
     private void runSelfTests(CallbackInfo ci)
     {
         SelfTests.runClientSelfTests();
+    }
+
+    @Shadow @Nullable
+    public MultiPlayerGameMode gameMode;
+
+    @ModifyExpressionValue(method = "startAttack", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/state/BlockState;isAir()Z", ordinal = 1))
+    private boolean startAttackPreventDoubleBreaking(boolean original)
+    {
+        return original || !this.gameMode.isDestroying();
     }
 }


### PR DESCRIPTION
Issue #2759 popped back up in 1.21, meaning snow pile breaking didn't work properly. I found that it affects not just snow piles but also vanilla snow, and charcoal pile breaking. You can replicate this in the 1.20 or 1.21 versions of the mod, instantly mining charcoal piles often mines 2 layers due to a bug in the vanilla game where the same block can be instabroken twice in the same tick. 
This PR fixes the vanilla bug that caused the issues, and cleans up the charcoal pile and snow pile code to go with it.

this took days I'm losing my marbles