### PR TITLE
(1.21) Fix broken barrel UI rendering

### DIFF
--- a/src/main/java/net/dries007/tfc/client/RenderHelpers.java
+++ b/src/main/java/net/dries007/tfc/client/RenderHelpers.java
@@ -650,7 +650,7 @@ public final class RenderHelpers
                 final float widthRatio = (float) actualWidth / spriteWidth;
                 final float heightRatio = (float) actualHeight / spriteHeight;
 
-                blit(stack, x + offsetX, y + offsetY, actualWidth, actualHeight, sprite.getU0(), sprite.getU(16 * widthRatio), sprite.getV0(), sprite.getV(16 * heightRatio));
+                blit(stack, x + offsetX, y + offsetY, actualWidth, actualHeight, sprite.getU0(), sprite.getU(widthRatio), sprite.getV0(), sprite.getV(heightRatio));
             }
         }
     }


### PR DESCRIPTION
Almost every usage of `RenderHelpers#fillAreaWithSprite` has broken rendering, such as barrels and other containers that render fluid textures. This fixes it, I check that every usage of `fillAreaWithSprite` works now.