### PR TITLE
(1.21) Misc bugfixes again

### DIFF
--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
@@ -330,6 +330,12 @@ public class BuiltinItemTags extends TagsProvider<Item> implements Accessors
             .add(TFCBlocks.PLANTS.get(Plant.MUSSELS).get())
             .add(TFCBlocks.PLANTS.get(Plant.BARNACLES).get());
 
+        // Vanilla Armor Tags
+        tag(ItemTags.HEAD_ARMOR).add(TFCItems.METAL_ITEMS, Metal.ItemType.HELMET);
+        tag(ItemTags.CHEST_ARMOR).add(TFCItems.METAL_ITEMS, Metal.ItemType.CHESTPLATE);
+        tag(ItemTags.LEG_ARMOR).add(TFCItems.METAL_ITEMS, Metal.ItemType.GREAVES);
+        tag(ItemTags.FOOT_ARMOR).add(TFCItems.METAL_ITEMS, Metal.ItemType.BOOTS);
+
         // Vanilla Tool Tags
         tag(ItemTags.SWORDS).add(TFCItems.METAL_ITEMS, Metal.ItemType.SWORD);
         tag(ItemTags.AXES)

--- a/src/generated/resources/data/minecraft/tags/item/chest_armor.json
+++ b/src/generated/resources/data/minecraft/tags/item/chest_armor.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "tfc:metal/chestplate/bismuth_bronze",
+    "tfc:metal/chestplate/black_bronze",
+    "tfc:metal/chestplate/bronze",
+    "tfc:metal/chestplate/copper",
+    "tfc:metal/chestplate/wrought_iron",
+    "tfc:metal/chestplate/steel",
+    "tfc:metal/chestplate/black_steel",
+    "tfc:metal/chestplate/blue_steel",
+    "tfc:metal/chestplate/red_steel"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/foot_armor.json
+++ b/src/generated/resources/data/minecraft/tags/item/foot_armor.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "tfc:metal/boots/bismuth_bronze",
+    "tfc:metal/boots/black_bronze",
+    "tfc:metal/boots/bronze",
+    "tfc:metal/boots/copper",
+    "tfc:metal/boots/wrought_iron",
+    "tfc:metal/boots/steel",
+    "tfc:metal/boots/black_steel",
+    "tfc:metal/boots/blue_steel",
+    "tfc:metal/boots/red_steel"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/head_armor.json
+++ b/src/generated/resources/data/minecraft/tags/item/head_armor.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "tfc:metal/helmet/bismuth_bronze",
+    "tfc:metal/helmet/black_bronze",
+    "tfc:metal/helmet/bronze",
+    "tfc:metal/helmet/copper",
+    "tfc:metal/helmet/wrought_iron",
+    "tfc:metal/helmet/steel",
+    "tfc:metal/helmet/black_steel",
+    "tfc:metal/helmet/blue_steel",
+    "tfc:metal/helmet/red_steel"
+  ]
+}

--- a/src/generated/resources/data/minecraft/tags/item/leg_armor.json
+++ b/src/generated/resources/data/minecraft/tags/item/leg_armor.json
@@ -1,0 +1,13 @@
+{
+  "values": [
+    "tfc:metal/greaves/bismuth_bronze",
+    "tfc:metal/greaves/black_bronze",
+    "tfc:metal/greaves/bronze",
+    "tfc:metal/greaves/copper",
+    "tfc:metal/greaves/wrought_iron",
+    "tfc:metal/greaves/steel",
+    "tfc:metal/greaves/black_steel",
+    "tfc:metal/greaves/blue_steel",
+    "tfc:metal/greaves/red_steel"
+  ]
+}

--- a/src/main/java/net/dries007/tfc/common/blockentities/rotation/WindmillBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/rotation/WindmillBlockEntity.java
@@ -9,27 +9,26 @@ package net.dries007.tfc.common.blockentities.rotation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.Direction.Axis;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.Component;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.neoforged.neoforge.items.ItemStackHandler;
-
+import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.blockentities.TickableInventoryBlockEntity;
+import net.dries007.tfc.common.blocks.rotation.AxleBlock;
 import net.dries007.tfc.common.blocks.rotation.WindmillBlock;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.rotation.NetworkAction;
 import net.dries007.tfc.util.rotation.Node;
 import net.dries007.tfc.util.rotation.Rotation;
 import net.dries007.tfc.util.rotation.SourceNode;
-
-import static net.dries007.tfc.TerraFirmaCraft.*;
-
 
 public class WindmillBlockEntity extends TickableInventoryBlockEntity<ItemStackHandler> implements RotatingBlockEntity
 {
@@ -136,10 +135,10 @@ public class WindmillBlockEntity extends TickableInventoryBlockEntity<ItemStackH
                 count++;
             }
         }
