### PR TITLE
(1.21) Fix swing hand animation for drinking

### DIFF
--- a/src/main/java/net/dries007/tfc/ForgeEventHandler.java
+++ b/src/main/java/net/dries007/tfc/ForgeEventHandler.java
@@ -1311,9 +1311,11 @@ public final class ForgeEventHandler
         if (event.getHand() == InteractionHand.MAIN_HAND && event.getItemStack().isEmpty())
         {
             // Cannot be cancelled, only fired on client.
-            final InteractionResult result = Drinkable.attemptDrink(event.getLevel(), event.getEntity(), false);
+            Player player = event.getEntity();
+            final InteractionResult result = Drinkable.attemptDrink(event.getLevel(), player, false);
             if (result.consumesAction())
             {
+                player.swing(InteractionHand.MAIN_HAND);
                 PacketDistributor.sendToServer(PlayerDrinkPacket.PACKET);
             }
         }


### PR DESCRIPTION
The swing hand animation currently isn't shown when drinking if the player isn't looking at a block.