### PR TITLE
Small miscellaneous fixes for 1.21

### DIFF
--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -262,6 +262,14 @@ public interface CraftingRecipes extends Recipes
                     .damageInputs()
                     .source(0, 2)
                     .shaped(blocks.get(Metal.BlockType.BLOCK), 8);
+                recipe()
+                    .input('B', ingredientOf(metal, Metal.BlockType.BLOCK))
+                    .pattern("BBB")
+                    .shaped(blocks.get(Metal.BlockType.BLOCK_SLAB), 6);
+                recipe()
+                    .input('B', ingredientOf(metal, Metal.BlockType.BLOCK))
+                    .pattern("B  ", "BB ", "BBB")
+                    .shaped(blocks.get(Metal.BlockType.BLOCK_STAIRS), 8);
             }
 
             if (metal.allParts())
@@ -292,6 +300,12 @@ public interface CraftingRecipes extends Recipes
                     .input('B', blocks.get(Metal.BlockType.BARS))
                     .pattern(" B ", "B B", " B ")
                     .shaped(blocks.get(Metal.BlockType.GRATE));
+                for(Wood wood : Wood.values())
+                    recipe()
+                        .input('L', TFCItems.LUMBER.get(wood))
+                        .input('C', ingredientOf(metal, Metal.BlockType.CHAIN))
+                        .pattern("C C", "LLL", "LLL")
+                        .shaped(TFCItems.HANGING_SIGNS.get(wood).get(metal), 3);
             }
         }
 
@@ -1148,7 +1162,7 @@ public interface CraftingRecipes extends Recipes
         recipe()
             .input('X', ItemTags.LOGS)
             .pattern("X", "X")
-            .shaped(TFCBlocks.WATTLE);
+            .shaped(TFCBlocks.WATTLE, 6);
         recipe()
             .input('L', TFCTags.Items.LUMBER)
             .input('C', TFCItems.WOOL_CLOTH)