-        if (count == 0)
+        if (count == 0) 
         {
-            BlockState axleState = ((WindmillBlock) getBlockState().getBlock()).getAxle().defaultBlockState();
-            axleState = Helpers.copyProperties(axleState, getBlockState());
+            final AxleBlock axle = ((WindmillBlock) getBlockState().getBlock()).getAxle();
+            BlockState axleState = axle.defaultBlockState().setValue(AxleBlock.AXIS, getBlockState().getValue(WindmillBlock.AXIS));
             level.setBlockAndUpdate(worldPosition, axleState);
         }
         else

--- a/src/main/java/net/dries007/tfc/common/blockentities/rotation/WindmillBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/rotation/WindmillBlockEntity.java
@@ -135,7 +135,7 @@ public class WindmillBlockEntity extends TickableInventoryBlockEntity<ItemStackH
                 count++;
             }
         }
-        if (count == 0) 
+        if (count == 0)
         {
             final AxleBlock axle = ((WindmillBlock) getBlockState().getBlock()).getAxle();
             BlockState axleState = axle.defaultBlockState().setValue(AxleBlock.AXIS, getBlockState().getValue(WindmillBlock.AXIS));

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BarrelBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BarrelBlock.java
@@ -300,7 +300,7 @@ public class BarrelBlock extends SealableDeviceBlock
     }
 
     @Override
-    protected boolean isStackSealed(ItemStack stack)
+    public boolean isStackSealed(ItemStack stack)
     {
         return stack.has(TFCComponents.BARREL);
     }

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/PowderkegBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/PowderkegBlock.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-
+import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.client.particle.TFCParticles;
 import net.dries007.tfc.common.blockentities.PowderkegBlockEntity;
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
@@ -149,6 +149,15 @@ public class PowderkegBlock extends SealableDeviceBlock
     public boolean canDropFromExplosion(BlockState state, BlockGetter level, BlockPos pos, Explosion explosion)
     {
         return false;
+    }
+
+    @Override
+    protected void onPlace(BlockState state, Level level, BlockPos pos, BlockState oldState, boolean isMoving)
+    {
+        if (level.hasNeighborSignal(pos) && !state.getValue(LIT) && state.getValue(SEALED))
+        {
+            level.getBlockEntity(pos, TFCBlockEntities.POWDERKEG.get()).ifPresent(keg -> keg.setLit(true, null));
+        }
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/SealableDeviceBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/SealableDeviceBlock.java
@@ -159,7 +159,7 @@ public class SealableDeviceBlock extends DeviceBlock implements IItemSize, Toolt
         }
     }
 
-    protected boolean isStackSealed(ItemStack stack)
+    public boolean isStackSealed(ItemStack stack)
     {
         return stack.has(TFCComponents.CONTENTS);
     }

--- a/src/main/java/net/dries007/tfc/common/entities/misc/HoldingMinecart.java
+++ b/src/main/java/net/dries007/tfc/common/entities/misc/HoldingMinecart.java
@@ -289,19 +289,24 @@ public class HoldingMinecart extends AbstractMinecart
         {
             return false;
         }
-        final int str = getPowderkegStrength();
-        if (str != 0)
+
+        final int strength = getPowderkegStrength();
+        if (strength != -1)
         {
-            toRun.accept(str);
+            toRun.accept(strength);
             return true;
         }
         return false;
     }
 
+    /**
+     * @return The explosion strength of the sealed powderkeg contained,
+     * or -1 if no sealed powderkeg is present.
+     */
     public int getPowderkegStrength()
     {
         final ItemStack stack = getHoldItem();
-        if (stack.getItem() instanceof BlockItem bi && bi.getBlock() instanceof PowderkegBlock)
+        if (stack.getItem() instanceof BlockItem bi && bi.getBlock() instanceof PowderkegBlock keg && keg.isStackSealed(stack))
         {
             final ItemListComponent contents = stack.get(TFCComponents.CONTENTS);
             if (contents != null)
@@ -309,6 +314,6 @@ public class HoldingMinecart extends AbstractMinecart
                 return PowderkegBlockEntity.getStrength(contents);
             }
         }
-        return 0;
+        return -1;
     }
 }


### PR DESCRIPTION
- Make powderkeg minecarts able to explode even with 0 explosion strength, to match normal powderkegs (for cosmetic explosion)
- Fix tfc armor not being tagged as armor
- Fix axles resetting their rotation when the last windmill blade is removed from them
- Fix sealed powderkegs not lighting when placed next to power