### PR TITLE
(1.21) Fix intoxication effects being applied to sober players

### DIFF
--- a/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
+++ b/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
@@ -114,6 +114,7 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
     @Override
     public float getIntoxication()
     {
+        if (intoxicationTick == Long.MIN_VALUE) return 0;
         return (float) Math.max(0, intoxicationTick - calendar().getTicks()) / TFCConfig.SERVER.maxIntoxicationTicks.get();
     }
 


### PR DESCRIPTION
A player who has never drank alcohol is represented by an intoxication value of `Long.MIN_VALUE`, which the intoxication logic currently doesn't have a check for.