### PR TITLE
(1.21) Misc bugfixes

### DIFF
--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemSizes.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemSizes.java
@@ -94,7 +94,8 @@ public class BuiltinItemSizes extends DataManagerProvider<ItemSizeDefinition> im
             Ingredient.of(TFCTags.Items.TOOLS_KNIFE),
             Ingredient.of(Tags.Items.TOOLS_SHEAR),
             Ingredient.of(TFCTags.Items.TOOLS_GLASSWORKING),
-            Ingredient.of(TFCTags.Items.TOOLS_BLOWPIPE)
+            Ingredient.of(TFCTags.Items.TOOLS_BLOWPIPE),
+            Ingredient.of(TFCItems.FIRESTARTER.get())
         ), Size.LARGE, Weight.MEDIUM);
         add("tools", ingredientOf(
             Ingredient.of(Tags.Items.TOOLS_FISHING_ROD),

--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
@@ -308,6 +308,24 @@ public class BuiltinItemTags extends TagsProvider<Item> implements Accessors
             .add(TFCItems.MOLDS)
             .add(TFCItems.FIRE_INGOT_MOLD)
             .add(TFCItems.BELL_MOLD);
+        tag(FLUXSTONE)
+            .add(TFCItems.FOOD.get(Food.SHELLFISH))
+            .add(TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MOLLUSK))
+            .add(TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.CLAM))
+            .add(TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MUSSEL))
+            .add(TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.SEA_URCHIN))
+            .add(Items.TURTLE_SCUTE)
+            .add(Items.ARMADILLO_SCUTE)
+            .add(TFCBlocks.ROCK_BLOCKS.get(Rock.LIMESTONE).get(Rock.BlockType.LOOSE))
+            .add(TFCBlocks.ROCK_BLOCKS.get(Rock.LIMESTONE).get(Rock.BlockType.MOSSY_LOOSE))
+            .add(TFCBlocks.ROCK_BLOCKS.get(Rock.DOLOMITE).get(Rock.BlockType.LOOSE))
+            .add(TFCBlocks.ROCK_BLOCKS.get(Rock.DOLOMITE).get(Rock.BlockType.MOSSY_LOOSE))
+            .add(TFCBlocks.ROCK_BLOCKS.get(Rock.CHALK).get(Rock.BlockType.LOOSE))
+            .add(TFCBlocks.ROCK_BLOCKS.get(Rock.CHALK).get(Rock.BlockType.MOSSY_LOOSE))
+            .add(TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.LOOSE))
+            .add(TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.MOSSY_LOOSE))
+            .add(TFCBlocks.PLANTS.get(Plant.MUSSELS).get())
+            .add(TFCBlocks.PLANTS.get(Plant.BARNACLES).get());
 
         // Vanilla Tool Tags
         tag(ItemTags.SWORDS).add(TFCItems.METAL_ITEMS, Metal.ItemType.SWORD);

--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
@@ -393,7 +393,7 @@ public class BuiltinItemTags extends TagsProvider<Item> implements Accessors
         tag(GLASS_BATCHES_NOT_T1).add(TFCItems.HEMATITIC_GLASS_BATCH, TFCItems.OLIVINE_GLASS_BATCH, TFCItems.VOLCANIC_GLASS_BATCH);
         tag(GLASS_BLOWPIPES).add(TFCItems.BLOWPIPE_WITH_GLASS, TFCItems.CERAMIC_BLOWPIPE_WITH_GLASS);
         tag(BLOWPIPES).addTags(TOOLS_BLOWPIPE, GLASS_BLOWPIPES);
-        tag(GLASS_POWDERS).add(GlassOperation.POWDERS.get().keySet().stream());
+        tag(GLASS_POWDERS).add(GlassOperation.POWDERS.get().keySet().stream().sorted()); // Sorted to make generation deterministic
         tag(GLASS_BOTTLES).add(
             TFCItems.SILICA_GLASS_BOTTLE,
             TFCItems.HEMATITIC_GLASS_BOTTLE,

--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
@@ -7,6 +7,7 @@
 package net.dries007.tfc.data.providers;
 
 import java.lang.reflect.Field;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -393,7 +394,7 @@ public class BuiltinItemTags extends TagsProvider<Item> implements Accessors
         tag(GLASS_BATCHES_NOT_T1).add(TFCItems.HEMATITIC_GLASS_BATCH, TFCItems.OLIVINE_GLASS_BATCH, TFCItems.VOLCANIC_GLASS_BATCH);
         tag(GLASS_BLOWPIPES).add(TFCItems.BLOWPIPE_WITH_GLASS, TFCItems.CERAMIC_BLOWPIPE_WITH_GLASS);
         tag(BLOWPIPES).addTags(TOOLS_BLOWPIPE, GLASS_BLOWPIPES);
-        tag(GLASS_POWDERS).add(GlassOperation.POWDERS.get().keySet().stream().sorted()); // Sorted to make generation deterministic
+        tag(GLASS_POWDERS).add(GlassOperation.POWDERS.get().keySet().stream().sorted(Comparator.comparing(item -> Item.getId(item)))); // Sorted to make generation deterministic
         tag(GLASS_BOTTLES).add(
             TFCItems.SILICA_GLASS_BOTTLE,
             TFCItems.HEMATITIC_GLASS_BOTTLE,

--- a/src/data/java/net/dries007/tfc/data/recipes/BarrelRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/BarrelRecipes.java
@@ -22,7 +22,6 @@ import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.NeoForgeMod;
 import net.neoforged.neoforge.common.Tags;
-import net.neoforged.neoforge.common.crafting.CompoundIngredient;
 import net.neoforged.neoforge.common.crafting.SizedIngredient;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
@@ -277,7 +276,8 @@ public interface BarrelRecipes extends Recipes
         barrel("clean_jute_net")
             .input(TFCItems.DIRTY_JUTE_NET)
             .input(Fluids.WATER, 100)
-            .output(TFCItems.JUTE_NET);
+            .output(TFCItems.JUTE_NET)
+            .instant();
 
         // Instant Fluid Mixing
         barrel()

--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -926,7 +926,7 @@ public interface CraftingRecipes extends Recipes
             .shaped(TFCBlocks.FIRE_BRICK_SHELF, 4);
         recipe().useTool(TFCTags.Items.TOOLS_KNIFE, Items.BONE, TFCItems.BONE_NEEDLE);
         recipe().bricksWithMortar(Items.BRICK, Items.BRICKS, 4);
-        replace("cake")
+        recipe()
             .input('M', FluidContentIngredient.of(Fluids.WATER, 100))
             .input('S', TFCTags.Items.SWEETENERS)
             .input('E', notRotten(Ingredient.of(Items.EGG)))
@@ -1265,8 +1265,8 @@ public interface CraftingRecipes extends Recipes
 
         for (int n = 1; n <= 8; n++)
             recipe("" + n)
-                .input(notRotten(flour), n)
                 .input(FluidContentIngredient.of(Fluids.WATER, 100))
+                .input(notRotten(flour), n)
                 .copyOldestFood()
                 .shapeless(TFCItems.FOOD.get(dough), n);
     }

--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -1013,8 +1013,9 @@ public interface CraftingRecipes extends Recipes
             .pattern(" XX", " XX", "X  ")
             .shaped(Items.LEAD);
         recipe()
+            .inputIsPrimary(TFCTags.Items.TOOLS_KNIFE)
             .input(notRotten(Ingredient.of(TFCBlocks.MELON)))
-            .input(TFCTags.Items.TOOLS_KNIFE)
+            .damageInputs()
             .shapeless(TFCItems.FOOD.get(Food.MELON_SLICE), 4);
         recipe()
             .input('L', TFCTags.Items.LUMBER)

--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -1170,25 +1170,7 @@ public interface CraftingRecipes extends Recipes
             .shapeless(TFCItems.CACTUS_WOOD);
         recipe().useTool(
             TFCTags.Items.TOOLS_HAMMER,
-            Ingredient.of(
-                TFCItems.FOOD.get(Food.SHELLFISH),
-                TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MOLLUSK),
-                TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.CLAM),
-                TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MUSSEL),
-                TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.SEA_URCHIN),
-                Items.TURTLE_SCUTE,
-                Items.ARMADILLO_SCUTE,
-                TFCBlocks.ROCK_BLOCKS.get(Rock.LIMESTONE).get(Rock.BlockType.LOOSE),
-                TFCBlocks.ROCK_BLOCKS.get(Rock.LIMESTONE).get(Rock.BlockType.MOSSY_LOOSE),
-                TFCBlocks.ROCK_BLOCKS.get(Rock.DOLOMITE).get(Rock.BlockType.LOOSE),
-                TFCBlocks.ROCK_BLOCKS.get(Rock.DOLOMITE).get(Rock.BlockType.MOSSY_LOOSE),
-                TFCBlocks.ROCK_BLOCKS.get(Rock.CHALK).get(Rock.BlockType.LOOSE),
-                TFCBlocks.ROCK_BLOCKS.get(Rock.CHALK).get(Rock.BlockType.MOSSY_LOOSE),
-                TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.LOOSE),
-                TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.MOSSY_LOOSE),
-                TFCBlocks.PLANTS.get(Plant.MUSSELS).get(),
-                TFCBlocks.PLANTS.get(Plant.BARNACLES).get()
-            ),
+            Ingredient.of(TFCTags.Items.FLUXSTONE),
             TFCItems.POWDERS.get(Powder.FLUX), 2
         );
     }

