### PR TITLE
(1.21) Fix server-only nutrition logic getting called from client

### DIFF
--- a/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
+++ b/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
@@ -75,7 +75,7 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
     private ChiselMode chiselMode = ChiselMode.SMOOTH.value();
     private NutritionData nutrition = new NutritionData(0.5f, 0f); // Nutrition information
 
-    private boolean modified = false;
+    private boolean modified = true;
 
     public PlayerInfo(Player player)
     {
@@ -206,7 +206,10 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
         addThirst(food.water());
         addIntoxication(food.intoxication());
 
-        nutrition.addNutrients(food);
+        if (!player.level().isClientSide)
+        {
+            nutrition.addNutrients(food);
+        }
 
         if (player instanceof ServerPlayer serverPlayer && nutrition.getAverageNutrition() >= 0.999)
         {
@@ -424,11 +427,19 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
         return food.getSaturationLevel();
     }
 
+    /**
+     * This method gets called from both the
+     * client and the server, but the nutrition
+     * logic must only be called from the server
+     */
     @Override
     public void setFoodLevel(int foodLevel)
     {
-        modified = true;
-        nutrition.setHunger(foodLevel);
+        if (!this.player.level().isClientSide)
+        {
+            modified = true;
+            nutrition.setHunger(foodLevel);
+        }
         food.setFoodLevel(foodLevel);
     }
 


### PR DESCRIPTION
Title, + marked the PlayerInfo as 'changed' by default so the client gets the proper nutrition information on joining a world.
Fixes #3007 