### PR TITLE
(1.20) Fix bird behavior with full nestboxes

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/NestBoxBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/NestBoxBlockEntity.java
@@ -6,6 +6,10 @@
 
 package net.dries007.tfc.common.blockentities;
 
+import java.util.Optional;
+
+import net.dries007.tfc.util.events.AnimalProductEvent;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
@@ -17,6 +21,7 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.items.ItemStackHandler;
 
 import net.dries007.tfc.common.capabilities.PartialItemHandler;
@@ -28,6 +33,7 @@ import net.dries007.tfc.common.entities.livestock.OviparousAnimal;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.calendar.Calendars;
+
 import org.jetbrains.annotations.Nullable;
 
 import static net.dries007.tfc.TerraFirmaCraft.MOD_ID;
@@ -46,13 +52,25 @@ public class NestBoxBlockEntity extends TickableInventoryBlockEntity<ItemStackHa
                 {
                     if (bird.getRandom().nextInt(7) == 0)
                     {
-                        Helpers.playSound(level, pos, SoundEvents.CHICKEN_EGG);
-                        if (Helpers.insertOne(level, pos, TFCBlockEntities.NEST_BOX.get(), bird.makeEgg()))
+                        final AnimalProductEvent event = bird.makeEggEvent();
+
+                        if (!MinecraftForge.EVENT_BUS.post(event))
                         {
-                            bird.setFertilized(false);
-                            bird.setProductsCooldown();
-                            bird.stopRiding();
-                            nest.markForSync();
+                            if (Helpers.insertOne(Optional.of(nest), event.getProduct()))
+                            {
+                                Helpers.playSound(level, pos, SoundEvents.CHICKEN_EGG);
+
+                                bird.addUses(event.getUses());
+                                bird.setFertilized(false);
+                                bird.setProductsCooldown();
+                                bird.stopRiding();
+                                nest.markForSync();
+                            }
+                            else
+                            {
+                                // the nest box is full, leave it be
+                                bird.stopRiding();
+                            }
                         }
                     }
                 }

--- a/src/main/java/net/dries007/tfc/common/blockentities/NestBoxBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/NestBoxBlockEntity.java
@@ -8,6 +8,7 @@ package net.dries007.tfc.common.blockentities;
 
 import java.util.Optional;
 
+import net.dries007.tfc.common.blocks.devices.NestBoxBlock;
 import net.dries007.tfc.util.events.AnimalProductEvent;
 
 import net.minecraft.core.BlockPos;