--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -1167,9 +1167,9 @@ public interface CraftingRecipes extends Recipes
         recipe()
             .input(TFCBlocks.PLANTS.get(Plant.BARREL_CACTUS))
             .shapeless(TFCItems.CACTUS_WOOD);
-        recipe()
-            .inputIsPrimary(TFCTags.Items.TOOLS_HAMMER)
-            .input(Ingredient.of(
+        recipe().useTool(
+            TFCTags.Items.TOOLS_HAMMER,
+            Ingredient.of(
                 TFCItems.FOOD.get(Food.SHELLFISH),
                 TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MOLLUSK),
                 TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.CLAM),
@@ -1187,9 +1187,9 @@ public interface CraftingRecipes extends Recipes
                 TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.MOSSY_LOOSE),
                 TFCBlocks.PLANTS.get(Plant.MUSSELS).get(),
                 TFCBlocks.PLANTS.get(Plant.BARNACLES).get()
-            ))
-            .damageInputs()
-            .shapeless(TFCItems.POWDERS.get(Powder.FLUX), 2);
+            ),
+            TFCItems.POWDERS.get(Powder.FLUX), 2
+        );
     }
 
     /**
@@ -1353,6 +1353,11 @@ public interface CraftingRecipes extends Recipes
         void useTool(TagKey<Item> tool, ItemLike input, ItemLike output)
         {
             input(input).inputIsPrimary(tool).damageInputs().shapeless(output);
+        }
+
+        void useTool(TagKey<Item> tool, Ingredient input, ItemLike output, int count)
+        {
+            input(input).inputIsPrimary(tool).damageInputs().shapeless(output, count);
         }
 
         void bricksWithMortar(ItemLike brick, ItemLike bricks, int count)

--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -1289,7 +1289,7 @@ public interface CraftingRecipes extends Recipes
 
         for (int n = 1; n <= 8; n++)
             recipe("" + n)
-                .input(FluidContentIngredient.of(Fluids.WATER, 100))
+                .inputIsPrimary(FluidContentIngredient.of(Fluids.WATER, 100))
                 .input(notRotten(flour), n)
                 .copyOldestFood()
                 .shapeless(TFCItems.FOOD.get(dough), n);

--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -112,7 +112,6 @@ public interface CraftingRecipes extends Recipes
             "leather_horse_armor",
             "leather_leggings",
             "lectern",
-            "loom",
             "melon",
             "melon_seeds",
             "mojang_banner_pattern",

--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -932,7 +932,7 @@ public interface CraftingRecipes extends Recipes
             .input('E', notRotten(Ingredient.of(Items.EGG)))
             .input('F', TFCTags.Items.FLOUR)
             .pattern(" M ", "SES", "FFF")
-            .shaped(Items.CAKE);
+            .shaped(TFCBlocks.CAKE);
         recipe()
             .input('L', TFCTags.Items.LUMBER)
             .input('D', ItemTags.DIRT)

--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -1167,6 +1167,29 @@ public interface CraftingRecipes extends Recipes
         recipe()
             .input(TFCBlocks.PLANTS.get(Plant.BARREL_CACTUS))
             .shapeless(TFCItems.CACTUS_WOOD);
+        recipe()
+            .inputIsPrimary(TFCTags.Items.TOOLS_HAMMER)
+            .input(Ingredient.of(
+                TFCItems.FOOD.get(Food.SHELLFISH),
+                TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MOLLUSK),
+                TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.CLAM),
+                TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MUSSEL),
+                TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.SEA_URCHIN),
+                Items.TURTLE_SCUTE,
+                Items.ARMADILLO_SCUTE,
+                TFCBlocks.ROCK_BLOCKS.get(Rock.LIMESTONE).get(Rock.BlockType.LOOSE),
+                TFCBlocks.ROCK_BLOCKS.get(Rock.LIMESTONE).get(Rock.BlockType.MOSSY_LOOSE),
+                TFCBlocks.ROCK_BLOCKS.get(Rock.DOLOMITE).get(Rock.BlockType.LOOSE),
+                TFCBlocks.ROCK_BLOCKS.get(Rock.DOLOMITE).get(Rock.BlockType.MOSSY_LOOSE),
+                TFCBlocks.ROCK_BLOCKS.get(Rock.CHALK).get(Rock.BlockType.LOOSE),
+                TFCBlocks.ROCK_BLOCKS.get(Rock.CHALK).get(Rock.BlockType.MOSSY_LOOSE),
+                TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.LOOSE),
+                TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.MOSSY_LOOSE),
+                TFCBlocks.PLANTS.get(Plant.MUSSELS).get(),
+                TFCBlocks.PLANTS.get(Plant.BARNACLES).get()
+            ))
+            .damageInputs()
+            .shapeless(TFCItems.POWDERS.get(Powder.FLUX), 2);
     }
 
     /**

--- a/src/data/java/net/dries007/tfc/data/recipes/QuernRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/QuernRecipes.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.ItemLike;
-
+import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.GroundcoverBlockType;
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.common.blocks.plant.Plant;
@@ -31,25 +31,7 @@ public interface QuernRecipes extends Recipes
     default void quernRecipes()
     {
         add(notRotten(TFCItems.FOOD.get(Food.OLIVE)), TFCItems.OLIVE_PASTE, 2);
-        add(Ingredient.of(
-            TFCItems.FOOD.get(Food.SHELLFISH),
-            TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MOLLUSK),
-            TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.CLAM),
-            TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.MUSSEL),
-            TFCBlocks.GROUNDCOVER.get(GroundcoverBlockType.SEA_URCHIN),
-            Items.TURTLE_SCUTE,
-            Items.ARMADILLO_SCUTE,
-            TFCBlocks.ROCK_BLOCKS.get(Rock.LIMESTONE).get(Rock.BlockType.LOOSE),
-            TFCBlocks.ROCK_BLOCKS.get(Rock.LIMESTONE).get(Rock.BlockType.MOSSY_LOOSE),
-            TFCBlocks.ROCK_BLOCKS.get(Rock.DOLOMITE).get(Rock.BlockType.LOOSE),
-            TFCBlocks.ROCK_BLOCKS.get(Rock.DOLOMITE).get(Rock.BlockType.MOSSY_LOOSE),
-            TFCBlocks.ROCK_BLOCKS.get(Rock.CHALK).get(Rock.BlockType.LOOSE),
-            TFCBlocks.ROCK_BLOCKS.get(Rock.CHALK).get(Rock.BlockType.MOSSY_LOOSE),
-            TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.LOOSE),
-            TFCBlocks.ROCK_BLOCKS.get(Rock.MARBLE).get(Rock.BlockType.MOSSY_LOOSE),
-            TFCBlocks.PLANTS.get(Plant.MUSSELS).get(),
-            TFCBlocks.PLANTS.get(Plant.BARNACLES).get()
-        ), TFCItems.POWDERS.get(Powder.FLUX), 2);
+        add(Ingredient.of(TFCTags.Items.FLUXSTONE), TFCItems.POWDERS.get(Powder.FLUX), 2);
         add("from_borax", TFCItems.ORES.get(Ore.BORAX), TFCItems.POWDERS.get(Powder.FLUX), 6);
         add(Ingredient.of(
             TFCItems.ORES.get(Ore.CINNABAR),

--- a/src/generated/resources/data/minecraft/recipe/loom.json
+++ b/src/generated/resources/data/minecraft/recipe/loom.json
@@ -1,7 +1,0 @@
-{
-  "neoforge:conditions": [
-    {
-      "type": "neoforge:false"
-    }
-  ]
-}

--- a/src/generated/resources/data/tfc/recipe/barrel/clean_jute_net.json
+++ b/src/generated/resources/data/tfc/recipe/barrel/clean_jute_net.json
@@ -1,0 +1,15 @@
+{
+  "type": "tfc:barrel_instant",
+  "input_fluid": {
+    "amount": 100,
+    "fluid": "minecraft:water"
+  },
+  "input_item": {
+    "count": 1,
+    "item": "tfc:dirty_jute_net"
+  },
+  "output_item": {
+    "count": 1,
+    "id": "tfc:jute_net"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/cake.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/cake.json
@@ -34,6 +34,6 @@
   ],
   "result": {
     "count": 1,
-    "id": "minecraft:cake"
+    "id": "tfc:cake"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_1.json
@@ -1,6 +1,14 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
+    {
+      "type": "tfc:fluid_content",
+      "fluid": {
+        "amount": 100,
+        "fluid": "minecraft:water"
+      }
+    },
     {
       "type": "tfc:and",
       "children": [
@@ -11,24 +19,10 @@
           "type": "tfc:not_rotten"
         }
       ]
-    },
-    {
-      "type": "tfc:fluid_content",
-      "fluid": {
-        "amount": 100,
-        "fluid": "minecraft:water"
-      }
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 1,
-      "id": "tfc:food/barley_dough"
-    }
+    "count": 1,
+    "id": "tfc:food/barley_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_1.json
@@ -20,6 +20,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_1.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -22,7 +21,14 @@
     }
   ],
   "result": {
-    "count": 1,
-    "id": "tfc:food/barley_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 1,
+      "id": "tfc:food/barley_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_2.json
@@ -1,45 +1,39 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 2,
-      "id": "tfc:food/barley_dough"
-    }
+    "count": 2,
+    "id": "tfc:food/barley_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_2.json
@@ -31,6 +31,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_2.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -33,7 +32,14 @@
     }
   ],
   "result": {
-    "count": 2,
-    "id": "tfc:food/barley_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 2,
+      "id": "tfc:food/barley_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_3.json
@@ -1,56 +1,50 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 3,
-      "id": "tfc:food/barley_dough"
-    }
+    "count": 3,
+    "id": "tfc:food/barley_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_3.json
@@ -42,6 +42,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_3.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -44,7 +43,14 @@
     }
   ],
   "result": {
-    "count": 3,
-    "id": "tfc:food/barley_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 3,
+      "id": "tfc:food/barley_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_4.json
@@ -1,67 +1,61 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 4,
-      "id": "tfc:food/barley_dough"
-    }
+    "count": 4,
+    "id": "tfc:food/barley_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_4.json
@@ -53,6 +53,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_4.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -55,7 +54,14 @@
     }
   ],
   "result": {
-    "count": 4,
-    "id": "tfc:food/barley_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 4,
+      "id": "tfc:food/barley_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_5.json
@@ -1,78 +1,72 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 5,
-      "id": "tfc:food/barley_dough"
-    }
+    "count": 5,
+    "id": "tfc:food/barley_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_5.json
@@ -64,6 +64,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_5.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -66,7 +65,14 @@
     }
   ],
   "result": {
-    "count": 5,
-    "id": "tfc:food/barley_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 5,
+      "id": "tfc:food/barley_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_6.json
@@ -1,89 +1,83 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 6,
-      "id": "tfc:food/barley_dough"
-    }
+    "count": 6,
+    "id": "tfc:food/barley_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_6.json
@@ -75,6 +75,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_6.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -77,7 +76,14 @@
     }
   ],
   "result": {
-    "count": 6,
-    "id": "tfc:food/barley_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 6,
+      "id": "tfc:food/barley_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_7.json
@@ -1,100 +1,94 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 7,
-      "id": "tfc:food/barley_dough"
-    }
+    "count": 7,
+    "id": "tfc:food/barley_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_7.json
@@ -86,6 +86,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_7.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -88,7 +87,14 @@
     }
   ],
   "result": {
-    "count": 7,
-    "id": "tfc:food/barley_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 7,
+      "id": "tfc:food/barley_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_8.json
@@ -1,111 +1,105 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/barley_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/barley_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 8,
-      "id": "tfc:food/barley_dough"
-    }
+    "count": 8,
+    "id": "tfc:food/barley_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_8.json
@@ -97,6 +97,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/barley_dough_8.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -99,7 +98,14 @@
     }
   ],
   "result": {
-    "count": 8,
-    "id": "tfc:food/barley_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 8,
+      "id": "tfc:food/barley_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_1.json
@@ -1,6 +1,14 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
+    {
+      "type": "tfc:fluid_content",
+      "fluid": {
+        "amount": 100,
+        "fluid": "minecraft:water"
+      }
+    },
     {
       "type": "tfc:and",
       "children": [
@@ -11,24 +19,10 @@
           "type": "tfc:not_rotten"
         }
       ]
-    },
-    {
-      "type": "tfc:fluid_content",
-      "fluid": {
-        "amount": 100,
-        "fluid": "minecraft:water"
-      }
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 1,
-      "id": "tfc:food/maize_dough"
-    }
+    "count": 1,
+    "id": "tfc:food/maize_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_1.json
@@ -20,6 +20,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_1.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -22,7 +21,14 @@
     }
   ],
   "result": {
-    "count": 1,
-    "id": "tfc:food/maize_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 1,
+      "id": "tfc:food/maize_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_2.json
@@ -1,45 +1,39 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 2,
-      "id": "tfc:food/maize_dough"
-    }
+    "count": 2,
+    "id": "tfc:food/maize_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_2.json
@@ -31,6 +31,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_2.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -33,7 +32,14 @@
     }
   ],
   "result": {
-    "count": 2,
-    "id": "tfc:food/maize_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 2,
+      "id": "tfc:food/maize_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_3.json
@@ -1,56 +1,50 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 3,
-      "id": "tfc:food/maize_dough"
-    }
+    "count": 3,
+    "id": "tfc:food/maize_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_3.json
@@ -42,6 +42,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_3.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -44,7 +43,14 @@
     }
   ],
   "result": {
-    "count": 3,
-    "id": "tfc:food/maize_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 3,
+      "id": "tfc:food/maize_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_4.json
@@ -1,67 +1,61 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 4,
-      "id": "tfc:food/maize_dough"
-    }
+    "count": 4,
+    "id": "tfc:food/maize_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_4.json
@@ -53,6 +53,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_4.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -55,7 +54,14 @@
     }
   ],
   "result": {
-    "count": 4,
-    "id": "tfc:food/maize_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 4,
+      "id": "tfc:food/maize_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_5.json
@@ -1,78 +1,72 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 5,
-      "id": "tfc:food/maize_dough"
-    }
+    "count": 5,
+    "id": "tfc:food/maize_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_5.json
@@ -64,6 +64,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_5.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -66,7 +65,14 @@
     }
   ],
   "result": {
-    "count": 5,
-    "id": "tfc:food/maize_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 5,
+      "id": "tfc:food/maize_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_6.json
@@ -1,89 +1,83 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 6,
-      "id": "tfc:food/maize_dough"
-    }
+    "count": 6,
+    "id": "tfc:food/maize_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_6.json
@@ -75,6 +75,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_6.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -77,7 +76,14 @@
     }
   ],
   "result": {
-    "count": 6,
-    "id": "tfc:food/maize_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 6,
+      "id": "tfc:food/maize_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_7.json
@@ -1,100 +1,94 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 7,
-      "id": "tfc:food/maize_dough"
-    }
+    "count": 7,
+    "id": "tfc:food/maize_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_7.json
@@ -86,6 +86,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_7.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -88,7 +87,14 @@
     }
   ],
   "result": {
-    "count": 7,
-    "id": "tfc:food/maize_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 7,
+      "id": "tfc:food/maize_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_8.json
@@ -1,111 +1,105 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/maize_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/maize_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 8,
-      "id": "tfc:food/maize_dough"
-    }
+    "count": 8,
+    "id": "tfc:food/maize_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_8.json
@@ -97,6 +97,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/maize_dough_8.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -99,7 +98,14 @@
     }
   ],
   "result": {
-    "count": 8,
-    "id": "tfc:food/maize_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 8,
+      "id": "tfc:food/maize_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/melon_slice.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/melon_slice.json
@@ -1,7 +1,9 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
+    {
+      "tag": "c:tools/knife"
+    },
     {
       "type": "tfc:and",
       "children": [
@@ -12,11 +14,18 @@
           "type": "tfc:not_rotten"
         }
       ]
-    },
-    {
-      "tag": "c:tools/knife"
     }
   ],
+  "primary_ingredient": {
+    "tag": "c:tools/knife"
+  },
+  "remainder": {
+    "modifiers": [
+      {
+        "type": "tfc:damage_crafting_remainder"
+      }
+    ]
+  },
   "result": {
     "count": 4,
     "id": "tfc:food/melon_slice"

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_1.json
@@ -1,6 +1,14 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
+    {
+      "type": "tfc:fluid_content",
+      "fluid": {
+        "amount": 100,
+        "fluid": "minecraft:water"
+      }
+    },
     {
       "type": "tfc:and",
       "children": [
@@ -11,24 +19,10 @@
           "type": "tfc:not_rotten"
         }
       ]
-    },
-    {
-      "type": "tfc:fluid_content",
-      "fluid": {
-        "amount": 100,
-        "fluid": "minecraft:water"
-      }
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 1,
-      "id": "tfc:food/oat_dough"
-    }
+    "count": 1,
+    "id": "tfc:food/oat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_1.json
@@ -20,6 +20,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_1.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -22,7 +21,14 @@
     }
   ],
   "result": {
-    "count": 1,
-    "id": "tfc:food/oat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 1,
+      "id": "tfc:food/oat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_2.json
@@ -1,45 +1,39 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 2,
-      "id": "tfc:food/oat_dough"
-    }
+    "count": 2,
+    "id": "tfc:food/oat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_2.json
@@ -31,6 +31,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_2.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -33,7 +32,14 @@
     }
   ],
   "result": {
-    "count": 2,
-    "id": "tfc:food/oat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 2,
+      "id": "tfc:food/oat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_3.json
@@ -1,56 +1,50 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 3,
-      "id": "tfc:food/oat_dough"
-    }
+    "count": 3,
+    "id": "tfc:food/oat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_3.json
@@ -42,6 +42,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_3.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -44,7 +43,14 @@
     }
   ],
   "result": {
-    "count": 3,
-    "id": "tfc:food/oat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 3,
+      "id": "tfc:food/oat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_4.json
@@ -1,67 +1,61 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 4,
-      "id": "tfc:food/oat_dough"
-    }
+    "count": 4,
+    "id": "tfc:food/oat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_4.json
@@ -53,6 +53,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_4.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -55,7 +54,14 @@
     }
   ],
   "result": {
-    "count": 4,
-    "id": "tfc:food/oat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 4,
+      "id": "tfc:food/oat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_5.json
@@ -1,78 +1,72 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 5,
-      "id": "tfc:food/oat_dough"
-    }
+    "count": 5,
+    "id": "tfc:food/oat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_5.json
@@ -64,6 +64,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_5.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -66,7 +65,14 @@
     }
   ],
   "result": {
-    "count": 5,
-    "id": "tfc:food/oat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 5,
+      "id": "tfc:food/oat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_6.json
@@ -1,89 +1,83 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 6,
-      "id": "tfc:food/oat_dough"
-    }
+    "count": 6,
+    "id": "tfc:food/oat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_6.json
@@ -75,6 +75,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_6.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -77,7 +76,14 @@
     }
   ],
   "result": {
-    "count": 6,
-    "id": "tfc:food/oat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 6,
+      "id": "tfc:food/oat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_7.json
@@ -1,100 +1,94 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 7,
-      "id": "tfc:food/oat_dough"
-    }
+    "count": 7,
+    "id": "tfc:food/oat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_7.json
@@ -86,6 +86,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_7.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -88,7 +87,14 @@
     }
   ],
   "result": {
-    "count": 7,
-    "id": "tfc:food/oat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 7,
+      "id": "tfc:food/oat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_8.json
@@ -1,111 +1,105 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/oat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/oat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 8,
-      "id": "tfc:food/oat_dough"
-    }
+    "count": 8,
+    "id": "tfc:food/oat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_8.json
@@ -97,6 +97,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/oat_dough_8.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -99,7 +98,14 @@
     }
   ],
   "result": {
-    "count": 8,
-    "id": "tfc:food/oat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 8,
+      "id": "tfc:food/oat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_1.json
@@ -1,6 +1,14 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
+    {
+      "type": "tfc:fluid_content",
+      "fluid": {
+        "amount": 100,
+        "fluid": "minecraft:water"
+      }
+    },
     {
       "type": "tfc:and",
       "children": [
@@ -11,24 +19,10 @@
           "type": "tfc:not_rotten"
         }
       ]
-    },
-    {
-      "type": "tfc:fluid_content",
-      "fluid": {
-        "amount": 100,
-        "fluid": "minecraft:water"
-      }
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 1,
-      "id": "tfc:food/rice_dough"
-    }
+    "count": 1,
+    "id": "tfc:food/rice_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_1.json
@@ -20,6 +20,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_1.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -22,7 +21,14 @@
     }
   ],
   "result": {
-    "count": 1,
-    "id": "tfc:food/rice_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 1,
+      "id": "tfc:food/rice_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_2.json
@@ -1,45 +1,39 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 2,
-      "id": "tfc:food/rice_dough"
-    }
+    "count": 2,
+    "id": "tfc:food/rice_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_2.json
@@ -31,6 +31,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_2.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -33,7 +32,14 @@
     }
   ],
   "result": {
-    "count": 2,
-    "id": "tfc:food/rice_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 2,
+      "id": "tfc:food/rice_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_3.json
@@ -1,56 +1,50 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 3,
-      "id": "tfc:food/rice_dough"
-    }
+    "count": 3,
+    "id": "tfc:food/rice_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_3.json
@@ -42,6 +42,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_3.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -44,7 +43,14 @@
     }
   ],
   "result": {
-    "count": 3,
-    "id": "tfc:food/rice_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 3,
+      "id": "tfc:food/rice_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_4.json
@@ -1,67 +1,61 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 4,
-      "id": "tfc:food/rice_dough"
-    }
+    "count": 4,
+    "id": "tfc:food/rice_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_4.json
@@ -53,6 +53,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_4.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -55,7 +54,14 @@
     }
   ],
   "result": {
-    "count": 4,
-    "id": "tfc:food/rice_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 4,
+      "id": "tfc:food/rice_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_5.json
@@ -1,78 +1,72 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 5,
-      "id": "tfc:food/rice_dough"
-    }
+    "count": 5,
+    "id": "tfc:food/rice_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_5.json
@@ -64,6 +64,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_5.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -66,7 +65,14 @@
     }
   ],
   "result": {
-    "count": 5,
-    "id": "tfc:food/rice_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 5,
+      "id": "tfc:food/rice_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_6.json
@@ -1,89 +1,83 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 6,
-      "id": "tfc:food/rice_dough"
-    }
+    "count": 6,
+    "id": "tfc:food/rice_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_6.json
@@ -75,6 +75,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_6.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -77,7 +76,14 @@
     }
   ],
   "result": {
-    "count": 6,
-    "id": "tfc:food/rice_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 6,
+      "id": "tfc:food/rice_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_7.json
@@ -1,100 +1,94 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 7,
-      "id": "tfc:food/rice_dough"
-    }
+    "count": 7,
+    "id": "tfc:food/rice_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_7.json
@@ -86,6 +86,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_7.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -88,7 +87,14 @@
     }
   ],
   "result": {
-    "count": 7,
-    "id": "tfc:food/rice_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 7,
+      "id": "tfc:food/rice_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_8.json
@@ -1,111 +1,105 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rice_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rice_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 8,
-      "id": "tfc:food/rice_dough"
-    }
+    "count": 8,
+    "id": "tfc:food/rice_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_8.json
@@ -97,6 +97,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rice_dough_8.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -99,7 +98,14 @@
     }
   ],
   "result": {
-    "count": 8,
-    "id": "tfc:food/rice_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 8,
+      "id": "tfc:food/rice_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_1.json
@@ -1,6 +1,14 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
+    {
+      "type": "tfc:fluid_content",
+      "fluid": {
+        "amount": 100,
+        "fluid": "minecraft:water"
+      }
+    },
     {
       "type": "tfc:and",
       "children": [
@@ -11,24 +19,10 @@
           "type": "tfc:not_rotten"
         }
       ]
-    },
-    {
-      "type": "tfc:fluid_content",
-      "fluid": {
-        "amount": 100,
-        "fluid": "minecraft:water"
-      }
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 1,
-      "id": "tfc:food/rye_dough"
-    }
+    "count": 1,
+    "id": "tfc:food/rye_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_1.json
@@ -20,6 +20,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_1.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -22,7 +21,14 @@
     }
   ],
   "result": {
-    "count": 1,
-    "id": "tfc:food/rye_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 1,
+      "id": "tfc:food/rye_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_2.json
@@ -1,45 +1,39 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 2,
-      "id": "tfc:food/rye_dough"
-    }
+    "count": 2,
+    "id": "tfc:food/rye_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_2.json
@@ -31,6 +31,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_2.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -33,7 +32,14 @@
     }
   ],
   "result": {
-    "count": 2,
-    "id": "tfc:food/rye_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 2,
+      "id": "tfc:food/rye_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_3.json
@@ -1,56 +1,50 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 3,
-      "id": "tfc:food/rye_dough"
-    }
+    "count": 3,
+    "id": "tfc:food/rye_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_3.json
@@ -42,6 +42,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_3.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -44,7 +43,14 @@
     }
   ],
   "result": {
-    "count": 3,
-    "id": "tfc:food/rye_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 3,
+      "id": "tfc:food/rye_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_4.json
@@ -1,67 +1,61 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 4,
-      "id": "tfc:food/rye_dough"
-    }
+    "count": 4,
+    "id": "tfc:food/rye_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_4.json
@@ -53,6 +53,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_4.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -55,7 +54,14 @@
     }
   ],
   "result": {
-    "count": 4,
-    "id": "tfc:food/rye_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 4,
+      "id": "tfc:food/rye_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_5.json
@@ -1,78 +1,72 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 5,
-      "id": "tfc:food/rye_dough"
-    }
+    "count": 5,
+    "id": "tfc:food/rye_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_5.json
@@ -64,6 +64,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_5.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -66,7 +65,14 @@
     }
   ],
   "result": {
-    "count": 5,
-    "id": "tfc:food/rye_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 5,
+      "id": "tfc:food/rye_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_6.json
@@ -1,89 +1,83 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 6,
-      "id": "tfc:food/rye_dough"
-    }
+    "count": 6,
+    "id": "tfc:food/rye_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_6.json
@@ -75,6 +75,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_6.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -77,7 +76,14 @@
     }
   ],
   "result": {
-    "count": 6,
-    "id": "tfc:food/rye_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 6,
+      "id": "tfc:food/rye_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_7.json
@@ -1,100 +1,94 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 7,
-      "id": "tfc:food/rye_dough"
-    }
+    "count": 7,
+    "id": "tfc:food/rye_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_7.json
@@ -86,6 +86,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_7.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -88,7 +87,14 @@
     }
   ],
   "result": {
-    "count": 7,
-    "id": "tfc:food/rye_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 7,
+      "id": "tfc:food/rye_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_8.json
@@ -1,111 +1,105 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/rye_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/rye_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 8,
-      "id": "tfc:food/rye_dough"
-    }
+    "count": 8,
+    "id": "tfc:food/rye_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_8.json
@@ -97,6 +97,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/rye_dough_8.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -99,7 +98,14 @@
     }
   ],
   "result": {
-    "count": 8,
-    "id": "tfc:food/rye_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 8,
+      "id": "tfc:food/rye_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_1.json
@@ -1,6 +1,14 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
+    {
+      "type": "tfc:fluid_content",
+      "fluid": {
+        "amount": 100,
+        "fluid": "minecraft:water"
+      }
+    },
     {
       "type": "tfc:and",
       "children": [
@@ -11,24 +19,10 @@
           "type": "tfc:not_rotten"
         }
       ]
-    },
-    {
-      "type": "tfc:fluid_content",
-      "fluid": {
-        "amount": 100,
-        "fluid": "minecraft:water"
-      }
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 1,
-      "id": "tfc:food/wheat_dough"
-    }
+    "count": 1,
+    "id": "tfc:food/wheat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_1.json
@@ -20,6 +20,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_1.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_1.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -22,7 +21,14 @@
     }
   ],
   "result": {
-    "count": 1,
-    "id": "tfc:food/wheat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 1,
+      "id": "tfc:food/wheat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_2.json
@@ -1,45 +1,39 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 2,
-      "id": "tfc:food/wheat_dough"
-    }
+    "count": 2,
+    "id": "tfc:food/wheat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_2.json
@@ -31,6 +31,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_2.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_2.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -33,7 +32,14 @@
     }
   ],
   "result": {
-    "count": 2,
-    "id": "tfc:food/wheat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 2,
+      "id": "tfc:food/wheat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_3.json
@@ -1,56 +1,50 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 3,
-      "id": "tfc:food/wheat_dough"
-    }
+    "count": 3,
+    "id": "tfc:food/wheat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_3.json
@@ -42,6 +42,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_3.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_3.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -44,7 +43,14 @@
     }
   ],
   "result": {
-    "count": 3,
-    "id": "tfc:food/wheat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 3,
+      "id": "tfc:food/wheat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_4.json
@@ -1,67 +1,61 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 4,
-      "id": "tfc:food/wheat_dough"
-    }
+    "count": 4,
+    "id": "tfc:food/wheat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_4.json
@@ -53,6 +53,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_4.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_4.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -55,7 +54,14 @@
     }
   ],
   "result": {
-    "count": 4,
-    "id": "tfc:food/wheat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 4,
+      "id": "tfc:food/wheat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_5.json
@@ -1,78 +1,72 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 5,
-      "id": "tfc:food/wheat_dough"
-    }
+    "count": 5,
+    "id": "tfc:food/wheat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_5.json
@@ -64,6 +64,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_5.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -66,7 +65,14 @@
     }
   ],
   "result": {
-    "count": 5,
-    "id": "tfc:food/wheat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 5,
+      "id": "tfc:food/wheat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_6.json
@@ -1,89 +1,83 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 6,
-      "id": "tfc:food/wheat_dough"
-    }
+    "count": 6,
+    "id": "tfc:food/wheat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_6.json
@@ -75,6 +75,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_6.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_6.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -77,7 +76,14 @@
     }
   ],
   "result": {
-    "count": 6,
-    "id": "tfc:food/wheat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 6,
+      "id": "tfc:food/wheat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_7.json
@@ -1,100 +1,94 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 7,
-      "id": "tfc:food/wheat_dough"
-    }
+    "count": 7,
+    "id": "tfc:food/wheat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_7.json
@@ -86,6 +86,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_7.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_7.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -88,7 +87,14 @@
     }
   ],
   "result": {
-    "count": 7,
-    "id": "tfc:food/wheat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 7,
+      "id": "tfc:food/wheat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_8.json
@@ -1,111 +1,105 @@
 {
-  "type": "tfc:advanced_shapeless_crafting",
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
-    {
-      "type": "tfc:and",
-      "children": [
-        {
-          "item": "tfc:food/wheat_flour"
-        },
-        {
-          "type": "tfc:not_rotten"
-        }
-      ]
-    },
     {
       "type": "tfc:fluid_content",
       "fluid": {
         "amount": 100,
         "fluid": "minecraft:water"
       }
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
+    },
+    {
+      "type": "tfc:and",
+      "children": [
+        {
+          "item": "tfc:food/wheat_flour"
+        },
+        {
+          "type": "tfc:not_rotten"
+        }
+      ]
     }
   ],
   "result": {
-    "modifiers": [
-      {
-        "type": "tfc:copy_oldest_food"
-      }
-    ],
-    "stack": {
-      "count": 8,
-      "id": "tfc:food/wheat_dough"
-    }
+    "count": 8,
+    "id": "tfc:food/wheat_dough"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_8.json
@@ -97,6 +97,13 @@
       ]
     }
   ],
+  "primary_ingredient": {
+    "type": "tfc:fluid_content",
+    "fluid": {
+      "amount": 100,
+      "fluid": "minecraft:water"
+    }
+  },
   "result": {
     "modifiers": [
       {

--- a/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_8.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/food/wheat_dough_8.json
@@ -1,6 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "category": "misc",
+  "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
     {
       "type": "tfc:fluid_content",
@@ -99,7 +98,14 @@
     }
   ],
   "result": {
-    "count": 8,
-    "id": "tfc:food/wheat_dough"
+    "modifiers": [
+      {
+        "type": "tfc:copy_oldest_food"
+      }
+    ],
+    "stack": {
+      "count": 8,
+      "id": "tfc:food/wheat_dough"
+    }
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/powder/flux.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/powder/flux.json
@@ -1,9 +1,6 @@
 {
   "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
-    {
-      "tag": "c:tools/hammer"
-    },
     [
       {
         "item": "tfc:food/shellfish"
@@ -56,7 +53,10 @@
       {
         "item": "tfc:plant/barnacles"
       }
-    ]
+    ],
+    {
+      "tag": "c:tools/hammer"
+    }
   ],
   "primary_ingredient": {
     "tag": "c:tools/hammer"

--- a/src/generated/resources/data/tfc/recipe/crafting/powder/flux.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/powder/flux.json
@@ -1,59 +1,9 @@
 {
   "type": "tfc:advanced_shapeless_crafting",
   "ingredients": [
-    [
-      {
-        "item": "tfc:food/shellfish"
-      },
-      {
-        "item": "tfc:groundcover/mollusk"
-      },
-      {
-        "item": "tfc:groundcover/clam"
-      },
-      {
-        "item": "tfc:groundcover/mussel"
-      },
-      {
-        "item": "tfc:groundcover/sea_urchin"
-      },
-      {
-        "item": "minecraft:turtle_scute"
-      },
-      {
-        "item": "minecraft:armadillo_scute"
-      },
-      {
-        "item": "tfc:rock/loose/limestone"
-      },
-      {
-        "item": "tfc:rock/mossy_loose/limestone"
-      },
-      {
-        "item": "tfc:rock/loose/dolomite"
-      },
-      {
-        "item": "tfc:rock/mossy_loose/dolomite"
-      },
-      {
-        "item": "tfc:rock/loose/chalk"
-      },
-      {
-        "item": "tfc:rock/mossy_loose/chalk"
-      },
-      {
-        "item": "tfc:rock/loose/marble"
-      },
-      {
-        "item": "tfc:rock/mossy_loose/marble"
-      },
-      {
-        "item": "tfc:plant/mussels"
-      },
-      {
-        "item": "tfc:plant/barnacles"
-      }
-    ],
+    {
+      "tag": "tfc:fluxstone"
+    },
     {
       "tag": "c:tools/hammer"
     }

--- a/src/generated/resources/data/tfc/recipe/crafting/powder/flux.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/powder/flux.json
@@ -1,0 +1,75 @@
+{
+  "type": "tfc:advanced_shapeless_crafting",
+  "ingredients": [
+    {
+      "tag": "c:tools/hammer"
+    },
+    [
+      {
+        "item": "tfc:food/shellfish"
+      },
+      {
+        "item": "tfc:groundcover/mollusk"
+      },
+      {
+        "item": "tfc:groundcover/clam"
+      },
+      {
+        "item": "tfc:groundcover/mussel"
+      },
+      {
+        "item": "tfc:groundcover/sea_urchin"
+      },
+      {
+        "item": "minecraft:turtle_scute"
+      },
+      {
+        "item": "minecraft:armadillo_scute"
+      },
+      {
+        "item": "tfc:rock/loose/limestone"
+      },
+      {
+        "item": "tfc:rock/mossy_loose/limestone"
+      },
+      {
+        "item": "tfc:rock/loose/dolomite"
+      },
+      {
+        "item": "tfc:rock/mossy_loose/dolomite"
+      },
+      {
+        "item": "tfc:rock/loose/chalk"
+      },
+      {
+        "item": "tfc:rock/mossy_loose/chalk"
+      },
+      {
+        "item": "tfc:rock/loose/marble"
+      },
+      {
+        "item": "tfc:rock/mossy_loose/marble"
+      },
+      {
+        "item": "tfc:plant/mussels"
+      },
+      {
+        "item": "tfc:plant/barnacles"
+      }
+    ]
+  ],
+  "primary_ingredient": {
+    "tag": "c:tools/hammer"
+  },
+  "remainder": {
+    "modifiers": [
+      {
+        "type": "tfc:damage_crafting_remainder"
+      }
+    ]
+  },
+  "result": {
+    "count": 2,
+    "id": "tfc:powder/flux"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/quern/powder/flux.json
+++ b/src/generated/resources/data/tfc/recipe/quern/powder/flux.json
@@ -1,58 +1,8 @@
 {
   "type": "tfc:quern",
-  "ingredient": [
-    {
-      "item": "tfc:food/shellfish"
-    },
-    {
-      "item": "tfc:groundcover/mollusk"
-    },
-    {
-      "item": "tfc:groundcover/clam"
-    },
-    {
-      "item": "tfc:groundcover/mussel"
-    },
-    {
-      "item": "tfc:groundcover/sea_urchin"
-    },
-    {
-      "item": "minecraft:turtle_scute"
-    },
-    {
-      "item": "minecraft:armadillo_scute"
-    },
-    {
-      "item": "tfc:rock/loose/limestone"
-    },
-    {
-      "item": "tfc:rock/mossy_loose/limestone"
-    },
-    {
-      "item": "tfc:rock/loose/dolomite"
-    },
-    {
-      "item": "tfc:rock/mossy_loose/dolomite"
-    },
-    {
-      "item": "tfc:rock/loose/chalk"
-    },
-    {
-      "item": "tfc:rock/mossy_loose/chalk"
-    },
-    {
-      "item": "tfc:rock/loose/marble"
-    },
-    {
-      "item": "tfc:rock/mossy_loose/marble"
-    },
-    {
-      "item": "tfc:plant/mussels"
-    },
-    {
-      "item": "tfc:plant/barnacles"
-    }
-  ],
+  "ingredient": {
+    "tag": "tfc:fluxstone"
+  },
   "result": {
     "count": 2,
     "id": "tfc:powder/flux"

--- a/src/generated/resources/data/tfc/tags/item/fluxstone.json
+++ b/src/generated/resources/data/tfc/tags/item/fluxstone.json
@@ -1,0 +1,21 @@
+{
+  "values": [
+    "tfc:food/shellfish",
+    "tfc:groundcover/mollusk",
+    "tfc:groundcover/clam",
+    "tfc:groundcover/mussel",
+    "tfc:groundcover/sea_urchin",
+    "minecraft:turtle_scute",
+    "minecraft:armadillo_scute",
+    "tfc:rock/loose/limestone",
+    "tfc:rock/mossy_loose/limestone",
+    "tfc:rock/loose/dolomite",
+    "tfc:rock/mossy_loose/dolomite",
+    "tfc:rock/loose/chalk",
+    "tfc:rock/mossy_loose/chalk",
+    "tfc:rock/loose/marble",
+    "tfc:rock/mossy_loose/marble",
+    "tfc:plant/mussels",
+    "tfc:plant/barnacles"
+  ]
+}

--- a/src/generated/resources/data/tfc/tags/item/glass_powders.json
+++ b/src/generated/resources/data/tfc/tags/item/glass_powders.json
@@ -1,22 +1,22 @@
 {
   "values": [
-    "tfc:powder/malachite",
-    "tfc:powder/cassiterite",
-    "tfc:powder/soda_ash",
-    "tfc:powder/hematite",
-    "tfc:powder/limonite",
-    "tfc:powder/tetrahedrite",
-    "tfc:powder/native_copper",
-    "tfc:powder/native_silver",
-    "tfc:powder/sulfur",
-    "tfc:powder/amethyst",
-    "tfc:powder/magnetite",
-    "tfc:powder/lapis_lazuli",
-    "tfc:powder/ruby",
-    "tfc:powder/sapphire",
-    "tfc:powder/native_gold",
     "tfc:powder/graphite",
+    "tfc:powder/native_copper",
+    "tfc:powder/native_gold",
+    "tfc:powder/hematite",
+    "tfc:powder/native_silver",
+    "tfc:powder/amethyst",
+    "tfc:powder/malachite",
+    "tfc:powder/garnierite",
+    "tfc:powder/ruby",
+    "tfc:powder/magnetite",
+    "tfc:powder/sapphire",
+    "tfc:powder/limonite",
+    "tfc:powder/soda_ash",
+    "tfc:powder/sulfur",
     "tfc:powder/pyrite",
-    "tfc:powder/garnierite"
+    "tfc:powder/cassiterite",
+    "tfc:powder/lapis_lazuli",
+    "tfc:powder/tetrahedrite"
   ]
 }

--- a/src/generated/resources/data/tfc/tags/item/glass_powders.json
+++ b/src/generated/resources/data/tfc/tags/item/glass_powders.json
@@ -1,22 +1,22 @@
 {
   "values": [
-    "tfc:powder/graphite",
+    "tfc:powder/soda_ash",
     "tfc:powder/native_copper",
     "tfc:powder/native_gold",
     "tfc:powder/hematite",
     "tfc:powder/native_silver",
-    "tfc:powder/amethyst",
-    "tfc:powder/malachite",
-    "tfc:powder/garnierite",
-    "tfc:powder/ruby",
-    "tfc:powder/magnetite",
-    "tfc:powder/sapphire",
-    "tfc:powder/limonite",
-    "tfc:powder/soda_ash",
-    "tfc:powder/sulfur",
-    "tfc:powder/pyrite",
     "tfc:powder/cassiterite",
+    "tfc:powder/garnierite",
+    "tfc:powder/malachite",
+    "tfc:powder/magnetite",
+    "tfc:powder/limonite",
+    "tfc:powder/tetrahedrite",
+    "tfc:powder/graphite",
+    "tfc:powder/sulfur",
+    "tfc:powder/amethyst",
     "tfc:powder/lapis_lazuli",
-    "tfc:powder/tetrahedrite"
+    "tfc:powder/pyrite",
+    "tfc:powder/ruby",
+    "tfc:powder/sapphire"
   ]
 }

--- a/src/generated/resources/data/tfc/tags/item/glass_powders.json
+++ b/src/generated/resources/data/tfc/tags/item/glass_powders.json
@@ -1,22 +1,22 @@
 {
   "values": [
-    "tfc:powder/native_copper",
-    "tfc:powder/limonite",
-    "tfc:powder/pyrite",
-    "tfc:powder/graphite",
-    "tfc:powder/cassiterite",
-    "tfc:powder/ruby",
-    "tfc:powder/lapis_lazuli",
     "tfc:powder/malachite",
-    "tfc:powder/sulfur",
+    "tfc:powder/cassiterite",
+    "tfc:powder/soda_ash",
     "tfc:powder/hematite",
+    "tfc:powder/limonite",
+    "tfc:powder/tetrahedrite",
+    "tfc:powder/native_copper",
+    "tfc:powder/native_silver",
+    "tfc:powder/sulfur",
+    "tfc:powder/amethyst",
+    "tfc:powder/magnetite",
+    "tfc:powder/lapis_lazuli",
+    "tfc:powder/ruby",
     "tfc:powder/sapphire",
     "tfc:powder/native_gold",
-    "tfc:powder/tetrahedrite",
-    "tfc:powder/soda_ash",
-    "tfc:powder/garnierite",
-    "tfc:powder/magnetite",
-    "tfc:powder/native_silver",
-    "tfc:powder/amethyst"
+    "tfc:powder/graphite",
+    "tfc:powder/pyrite",
+    "tfc:powder/garnierite"
   ]
 }

--- a/src/generated/resources/data/tfc/tfc/item_size/small_tools.json
+++ b/src/generated/resources/data/tfc/tfc/item_size/small_tools.json
@@ -14,6 +14,9 @@
     },
     {
       "tag": "c:tools/blowpipe"
+    },
+    {
+      "item": "tfc:firestarter"
     }
   ],
   "size": "large",

--- a/src/main/java/net/dries007/tfc/common/TFCTags.java
+++ b/src/main/java/net/dries007/tfc/common/TFCTags.java
@@ -493,6 +493,7 @@ public class TFCTags
         /** Used by patchouli */
         public static final TagKey<Item> ORE_DEPOSITS = tag("ore_deposits");
         public static final TagKey<Item> TANNIN_LOGS = tag("tannin_logs");
