### PR TITLE
(1.21) Fix BarrelBlockEntity.updateRecipe() not actually updating the recipe

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
@@ -484,6 +484,7 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
         assert level != null;
 
         final @Nullable SealedBarrelRecipe oldRecipe = RecipeHelpers.unbox(recipe.value());
+        recipe.unload();
         final @Nullable SealedBarrelRecipe newRecipe = getRecipe(); // Trigger the update
 
         if (oldRecipe != null && newRecipe != null && oldRecipe != newRecipe)


### PR DESCRIPTION
This causes barrel recipes to never finish until the world is reloaded