--- a/src/data/java/net/dries007/tfc/data/recipes/WeldingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/WeldingRecipes.java
@@ -23,7 +23,7 @@ public interface WeldingRecipes extends Recipes
             if (metal.defaultParts())
             {
                 weld(metal, ItemType.INGOT, ItemType.INGOT, ItemType.DOUBLE_INGOT, IGNORE);
-                weld(metal, ItemType.SHEET, ItemType.INGOT, ItemType.DOUBLE_SHEET, IGNORE);
+                weld(metal, ItemType.SHEET, ItemType.SHEET, ItemType.DOUBLE_SHEET, IGNORE);
             }
             if (metal.allParts())
             {

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/bismuth_bronze_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/bismuth_bronze_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/bismuth_bronze"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/bismuth_bronze_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/bismuth_bronze_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/bismuth_bronze_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/bismuth_bronze"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/bismuth_bronze_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/bismuth_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/bismuth_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/bismuth"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/bismuth_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/bismuth_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/bismuth_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/bismuth"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/bismuth_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/black_bronze_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/black_bronze_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/black_bronze"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/black_bronze_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/black_bronze_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/black_bronze_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/black_bronze"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/black_bronze_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/black_steel_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/black_steel_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/black_steel"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/black_steel_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/black_steel_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/black_steel_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/black_steel"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/black_steel_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/blue_steel_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/blue_steel_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/blue_steel"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/blue_steel_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/blue_steel_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/blue_steel_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/blue_steel"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/blue_steel_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/brass_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/brass_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/brass"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/brass_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/brass_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/brass_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/brass"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/brass_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/bronze_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/bronze_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/bronze"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/bronze_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/bronze_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/bronze_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/bronze"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/bronze_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/cast_iron_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/cast_iron_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/cast_iron"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/cast_iron_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/cast_iron_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/cast_iron_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/cast_iron"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/cast_iron_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/copper_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/copper_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/copper"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/copper_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/copper_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/copper_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/copper"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/copper_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/gold_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/gold_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/gold"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/gold_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/gold_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/gold_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/gold"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/gold_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/nickel_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/nickel_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/nickel"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/nickel_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/nickel_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/nickel_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/nickel"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/nickel_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/red_steel_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/red_steel_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/red_steel"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/red_steel_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/red_steel_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/red_steel_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/red_steel"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/red_steel_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/rose_gold_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/rose_gold_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/rose_gold"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/rose_gold_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/rose_gold_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/rose_gold_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/rose_gold"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/rose_gold_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/silver_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/silver_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/silver"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/silver_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/silver_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/silver_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/silver"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/silver_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/steel_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/steel_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/steel"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/steel_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/steel_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/steel_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/steel"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/steel_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/sterling_silver_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/sterling_silver_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/sterling_silver"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/sterling_silver_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/sterling_silver_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/sterling_silver_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/sterling_silver"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/sterling_silver_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/tin_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/tin_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/tin"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/tin_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/tin_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/tin_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/tin"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/tin_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/wrought_iron_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/wrought_iron_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/wrought_iron"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/wrought_iron_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/wrought_iron_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/wrought_iron_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/wrought_iron"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/wrought_iron_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/zinc_slab.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/zinc_slab.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/zinc"
+    }
+  },
+  "pattern": [
+    "BBB"
+  ],
+  "result": {
+    "count": 6,
+    "id": "tfc:metal/block/zinc_slab"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/metal/block/zinc_stairs.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/metal/block/zinc_stairs.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "B": {
+      "tag": "c:storage_blocks/zinc"
+    }
+  },
+  "pattern": [
+    "B  ",
+    "BB ",
+    "BBB"
+  ],
+  "result": {
+    "count": 8,
+    "id": "tfc:metal/block/zinc_stairs"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wattle.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wattle.json
@@ -11,7 +11,7 @@
     "X"
   ],
   "result": {
-    "count": 1,
+    "count": 6,
     "id": "tfc:wattle"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bismuth_bronze/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bismuth_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bismuth_bronze/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_bronze/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_bronze/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/black_steel/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/black_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/black_steel/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/blue_steel/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/blue_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/blue_steel/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/bronze/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/bronze"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/bronze/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/copper/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/copper"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/copper/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/red_steel/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/red_steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/red_steel/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/steel/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/steel"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/steel/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/acacia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/acacia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/acacia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/acacia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/ash.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/ash.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/ash"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/ash"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/aspen.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/aspen.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/aspen"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/aspen"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/birch.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/birch.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/birch"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/birch"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/blackwood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/blackwood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/blackwood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/blackwood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/chestnut.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/chestnut.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/chestnut"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/chestnut"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/douglas_fir.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/douglas_fir.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/douglas_fir"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/douglas_fir"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/hickory.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/hickory.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/hickory"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/hickory"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/kapok.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/kapok.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/kapok"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/kapok"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/mangrove.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/mangrove.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/mangrove"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/mangrove"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/maple.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/maple.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/maple"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/maple"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/oak.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/oak.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/oak"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/oak"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/palm.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/palm.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/palm"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/palm"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/pine.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/pine.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/pine"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/pine"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/rosewood.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/rosewood.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/rosewood"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/rosewood"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/sequoia.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/sequoia.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sequoia"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/sequoia"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/spruce.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/spruce.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/spruce"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/spruce"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/sycamore.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/sycamore.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/sycamore"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/sycamore"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/white_cedar.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/white_cedar.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/white_cedar"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/white_cedar"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/willow.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/wood/hanging_sign/wrought_iron/willow.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "C": {
+      "item": "tfc:metal/chain/wrought_iron"
+    },
+    "L": {
+      "item": "tfc:wood/lumber/willow"
+    }
+  },
+  "pattern": [
+    "C C",
+    "LLL",
+    "LLL"
+  ],
+  "result": {
+    "count": 3,
+    "id": "tfc:wood/hanging_sign/wrought_iron/willow"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/bismuth.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/bismuth.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/bismuth"
   },
   "second_input": {
-    "tag": "c:ingots/bismuth"
+    "tag": "c:sheets/bismuth"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/bismuth_bronze.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/bismuth_bronze.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/bismuth_bronze"
   },
   "second_input": {
-    "tag": "c:ingots/bismuth_bronze"
+    "tag": "c:sheets/bismuth_bronze"
   },
   "tier": 1
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/black_bronze.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/black_bronze.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/black_bronze"
   },
   "second_input": {
-    "tag": "c:ingots/black_bronze"
+    "tag": "c:sheets/black_bronze"
   },
   "tier": 1
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/black_steel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/black_steel.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/black_steel"
   },
   "second_input": {
-    "tag": "c:ingots/black_steel"
+    "tag": "c:sheets/black_steel"
   },
   "tier": 4
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/blue_steel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/blue_steel.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/blue_steel"
   },
   "second_input": {
-    "tag": "c:ingots/blue_steel"
+    "tag": "c:sheets/blue_steel"
   },
   "tier": 5
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/brass.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/brass.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/brass"
   },
   "second_input": {
-    "tag": "c:ingots/brass"
+    "tag": "c:sheets/brass"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/bronze.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/bronze.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/bronze"
   },
   "second_input": {
-    "tag": "c:ingots/bronze"
+    "tag": "c:sheets/bronze"
   },
   "tier": 1
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/cast_iron.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/cast_iron.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/cast_iron"
   },
   "second_input": {
-    "tag": "c:ingots/cast_iron"
+    "tag": "c:sheets/cast_iron"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/copper.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/copper.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/copper"
   },
   "second_input": {
-    "tag": "c:ingots/copper"
+    "tag": "c:sheets/copper"
   },
   "tier": 0
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/gold.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/gold.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/gold"
   },
   "second_input": {
-    "tag": "c:ingots/gold"
+    "tag": "c:sheets/gold"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/nickel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/nickel.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/nickel"
   },
   "second_input": {
-    "tag": "c:ingots/nickel"
+    "tag": "c:sheets/nickel"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/red_steel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/red_steel.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/red_steel"
   },
   "second_input": {
-    "tag": "c:ingots/red_steel"
+    "tag": "c:sheets/red_steel"
   },
   "tier": 5
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/rose_gold.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/rose_gold.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/rose_gold"
   },
   "second_input": {
-    "tag": "c:ingots/rose_gold"
+    "tag": "c:sheets/rose_gold"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/silver.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/silver.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/silver"
   },
   "second_input": {
-    "tag": "c:ingots/silver"
+    "tag": "c:sheets/silver"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/steel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/steel.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/steel"
   },
   "second_input": {
-    "tag": "c:ingots/steel"
+    "tag": "c:sheets/steel"
   },
   "tier": 3
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/sterling_silver.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/sterling_silver.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/sterling_silver"
   },
   "second_input": {
-    "tag": "c:ingots/sterling_silver"
+    "tag": "c:sheets/sterling_silver"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/tin.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/tin.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/tin"
   },
   "second_input": {
-    "tag": "c:ingots/tin"
+    "tag": "c:sheets/tin"
   }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/wrought_iron.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/wrought_iron.json
