### PR TITLE
[1.20.1] Allow FluidItemIngredients with delegate ingredients to display fluids in JEI

### DIFF
--- a/src/main/java/net/dries007/tfc/common/recipes/ingredients/DelegateIngredient.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/ingredients/DelegateIngredient.java
@@ -48,7 +48,7 @@ public abstract class DelegateIngredient extends Ingredient
                     // We force them to copy here which *should*, if this is called late enough, cause the capabilities to be present
                     // This is needed for almost all delegate ingredients, which are querying a capability underneath the hood.
                     .map(ItemStack::copy)
-                    .map(this::testDefaultItem)
+                    .flatMap(this::multiTestDefaultItem)
                     .filter(Objects::nonNull)
                     .toArray(ItemStack[]::new);
             }
@@ -140,6 +140,19 @@ public abstract class DelegateIngredient extends Ingredient
             })
             .filter(Objects::nonNull)
             .toArray(ItemStack[]::new);
+    }
+
+    /**
+     * Tests if an item stack is valid for the default items, and applies specific traits (usually desirable to show in JEI) if possible.
+     * Allows for multiple stack to be returned for cases where there are multiple valid states for each default item.
+     * <p>
+     * Null entries will be filtered out after invocation.
+     * @return A stream of item stacks, possibly modified from the original stack, that are valid for this ingredient.
+     */
+    protected Stream<ItemStack> multiTestDefaultItem(ItemStack stack)
+    {
+        final ItemStack tested = testDefaultItem(stack);
+        return tested == null ? Stream.empty() : Stream.of(tested);
     }
 
     /**

--- a/src/main/java/net/dries007/tfc/common/recipes/ingredients/FluidItemIngredient.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/ingredients/FluidItemIngredient.java
@@ -7,6 +7,8 @@
 package net.dries007.tfc.common.recipes.ingredients;
 
 import java.util.Objects;
+import java.util.stream.Stream;
+
 import com.google.gson.JsonObject;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.item.ItemStack;
@@ -76,6 +78,30 @@ public class FluidItemIngredient extends DelegateIngredient
                 }))
             .filter(Objects::nonNull)
             .toArray(ItemStack[]::new);
+    }
+
+    @Override
+    protected Stream<ItemStack> multiTestDefaultItem(ItemStack stack)
+    {
+        return fluid.ingredient()
+                .all()
+                .map(fluid -> {
+                    final ItemStack itemStack = stack.copy();
+                    final IFluidHandlerItem fluidHandler = Helpers.getCapability(itemStack, Capabilities.FLUID_ITEM);
+                    if (fluidHandler != null)
+                    {
+                        // Attempt to fill with the current fluid
+                        fluidHandler.fill(new FluidStack(fluid, Integer.MAX_VALUE), IFluidHandler.FluidAction.EXECUTE);
+
+                        // The attempt to drain, and ensure the content matches the filled fluid, and is of amount > the required amount.
+                        final FluidStack content = fluidHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE);
+                        if (content.getFluid() == fluid && content.getAmount() >= this.fluid.amount())
+                        {
+                            return fluidHandler.getContainer();
+                        }
+                    }
+                    return null;
+                });
     }
 
     @Override


### PR DESCRIPTION
Fix #3031 by introducing `DelegateIngredient#multiTestDefaultItem` and `flatMap`-ing it over the delegate ingredient items

Tested with the attached datapack which adds the following recipe

```json
{
	"type": "minecraft:crafting_shapeless",
	"ingredients": [
	{
		"type": "tfc:fluid_item",
		"fluid_ingredient": {
			"ingredient": [
				"minecraft:water",
				"minecraft:lava"
			],
			"amount": 50
		},
		"ingredient": {
			"item": "minecraft:bucket"
		}
	}
	],
	"result": {
		"item": "minecraft:cobblestone"
	}
}
```

[recipe_viewer_test.zip](https://github.com/user-attachments/files/21764060/recipe_viewer_test.zip)
