### PR TITLE
(1.21) Fluid handler fixes

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/LampBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/LampBlockEntity.java
@@ -7,6 +7,7 @@
 package net.dries007.tfc.common.blockentities;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Mth;
@@ -19,17 +20,20 @@ import org.jetbrains.annotations.Nullable;
 import net.dries007.tfc.common.blocks.devices.LampBlock;
 import net.dries007.tfc.common.capabilities.FluidTankCallback;
 import net.dries007.tfc.common.capabilities.InventoryFluidTank;
+import net.dries007.tfc.common.capabilities.SidedHandler;
 import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.data.LampFuel;
 
 public class LampBlockEntity extends TickCounterBlockEntity implements FluidTankCallback
 {
     protected FluidTank tank;
+    private final SidedHandler<IFluidHandler> sidedFluidInventory;
 
     public LampBlockEntity(BlockPos pos, BlockState state)
     {
         super(TFCBlockEntities.LAMP.get(), pos, state);
         this.tank = new InventoryFluidTank(TFCConfig.SERVER.lampCapacity.get(), stack -> LampFuel.get(stack.getFluid(), getBlockState()) != null, this);
+        this.sidedFluidInventory = new SidedHandler<>(tank);
     }
 
     @Override
@@ -97,5 +101,10 @@ public class LampBlockEntity extends TickCounterBlockEntity implements FluidTank
     {
         tag.put("tank", tank.writeToNBT(provider, new CompoundTag()));
         super.saveAdditional(tag, provider);
+    }
+
+    public IFluidHandler getSidedFluidInventory(@Nullable Direction context)
+    {
+        return sidedFluidInventory.get(context);
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/soil/IMudBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/soil/IMudBlock.java
@@ -54,7 +54,7 @@ public interface IMudBlock
         {
             final FluidStack simulatedDrained = fluidHandler.drain(waterRequired, IFluidHandler.FluidAction.SIMULATE);
 
-            if (simulatedDrained.is(TFCTags.Fluids.ANY_INFINITE_WATER) && simulatedDrained.getAmount() >= waterRequired)
+            if (simulatedDrained.is(TFCTags.Fluids.ANY_FRESH_WATER) && simulatedDrained.getAmount() >= waterRequired)
             {
                 fluidHandler.drain(waterRequired, IFluidHandler.FluidAction.EXECUTE);
                 level.setBlockAndUpdate(pos, mud);

--- a/src/main/java/net/dries007/tfc/common/blocks/soil/IMudBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/soil/IMudBlock.java
@@ -19,7 +19,7 @@ import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
-
+import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.fluids.FluidHelpers;
 import net.dries007.tfc.common.fluids.FluidHelpers.Transfer;
 import net.dries007.tfc.config.TFCConfig;
@@ -54,7 +54,7 @@ public interface IMudBlock
         {
             final FluidStack simulatedDrained = fluidHandler.drain(waterRequired, IFluidHandler.FluidAction.SIMULATE);
 
-            if (simulatedDrained.getAmount() >= waterRequired)
+            if (simulatedDrained.is(TFCTags.Fluids.ANY_INFINITE_WATER) && simulatedDrained.getAmount() >= waterRequired)
             {
                 fluidHandler.drain(waterRequired, IFluidHandler.FluidAction.EXECUTE);
                 level.setBlockAndUpdate(pos, mud);

--- a/src/main/java/net/dries007/tfc/common/capabilities/BlockCapabilities.java
+++ b/src/main/java/net/dries007/tfc/common/capabilities/BlockCapabilities.java
@@ -20,6 +20,7 @@ import net.dries007.tfc.common.blockentities.BarrelBlockEntity;
 import net.dries007.tfc.common.blockentities.BlastFurnaceBlockEntity;
 import net.dries007.tfc.common.blockentities.CrucibleBlockEntity;
 import net.dries007.tfc.common.blockentities.InventoryBlockEntity;
+import net.dries007.tfc.common.blockentities.LampBlockEntity;
 import net.dries007.tfc.common.blockentities.PotBlockEntity;
 import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.component.heat.IHeatConsumer;
@@ -51,6 +52,7 @@ public final class BlockCapabilities
         event.registerBlockEntity(HEAT, TFCBlockEntities.CRUCIBLE.get(), (object, context) -> object.getInventory());
         registerInventory(event, TFCBlockEntities.FIREPIT);
         registerInventory(event, TFCBlockEntities.GRILL);
+        event.registerBlockEntity(FLUID, TFCBlockEntities.LAMP.get(), LampBlockEntity::getSidedFluidInventory);
         registerInventory(event, TFCBlockEntities.LARGE_VESSEL);
         registerInventory(event, TFCBlockEntities.LOOM);
         registerInventory(event, TFCBlockEntities.NEST_BOX);


### PR DESCRIPTION
- Fix mud creation by right clicking a fluid container on dirt accepting any fluid, now it only accepts fresh water
- Fix lamps not being able to be filled with fluid due to the blockentity not having a fluid capability