### PR TITLE
(1.21) Add testAdvancedShapelessRecipesHavePrimaryInput

### DIFF
--- a/src/main/java/net/dries007/tfc/common/recipes/AdvancedShapelessRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/AdvancedShapelessRecipe.java
@@ -139,4 +139,10 @@ public class AdvancedShapelessRecipe extends ShapelessRecipe
     {
         return remainder;
     }
+
+    @VisibleForTesting
+    public Optional<Ingredient> getPrimaryIngredient()
+    {
+        return primaryIngredient;
+    }
 }

--- a/src/test/java/net/dries007/tfc/test/recipes/CraftingRecipesTest.java
+++ b/src/test/java/net/dries007/tfc/test/recipes/CraftingRecipesTest.java
@@ -34,7 +34,6 @@ import net.neoforged.neoforge.common.Tags;
 
 public class CraftingRecipesTest implements TestSetup
 {
-    @SuppressWarnings("unchecked")
     @Test
     public void testCraftingRecipesWithToolsDamageInputs()
     {
@@ -74,5 +73,30 @@ public class CraftingRecipesTest implements TestSetup
             .toList();
 
         assertTrue(recipes.isEmpty(), "Recipes with tools do not damage inputs: " + String.join("\n", recipes));
+    }
+
+    @Test
+    public void testAdvancedShapelessRecipesHavePrimaryInput()
+    {
+        final RecipeManager manager = Helpers.getUnsafeRecipeManager();
+
+        final List<String> recipes = manager
+            .getAllRecipesFor(RecipeType.CRAFTING)
+            .stream()
+            .filter(holder -> {
+                final CraftingRecipe recipe = holder.value();
+                if (recipe instanceof AdvancedShapelessRecipe advancedShapeless)
+                {
+                    return advancedShapeless.getPrimaryIngredient().isEmpty();
+                }
+                else
+                {
+                    return false;
+                }
+            })
+            .map(holder -> holder.id().toString())
+            .toList();
+
+        assertTrue(recipes.isEmpty(), "Advanced shapeless crafting recipes do not have primary inputs: " + String.join("\n", recipes));
     }
 }


### PR DESCRIPTION
This would have caught the broken dough recipe, and forgetting a primary ingredient is an easy mistake to make when adding recipes