### PR TITLE
(1.21) Fix TFC damage types dealing knockback

### DIFF
--- a/src/data/java/net/dries007/tfc/data/DataEntryPoint.java
+++ b/src/data/java/net/dries007/tfc/data/DataEntryPoint.java
@@ -17,6 +17,7 @@ import net.minecraft.data.DataProvider;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.TagsProvider;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.tags.PaintingVariantTags;
 import net.minecraft.tags.TagKey;
 import net.minecraft.tags.WorldPresetTags;
@@ -25,7 +26,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.common.data.DatapackBuiltinEntriesProvider;
 import net.neoforged.neoforge.data.event.GatherDataEvent;
-
+import net.dries007.tfc.common.TFCDamageTypes;
 import net.dries007.tfc.data.providers.BuiltinBlockTags;
 import net.dries007.tfc.data.providers.BuiltinClimateRanges;
 import net.dries007.tfc.data.providers.BuiltinDamageTypes;
@@ -92,6 +93,13 @@ public final class DataEntryPoint
             BuiltinPaintings.VOLCANO
         ));
         tags(event, Registries.DAMAGE_TYPE, lookup, (provider, tags) -> {
+            tags.tag(DamageTypeTags.NO_KNOCKBACK).add(
+                TFCDamageTypes.CORAL,
+                TFCDamageTypes.DEHYDRATION,
+                TFCDamageTypes.GRILL,
+                TFCDamageTypes.PLUCK,
+                TFCDamageTypes.POT
+            );
             tags.tag(PhysicalDamageType.IS_CRUSHING).add(
                 DamageTypes.IN_WALL,
                 DamageTypes.CRAMMING,

--- a/src/generated/resources/data/minecraft/tags/damage_type/no_knockback.json
+++ b/src/generated/resources/data/minecraft/tags/damage_type/no_knockback.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "tfc:coral",
+    "tfc:dehydration",
+    "tfc:grill",
+    "tfc:pluck",
+    "tfc:pot"
+  ]
+}


### PR DESCRIPTION
All of TFC's custom damage types are intended not to deal knockback, but they're not added to the no_knockback damage type tag. This adds them to the tag, so things like dehydration and standing on a grill don't deal knockback.