@@ -48,7 +49,7 @@ public class NestBoxBlockEntity extends TickableInventoryBlockEntity<ItemStackHa
             Entity sitter = Seat.getSittingEntity(level, pos);
             if (sitter instanceof OviparousAnimal bird)
             {
-                if (bird.isReadyForAnimalProduct())
+                if (bird.isReadyForAnimalProduct() && !nest.isFull())
                 {
                     if (bird.getRandom().nextInt(7) == 0)
                     {
@@ -124,8 +125,15 @@ public class NestBoxBlockEntity extends TickableInventoryBlockEntity<ItemStackHa
     @Override
     public void setAndUpdateSlots(int slot)
     {
+        assert level != null;
+
         super.setAndUpdateSlots(slot);
         markForSync();
+
+        // update blockstate for birds to not pathfinds towards full nestboxes
+        BlockPos pos = this.getBlockPos();
+        BlockState newBlockState = level.getBlockState(pos).setValue(NestBoxBlock.FULL, isFull());
+        this.level.setBlockAndUpdate(pos, newBlockState);
     }
 
     @Nullable
@@ -133,5 +141,10 @@ public class NestBoxBlockEntity extends TickableInventoryBlockEntity<ItemStackHa
     public AbstractContainerMenu createMenu(int windowID, Inventory inv, Player player)
     {
         return NestBoxContainer.create(this, inv, windowID);
+    }
+
+    private boolean isFull()
+    {
+        return Helpers.isFull(inventory);
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/TFCBlockStateProperties.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/TFCBlockStateProperties.java
@@ -117,6 +117,8 @@ public class TFCBlockStateProperties
     public static final EnumProperty<Flow> FLOW = EnumProperty.create("flow", Flow.class);
     public static final BooleanProperty MIRROR = BooleanProperty.create("mirror");
 
+    public static final BooleanProperty FULL = BooleanProperty.create("full");
+
     private static final IntegerProperty[] STAGES = {STAGE_1, STAGE_2, STAGE_3, STAGE_4, STAGE_5, STAGE_6, STAGE_7, STAGE_8, STAGE_9, STAGE_10, STAGE_11, STAGE_12};
     private static final IntegerProperty[] AGES = {AGE_1, AGE_2, AGE_3, AGE_4, AGE_5, AGE_6, AGE_7, AGE_8};
 

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/NestBoxBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/NestBoxBlock.java
@@ -6,6 +6,8 @@
 
 package net.dries007.tfc.common.blocks.devices;
 
+import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
@@ -13,7 +15,10 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
@@ -24,11 +29,15 @@ import net.dries007.tfc.util.Helpers;
 
 public class NestBoxBlock extends BottomSupportedDeviceBlock
 {
+    public static final BooleanProperty FULL = TFCBlockStateProperties.FULL;
+
     private static final VoxelShape SHAPE = box(2, 0, 2, 14, 5, 14);
 
     public NestBoxBlock(ExtendedProperties properties)
     {
         super(properties, InventoryRemoveBehavior.DROP, SHAPE);
+
+        this.registerDefaultState(stateDefinition.any().setValue(FULL, false));
     }
 
     @Override
@@ -55,5 +64,11 @@ public class NestBoxBlock extends BottomSupportedDeviceBlock
         {
             sitter.stopRiding();
         }
+    }
+
+    @Override
+    protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder)
+    {
+        super.createBlockStateDefinition(builder.add(FULL));
     }
 }

--- a/src/main/java/net/dries007/tfc/common/entities/ai/TFCBrain.java
+++ b/src/main/java/net/dries007/tfc/common/entities/ai/TFCBrain.java
@@ -9,8 +9,12 @@ package net.dries007.tfc.common.entities.ai;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
+
+import net.dries007.tfc.common.blocks.devices.NestBoxBlock;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.GlobalPos;
 import net.minecraft.core.registries.Registries;
@@ -62,7 +66,14 @@ public class TFCBrain
     public static final RegistryObject<SensorType<NearestNestBoxSensor>> NEST_BOX_SENSOR = registerSensorType("nearest_nest_box", NearestNestBoxSensor::new);
     public static final RegistryObject<SensorType<PackLeaderSensor>> PACK_LEADER_SENSOR = registerSensorType("pack_leader", PackLeaderSensor::new);
 
-    public static final RegistryObject<PoiType> NEST_BOX_POI = registerPoi("nest_box", () -> new PoiType(getBlockStates(TFCBlocks.NEST_BOX.get()), 1, 1));
+    public static final RegistryObject<PoiType> NEST_BOX_POI = registerPoi("nest_box", () -> new PoiType(
+        getBlockStates(TFCBlocks.NEST_BOX.get())
+            .stream()
+            // do not pathfind towards full nest boxes
+            .filter(blockState -> !blockState.getValue(NestBoxBlock.FULL))
+            .collect(Collectors.toUnmodifiableSet()),
+        1, 1)
+    );
 
     private static Set<BlockState> getBlockStates(Block block)
     {

--- a/src/main/java/net/dries007/tfc/common/entities/livestock/OviparousAnimal.java
+++ b/src/main/java/net/dries007/tfc/common/entities/livestock/OviparousAnimal.java
@@ -221,8 +221,23 @@ public abstract class OviparousAnimal extends ProducingAnimal implements Pluckab
         return false;
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * @deprecated This method will unconditionally add uses to the animal, even if there is no space for the egg.
+     * Use {@link #makeEggEvent()} instead, and add the uses in the api caller.
+     */
+    @Deprecated
     public ItemStack makeEgg()
+    {
+        final AnimalProductEvent event = makeEggEvent();
+        if (!MinecraftForge.EVENT_BUS.post(event))
+        {
+            addUses(event.getUses());
+        }
+        return event.getProduct();
+    }
+
+    @SuppressWarnings("unchecked")
+    public AnimalProductEvent makeEggEvent()
     {
         final ItemStack stack = new ItemStack(Items.EGG);
         if (isFertilized())
@@ -240,12 +255,7 @@ public abstract class OviparousAnimal extends ProducingAnimal implements Pluckab
                 }
             }
         }
-        AnimalProductEvent event = new AnimalProductEvent(level(), blockPosition(), null, this, stack, ItemStack.EMPTY, 1);
-        if (!MinecraftForge.EVENT_BUS.post(event))
-        {
-            addUses(event.getUses());
-        }
-        return event.getProduct();
+        return new AnimalProductEvent(level(), blockPosition(), null, this, stack, ItemStack.EMPTY, 1);
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/util/Helpers.java
+++ b/src/main/java/net/dries007/tfc/util/Helpers.java
@@ -920,6 +920,21 @@ public final class Helpers
     }
 
     /**
+     * @return {@code true} if every slot in the provided inventory is full.
+     */
+    public static boolean isFull(IItemHandler inventory)
+    {
+        for (int i = 0; i < inventory.getSlots(); i++)
+        {
+            if (inventory.getStackInSlot(i).getCount() < inventory.getSlotLimit(i))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
      * Attempts to spread fire, in a half dome of max {@code radius}. Larger radii check more blocks.
      */
     public static void fireSpreaderTick(ServerLevel level, BlockPos pos, RandomSource random, int radius)


### PR DESCRIPTION
Currently, if a nest box is full, a duck will repeatedly try and fail to lay an egg there, wasting wear & tear.

This PR improves the behavior in two ways:
1. Stops increasing wear & tear when an egg fails to be laid into a full nestbox
2. Prevents ducks from pathfinding to full nestboxes, so they would rarely even try to lay eggs into full nestboxes.

To implement 2, I added a boolean blockstate property `full` that allows to filter for non-full nestboxes in `NearestNestBoxSensor` without looking up the corresponding block entity.

I think that merging 1 is very important to fix and is quite simple. 2 is nice to have, but not 100% necessary, as not doing it will only slow down breeding, but not lead to birds tearing themselves apart.