@@ -8,7 +8,7 @@
     "id": "tfc:metal/double_sheet/wrought_iron"
   },
   "second_input": {
-    "tag": "c:ingots/wrought_iron"
+    "tag": "c:sheets/wrought_iron"
   },
   "tier": 2
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/zinc.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/zinc.json
@@ -8,6 +8,6 @@
     "id": "tfc:metal/double_sheet/zinc"
   },
   "second_input": {
-    "tag": "c:ingots/zinc"
+    "tag": "c:sheets/zinc"
   }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/TFCBlocks.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/TFCBlocks.java
@@ -471,7 +471,7 @@ public final class TFCBlocks
         registerNoItem("candle_cake/" + color.getName(), () -> new TFCCandleCakeBlock(ExtendedProperties.of(MapColor.SAND).randomTicks().noOcclusion().strength(0.5F).sound(SoundType.WOOL).lightLevel(litBlockEmission(3)).blockEntity(TFCBlockEntities.TICK_COUNTER).cloneItem(Blocks.CAKE)))
     );
     public static final Map<DyeColor, Id<Block>> DYED_CANDLE = Helpers.mapOf(DyeColor.class, color ->
-        register("candle/" + color.getName(), () -> new TFCCandleBlock(ExtendedProperties.of(MapColor.SAND).randomTicks().noOcclusion().strength(0.1F).sound(SoundType.CANDLE).lightLevel(TFCCandleBlock.LIGHTING_SCALE).blockEntity(TFCBlockEntities.TICK_COUNTER)), b -> new CandleBlockItem(new Item.Properties(), b, TFCBlocks.DYED_CANDLE_CAKES.get(color)))
+        register("candle/" + color.getName(), () -> new TFCCandleBlock(ExtendedProperties.of(Blocks.CANDLE).mapColor(MapColor.SAND).randomTicks().noOcclusion().strength(0.1F).sound(SoundType.CANDLE).lightLevel(TFCCandleBlock.LIGHTING_SCALE).blockEntity(TFCBlockEntities.TICK_COUNTER)), b -> new CandleBlockItem(new Item.Properties(), b, TFCBlocks.DYED_CANDLE_CAKES.get(color)))
     );
 
     public static final Id<Block> LARGE_VESSEL = register("ceramic/large_vessel", () -> new LargeVesselBlock(ExtendedProperties.of(MapColor.CLAY).strength(2.5F).noOcclusion().blockEntity(TFCBlockEntities.LARGE_VESSEL)), block -> new TooltipBlockItem(block, new Item.Properties()));

--- a/src/main/java/net/dries007/tfc/common/component/heat/HeatCapability.java
+++ b/src/main/java/net/dries007/tfc/common/component/heat/HeatCapability.java
@@ -220,7 +220,7 @@ public final class HeatCapability
     /**
      * Use this to increase the heat on an IItemHeat instance.
      *
-     * @param modifier the modifier for how much this will heat up: 0 - 1 slows down cooling, 1 = no heating or cooling, > 1 heats, 2 heats at the same rate of normal cooling, 2+ heats faster
+     * @param modifier the modifier for how much this will heat up: 0 - 1 slows down cooling, 1 = no heating or cooling, > 1 heats, 1.8 heats at the same rate of normal cooling, 1.8+ heats faster
      */
     public static void addTemp(IHeat instance, float targetTemperature, float modifier)
     {


### PR DESCRIPTION
- Fixed a minor inaccuracy in the documentation for `HeatCapability#addTemp`
- Fixed dyed candles not behaving like undyed candles / vanilla candles in regards to being pushed by pistons
- Added missing recipes for plated metal slabs and stairs
- Added missing recipes for hanging signs
- Fixed wattle recipe only returning a single block of wattle instead of six
- Fixed double sheet welding recipe taking a sheet + an ingot instead of two sheets