### PR TITLE
[1.20.x] Preserve Layer Ordering

### DIFF
--- a/src/main/java/net/dries007/tfc/world/Codecs.java
+++ b/src/main/java/net/dries007/tfc/world/Codecs.java
@@ -8,15 +8,15 @@ package net.dries007.tfc.world;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.mojang.datafixers.util.Either;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
@@ -200,22 +200,6 @@ public final class Codecs extends ExtraCodecs
         return Codec.of(orderedEncoder(baseMapCodec, asList), orderedDecoder(Codec.either(baseMapCodec, asList)), "OrderPreservingUnboundMapCodec[" + keyCodec + " -> " + elementCodec + "]");
     }
 
-    private static <K, V> Map<K, V> listToMap(List<Pair<K, V>> list)
-    {
-        final ImmutableMap.Builder<K, V> builder = ImmutableMap.builder();
-        for (Pair<K, V> pair : list) {
-            builder.put(pair.getFirst(), pair.getSecond());
-        }
-        return builder.build();
-    }
-
-    private static <K, V> List<Pair<K, V>> mapToList(Map<K, V> map)
-    {
-        final ImmutableList.Builder<Pair<K, V>> builder = ImmutableList.builder();
-        map.forEach((k, v) -> builder.add(Pair.of(k, v)));
-        return builder.build();
-    }
-
     private static <K, V> Encoder<Map<K, V>> orderedEncoder(Codec<Map<K, V>> map, Codec<List<Pair<K, V>>> list)
     {
         return new Encoder<>() {
@@ -223,7 +207,7 @@ public final class Codecs extends ExtraCodecs
             public <T> DataResult<T> encode(Map<K, V> input, DynamicOps<T> ops, T prefix) {
                 if (ops == NbtOps.INSTANCE || ops instanceof DelegatingOps<T> del && del.delegate == NbtOps.INSTANCE)
                 {
-                    return list.encode(mapToList(input), ops, prefix);
+                    return list.encode(input.entrySet().stream().map(e -> Pair.of(e.getKey(), e.getValue())).toList(), ops, prefix);
                 }
                 else
                 {
@@ -239,7 +223,14 @@ public final class Codecs extends ExtraCodecs
             @Override
             public <T> DataResult<Pair<Map<K, V>, T>> decode(DynamicOps<T> ops, T input) {
                 return eitherCodec.decode(ops, input)
-                        .map(pair -> pair.mapFirst(either -> either.map(Function.identity(), Codecs::listToMap)));
+                        .map(pair -> pair.mapFirst(either -> either.map(Function.identity(), list -> list.stream().collect(Collector.of(
+                            LinkedHashMap::new,
+                            (map, p) -> map.put(p.getFirst(), p.getSecond()),
+                            (m1, m2) -> {
+                                m1.putAll(m2);
+                                return m1;
+                            }
+                        )))));
             }
         };
     }

--- a/src/main/java/net/dries007/tfc/world/Codecs.java
+++ b/src/main/java/net/dries007/tfc/world/Codecs.java
@@ -12,14 +12,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.mojang.datafixers.util.Either;
 import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Decoder;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.Encoder;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.resources.DelegatingOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.world.level.block.Block;
@@ -179,5 +188,59 @@ public final class Codecs extends ExtraCodecs
             o -> o.orElse(defaultValue),
             a -> Objects.equals(a, defaultValue) ? Optional.empty() : Optional.of(a)
         );
+    }
+
+    /**
+     * Version of {@link Codec#unboundedMap(Codec, Codec)} which ensures the order of map entries are preserved when (de)serializing to/from nbt.
+     */
+    public static <K, V> Codec<Map<K, V>> orderPreservingUnboundedMapCodec(Codec<K> keyCodec, Codec<V> elementCodec)
+    {
+        final Codec<Map<K, V>> baseMapCodec = Codec.unboundedMap(keyCodec, elementCodec);
+        final Codec<List<Pair<K, V>>> asList = recordPairCodec(keyCodec, "key", elementCodec, "value").listOf();
+        return Codec.of(orderedEncoder(baseMapCodec, asList), orderedDecoder(Codec.either(baseMapCodec, asList)), "OrderPreservingUnboundMapCodec[" + keyCodec + " -> " + elementCodec + "]");
+    }
+
+    private static <K, V> Map<K, V> listToMap(List<Pair<K, V>> list)
+    {
+        final ImmutableMap.Builder<K, V> builder = ImmutableMap.builder();
+        for (Pair<K, V> pair : list) {
+            builder.put(pair.getFirst(), pair.getSecond());
+        }
+        return builder.build();
+    }
+
+    private static <K, V> List<Pair<K, V>> mapToList(Map<K, V> map)
+    {
+        final ImmutableList.Builder<Pair<K, V>> builder = ImmutableList.builder();
+        map.forEach((k, v) -> builder.add(Pair.of(k, v)));
+        return builder.build();
+    }
+
+    private static <K, V> Encoder<Map<K, V>> orderedEncoder(Codec<Map<K, V>> map, Codec<List<Pair<K, V>>> list)
+    {
+        return new Encoder<>() {
+            @Override
+            public <T> DataResult<T> encode(Map<K, V> input, DynamicOps<T> ops, T prefix) {
+                if (ops == NbtOps.INSTANCE || ops instanceof DelegatingOps<T> del && del.delegate == NbtOps.INSTANCE)
+                {
+                    return list.encode(mapToList(input), ops, prefix);
+                }
+                else
+                {
+                    return map.encode(input, ops, prefix);
+                }
+            }
+        };
+    }
+
+    private static <K, V> Decoder<Map<K, V>> orderedDecoder(Codec<Either<Map<K, V>, List<Pair<K, V>>>> eitherCodec)
+    {
+        return new Decoder<>() {
+            @Override
+            public <T> DataResult<Pair<Map<K, V>, T>> decode(DynamicOps<T> ops, T input) {
+                return eitherCodec.decode(ops, input)
+                        .map(pair -> pair.mapFirst(either -> either.map(Function.identity(), Codecs::listToMap)));
+            }
+        };
     }
 }

--- a/src/main/java/net/dries007/tfc/world/settings/RockLayerSettings.java
+++ b/src/main/java/net/dries007/tfc/world/settings/RockLayerSettings.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.dries007.tfc.world.Codecs;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
@@ -211,7 +212,7 @@ public final class RockLayerSettings
     {
         static final Codec<LayerData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.STRING.fieldOf("id").forGetter(c -> c.id),
-            Codec.unboundedMap(Codec.STRING, Codec.STRING).fieldOf("layers").forGetter(c -> c.layers)
+            Codecs.orderPreservingUnboundedMapCodec(Codec.STRING, Codec.STRING).fieldOf("layers").forGetter(c -> c.layers)
         ).apply(instance, LayerData::new));
     }
 }

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -15,3 +15,6 @@ public net.minecraft.world.entity.projectile.FishingHook f_37094_ # hookedIn
 public net.minecraft.world.entity.projectile.FishingHook m_150157_(Lnet/minecraft/world/entity/Entity;)V # setHookedEntity
 public net.minecraft.world.entity.projectile.FishingHook f_37095_ # currentState
 public net.minecraft.world.entity.projectile.FishingHook$FishHookState
+
+# Used by Codecs#orderPreservingUnboundMapCodec to encode layer mappings as lists when serializing to nbt
+public net.minecraft.resources.DelegatingOps f_135465_ # delegate


### PR DESCRIPTION
Addresses #3054 in 1.20 by using a custom codec that serializes to NBT as a list.

This is non-breaking and backwards compatible with worlds created before this change.