### PR TITLE
(1.21) Fix crash with prickly pear blocks

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/plant/PlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/PlantBlock.java
@@ -227,7 +227,7 @@ public abstract class PlantBlock extends TFCBushBlock
     @Override
     protected void randomTick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random)
     {
-        final var ageProp = getPlant().getAgeProperty();
+        final IntegerProperty ageProp = getPlant().getAgeProperty();
         if (ageProp != null)
         {
             final int age = state.getValue(ageProp);

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/ShortGrassBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/ShortGrassBlock.java
@@ -74,7 +74,7 @@ public abstract class ShortGrassBlock extends PlantBlock implements ISpecialPile
             final BlockPos newPos = PlantRegrowth.spreadSelf(state, level, pos, random, 2, 2, 4);
             if (newPos != null)
             {
-                level.setBlockAndUpdate(newPos, state.setValue(AGE, 0));
+                level.setBlockAndUpdate(newPos, Helpers.setProperty(state, AGE, 0));
             }
         }
     }

--- a/src/main/java/net/dries007/tfc/common/blocks/plant/TFCPassableCactusBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/TFCPassableCactusBlock.java
@@ -38,13 +38,9 @@ public abstract class TFCPassableCactusBlock extends TFCTallGrassBlock
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     protected boolean canSurvive(BlockState state, LevelReader level, BlockPos pos)
     {
-        final BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
-
-        mutable.setWithOffset(pos, 0, -1, 0);
-        BlockState belowState = level.getBlockState(mutable);
+        BlockState belowState = level.getBlockState(pos.below());
         if (state.getValue(PART) == Part.LOWER)
         {
             return Helpers.isBlock(belowState, TFCTags.Blocks.DRY_PLANT_PLANTABLE_ON);


### PR DESCRIPTION
The short grass block's randomTick method didn't check whether the plant had an age property or not, so it was trying to set the age value of a plant without an age property. Also cleaned up a few things that bothered me.