+        public static final TagKey<Item> FLUXSTONE = tag("fluxstone");
 
         // Device Required Items
         public static final TagKey<Item> FIREPIT_KINDLING = tag("firepit_kindling");

--- a/src/main/java/net/dries007/tfc/common/recipes/outputs/DamageCraftingRemainderModifier.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/outputs/DamageCraftingRemainderModifier.java
@@ -23,22 +23,19 @@ public enum DamageCraftingRemainderModifier implements ItemStackModifier
     @SuppressWarnings("deprecation") // For damageItem(), but we don't have access to a level here
     public ItemStack apply(ItemStack stack, ItemStack input, Context context)
     {
-        for (ItemStack craftingStack : RecipeHelpers.getCraftingInput())
+        if (input.isDamageableItem())
         {
-            if (craftingStack.isDamageableItem())
+            final @Nullable Player player = RecipeHelpers.getCraftingPlayer();
+            if (player != null)
             {
-                final @Nullable Player player = RecipeHelpers.getCraftingPlayer();
-                if (player != null)
-                {
-                    Helpers.damageItem(craftingStack, player.level());
-                }
-                else
-                {
-                    Helpers.damageItem(craftingStack);
-                }
+                Helpers.damageItem(input, player.level());
+            }
+            else
+            {
+                Helpers.damageItem(input);
             }
         }
-        if (input.isDamageableItem() || input.has(DataComponents.UNBREAKABLE) || input.hasCraftingRemainingItem())
+        if (input.has(DataComponents.MAX_DAMAGE) && input.has(DataComponents.DAMAGE)) // stack.isDamageableItem(), without unbreakable check
         {
             return input.copy();
         }

--- a/src/test/java/net/dries007/tfc/test/item/VesselTest.java
+++ b/src/test/java/net/dries007/tfc/test/item/VesselTest.java
@@ -6,8 +6,8 @@
 
 package net.dries007.tfc.test.item;
 
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Blocks;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.common.blocks.rock.Ore;
+import net.dries007.tfc.common.blocks.rock.Rock;
 import net.dries007.tfc.common.capabilities.ItemCapabilities;
 import net.dries007.tfc.common.component.food.FoodCapability;
 import net.dries007.tfc.common.component.food.IFood;
@@ -38,44 +39,46 @@ import static net.dries007.tfc.test.TestAssertions.*;
 
 public class VesselTest implements TestSetup
 {
+    private final Item testItem = TFCBlocks.ROCK_BLOCKS.get(Rock.CHERT).get(Rock.BlockType.LOOSE).asItem();
+
     @Test
     public void testInsertAndExtractItems()
     {
         final ItemStack stack = new ItemStack(TFCItems.VESSEL);
-        final ItemStack stick5 = new ItemStack(Items.STICK, 5);
-        final ItemStack stick11 = new ItemStack(Items.STICK, 11);
-        final ItemStack stick16 = new ItemStack(Items.STICK, 16);
-        final ItemStack stick32 = new ItemStack(Items.STICK, 32);
+        final ItemStack stack5 = new ItemStack(testItem, 5);
+        final ItemStack stack11 = new ItemStack(testItem, 11);
+        final ItemStack stack16 = new ItemStack(testItem, 16);
+        final ItemStack stack32 = new ItemStack(testItem, 32);
         final Vessel vessel = Vessel.get(stack);
 
         assertNotNull(vessel);
 
-        assertEquals(ItemStack.EMPTY, vessel.insertItem(0, stick5, true)); // Simulate insert less than capacity
+        assertEquals(ItemStack.EMPTY, vessel.insertItem(0, stack5, true)); // Simulate insert less than capacity
         assertEquals(ItemStack.EMPTY, vessel.getStackInSlot(0));
 
-        assertEquals(ItemStack.EMPTY, vessel.insertItem(0, stick5, false)); // Actually insert less than capacity
-        assertEquals(stick5, vessel.getStackInSlot(0)); // The stack in slot should equal
-        assertNotSame(stick5, vessel.getStackInSlot(0)); // But they should not be the same instance (mutable guarding)
+        assertEquals(ItemStack.EMPTY, vessel.insertItem(0, stack5, false)); // Actually insert less than capacity
+        assertEquals(stack5, vessel.getStackInSlot(0)); // The stack in slot should equal
+        assertNotSame(stack5, vessel.getStackInSlot(0)); // But they should not be the same instance (mutable guarding)
 
-        assertEquals(stick5, vessel.insertItem(0, stick16, true)); // Insert over capacity (with content inside)
-        assertEquals(stick5, vessel.insertItem(0, stick16, false));
-        assertEquals(stick16, vessel.getStackInSlot(0));
-        assertNotSame(stick16, vessel.getStackInSlot(0));
+        assertEquals(stack5, vessel.insertItem(0, stack16, true)); // Insert over capacity (with content inside)
+        assertEquals(stack5, vessel.insertItem(0, stack16, false));
+        assertEquals(stack16, vessel.getStackInSlot(0));
+        assertNotSame(stack16, vessel.getStackInSlot(0));
 
-        assertEquals(stick5, vessel.extractItem(0, 5, true)); // Extract less than contained
-        assertEquals(stick5, vessel.extractItem(0, 5, false));
-        assertEquals(stick11, vessel.getStackInSlot(0));
+        assertEquals(stack5, vessel.extractItem(0, 5, true)); // Extract less than contained
+        assertEquals(stack5, vessel.extractItem(0, 5, false));
+        assertEquals(stack11, vessel.getStackInSlot(0));
 
-        assertEquals(stick11, vessel.extractItem(0, 64, true)); // Extract more than contained
-        assertEquals(stick11, vessel.extractItem(0, 64, false));
+        assertEquals(stack11, vessel.extractItem(0, 64, true)); // Extract more than contained
+        assertEquals(stack11, vessel.extractItem(0, 64, false));
         assertEquals(ItemStack.EMPTY, vessel.getStackInSlot(0));
 
-        assertEquals(stick16, vessel.insertItem(1, stick32, true)); // Insert over capacity (with empty inside)
-        assertEquals(stick16, vessel.insertItem(1, stick32, false));
-        assertEquals(stick16, vessel.getStackInSlot(1));
+        assertEquals(stack16, vessel.insertItem(1, stack32, true)); // Insert over capacity (with empty inside)
+        assertEquals(stack16, vessel.insertItem(1, stack32, false));
+        assertEquals(stack16, vessel.getStackInSlot(1));
 
-        assertEquals(stick16, vessel.extractItem(1, 16, true)); // Extract exactly equal to contained
-        assertEquals(stick16, vessel.extractItem(1, 16, false)); // Extract exactly equal to contained
+        assertEquals(stack16, vessel.extractItem(1, 16, true)); // Extract exactly equal to contained
+        assertEquals(stack16, vessel.extractItem(1, 16, false)); // Extract exactly equal to contained
         assertEquals(ItemStack.EMPTY, vessel.getStackInSlot(1));
     }
 
@@ -94,22 +97,22 @@ public class VesselTest implements TestSetup
     public void testItemHandlerLocksWhenHot()
     {
         final ItemStack stack = new ItemStack(TFCItems.VESSEL);
-        final ItemStack stick = new ItemStack(Items.STICK, 5);
+        final ItemStack stack5 = new ItemStack(testItem, 5);
         final Vessel vessel = Vessel.get(stack);
 
         assertNotNull(vessel);
 
-        vessel.insertItem(0, stick, false);
+        vessel.insertItem(0, stack5, false);
         vessel.setTemperature(10f); // The vessel is hot
 
-        assertEquals(stick, vessel.getStackInSlot(0)); // The content should still be there
+        assertEquals(stack5, vessel.getStackInSlot(0)); // The content should still be there
         assertEquals(ItemStack.EMPTY, vessel.extractItem(0, 64, true)); // But extraction is not allowed
-        assertEquals(stick, vessel.insertItem(1, stick, true)); // And neither is insertion
+        assertEquals(stack5, vessel.insertItem(1, stack5, true)); // And neither is insertion
 
         assertEquals(ItemStack.EMPTY, vessel.extractItem(0, 64, false)); // Even when not simulating
-        assertEquals(stick, vessel.insertItem(1, stick, false));
+        assertEquals(stack5, vessel.insertItem(1, stack5, false));
 
-        assertEquals(stick, vessel.getStackInSlot(0)); // The vessel should have been unmodified
+        assertEquals(stack5, vessel.getStackInSlot(0)); // The vessel should have been unmodified
         assertEquals(ItemStack.EMPTY, vessel.getStackInSlot(1));
     }
 


### PR DESCRIPTION
- Make the cake recipe give TFC cake instead of vanilla cake
- Fix dough not being craftable
- Add recipe to hammer rocks to get flux
- Fix a resource file being generated nondeterministically
- Fix recipes that damage items being very broken
- Mark firestarters as a small tool
- Fix melon recipe consuming knife
- Replace the test item used in vessel unit tests, as sticks no longer fit in vessels
- Fix unfinished clean jute net recipe
- Re-add banner loom recipe