### PR TITLE
(1.21) Add mixin to Biome.getPrecipitationAt() for mod compatibility

### DIFF
--- a/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
@@ -51,6 +51,8 @@ public abstract class BiomeMixin implements BiomeBridge
      * We only do this on the client, where we can get the client level.
      * This is safe to do even for levels that use biome based precipitation, because
      * {@link WeatherHelpers#getPrecipitationAt(Level, BlockPos, Biome.Precipitation)} checks for us what type of climate the level uses.
+     * 
+     * TFC doesn't currently directly use this, but it's needed for mod compatability.
      */
     @OnlyIn(Dist.CLIENT)
     @ModifyReturnValue(method = "getPrecipitationAt", at = @At("RETURN"))

--- a/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
@@ -46,7 +46,11 @@ public abstract class BiomeMixin implements BiomeBridge
 
 
     /**
-     * 
+     * Replace {@link Biome#getPrecipitationAt(BlockPos)} with a method that takes our climate model into account
+     * <p>
+     * We only do this on the client, where we can get the client level.
+     * This is safe to do even for levels that use biome based precipitation, because
+     * {@link WeatherHelpers#getPrecipitationAt(Level, BlockPos, Biome.Precipitation)} checks for us what type of climate the level uses.
      */
     @OnlyIn(Dist.CLIENT)
     @ModifyReturnValue(method = "getPrecipitationAt", at = @At("RETURN"))

--- a/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
@@ -6,17 +6,14 @@
 
 package net.dries007.tfc.mixin;
 
-import java.util.Optional;
-import java.util.function.Supplier;
-
+import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.CommonLevelAccessor;
-import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.biome.Biome;
-
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import net.dries007.tfc.common.component.CachedMut;
-import net.dries007.tfc.util.climate.Climate;
+import net.dries007.tfc.util.tracker.WeatherHelpers;
 import net.dries007.tfc.world.biome.BiomeBridge;
 import net.dries007.tfc.world.biome.BiomeExtension;
 import net.dries007.tfc.world.biome.TFCBiomes;
@@ -26,7 +23,9 @@ import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 
 @Mixin(Biome.class)
 public abstract class BiomeMixin implements BiomeBridge
@@ -43,5 +42,16 @@ public abstract class BiomeMixin implements BiomeBridge
             tfc$cachedExtension.load(TFCBiomes.findExtension(level, (Biome) (Object) this));
         }
         return tfc$cachedExtension.value();
+    }
+
+
+    /**
+     * 
+     */
+    @OnlyIn(Dist.CLIENT)
+    @ModifyReturnValue(method = "getPrecipitationAt", at = @At("RETURN"))
+    private Biome.Precipitation getPrecipitaitionFromClimate(Biome.Precipitation original, @Local BlockPos pos)
+    {
+        return WeatherHelpers.getPrecipitationAt(Minecraft.getInstance().level, pos, original);
     }
 }


### PR DESCRIPTION
This modifies the return value of `Biome.getPrecipitationAt()` so other mods (such as Particle Rain) can figure out if it is raining or snowing. Issue #2992 doesn't happen here, because `WeatherHelpers.getPrecipitationAt()` already checks if the level has a climate based precipitation model.

I couldn't find any mixins that would be able to be removed after adding this. The only candidate I found was the mixin to `isRainingAt()` in `LevelMixin`, but that runs both the client and server side while the mixin I add here only runs on the client side.

I don't think there are any good alternatives to using `@OnlyIn`, because the mixin doesn't have access to a generic level to call `.isClientSide()` on, and the class exists on both the server and client.