### PR TITLE
(1.21) Fix crash with bookshelves

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/BookshelfBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/BookshelfBlockEntity.java
@@ -7,6 +7,7 @@
 package net.dries007.tfc.common.blockentities;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.ChiseledBookShelfBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -16,5 +17,11 @@ public class BookshelfBlockEntity extends ChiseledBookShelfBlockEntity
     public BookshelfBlockEntity(BlockPos pos, BlockState state)
     {
         super(pos, state);
+    }
+
+    @Override
+    public BlockEntityType<?> getType()
+    {
+        return TFCBlockEntities.BOOKSHELF.get();
     }
 }


### PR DESCRIPTION
Bookshelves are missing an override that tells the BlockEntity.isValid() check what block entity type to use, causing a game crash upon placing a bookshelf. I copied the override from TFC signs (another blockentity that extends a vanilla blockentity without changes) and this fixes the crash.