### PR TITLE
Advancement & recipe fixes

### DIFF
--- a/resources/advancements.py
+++ b/resources/advancements.py
@@ -108,7 +108,7 @@ def generate(rm: ResourceManager):
     world.advancement('dune', icon('tfc:plant/barrel_cactus'), 'Dune', 'Travel to a desert and find a barrel cactus', 'seeds', inventory_changed('tfc:plant/barrel_cactus'))
     world.advancement('fruit', food_icon('tfc:food/orange'), 'Healthy Diet', 'Eat every berry and tree fruit in TFC', 'root', multiple_all(*[consume_item('tfc:food/%s' % f, name=f) for f in (*BERRIES, *FRUITS)]), requirements=[[f] for f in (*BERRIES, *FRUITS)], frame='challenge')
     world.advancement('saplings', icon('tfc:wood/sapling/pine'), 'Arborist', 'Find every (non-fruit) tree sapling in TFC', 'root', multiple_all(*[inventory_changed('tfc:wood/sapling/%s' % t, name=t) for t in WOODS.keys()]), requirements=[[t] for t in WOODS.keys()])
-    world.advancement('nugget', icon('tfc:ore/small_native_copper'), 'A Weird Rock', 'Find a metal nugget on the ground', 'root', inventory_changed('tfc:metal_ores'))
+    world.advancement('nugget', icon('tfc:ore/small_native_copper'), 'A Weird Rock', 'Find a metal nugget on the ground', 'root', inventory_changed('#tfc:metal_ores'))
     world.advancement('coal', icon('tfc:ore/lignite'), 'Carboniferous', 'Find Bituminous Coal or Lignite', 'nugget', multiple_all(inventory_changed('tfc:ore/lignite'), inventory_changed('tfc:ore/bituminous_coal')))
     world.advancement('diamond', icon('tfc:ore/diamond'), 'DIAM- oh, wait', 'Find Diamonds (Kimberlite)', 'nugget', inventory_changed('tfc:ore/diamond'))
     world.advancement('graphite', icon('tfc:ore/graphite'), 'Better than Diamonds', 'Find Graphite', 'nugget', inventory_changed('tfc:ore/graphite'), frame='goal')

--- a/src/data/java/net/dries007/tfc/data/recipes/HeatRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/HeatRecipes.java
@@ -117,7 +117,7 @@ public interface HeatRecipes extends Recipes
         add(TFCItems.CACTUS_WOOD, TFCItems.DRIED_CACTUS_WOOD, 700);
 
         burnFood("bread", Ingredient.of(TFCTags.Items.BREAD), 700);
-        burnFood("meat", Ingredient.of(TFCTags.Items.MEATS), 900);
+        burnFood("meat", Ingredient.of(TFCTags.Items.COOKED_MEATS), 900);
 
         for (Ore ore : Ore.values())
             if (ore.isGraded())

--- a/src/generated/resources/data/tfc/recipe/heating/burn_meat.json
+++ b/src/generated/resources/data/tfc/recipe/heating/burn_meat.json
@@ -1,7 +1,7 @@
 {
   "type": "tfc:heating",
   "ingredient": {
-    "tag": "c:foods/meat"
+    "tag": "c:foods/cooked_meat"
   },
   "temperature": 900.0
 }

--- a/src/main/resources/data/tfc/advancement/world/nugget.json
+++ b/src/main/resources/data/tfc/advancement/world/nugget.json
@@ -7,7 +7,7 @@
       "conditions": {
         "items": [
           {
-            "items": "tfc:metal_ores"
+            "items": "#tfc:metal_ores"
           }
         ]
       }


### PR DESCRIPTION
-Fix 'A weird rock' advancement checking for an item that doesn't exist rather than a tag
-Fix meat being unable to be cooked, because of a recipe conflict with the recipe to burn food (Closes #3121)