### PR TITLE
Fixed nutrition of players not updating correctly on both server and client

### DIFF
--- a/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
+++ b/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
@@ -207,11 +207,6 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
         addThirst(food.water());
         addIntoxication(food.intoxication());
 
-        if (player instanceof ServerPlayer serverPlayer && nutrition.getAverageNutrition() >= 0.999)
-        {
-            TFCAdvancements.FULL_NUTRITION.trigger(serverPlayer);
-        }
-
         if (food.hunger() > 0)
         {
             // In order to get the exact saturation we want, apply this scaling factor here
@@ -223,6 +218,11 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
         {
             nutrition.addNutrients(food);
             nutrition.setHunger(getFoodLevel());
+        }
+
+        if (player instanceof ServerPlayer serverPlayer && nutrition.getAverageNutrition() >= 0.999)
+        {
+            TFCAdvancements.FULL_NUTRITION.trigger(serverPlayer);
         }
 
         modified = true;

--- a/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
+++ b/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
@@ -207,11 +207,6 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
         addThirst(food.water());
         addIntoxication(food.intoxication());
 
-        if (!player.level().isClientSide)
-        {
-            nutrition.addNutrients(food);
-        }
-
         if (player instanceof ServerPlayer serverPlayer && nutrition.getAverageNutrition() >= 0.999)
         {
             TFCAdvancements.FULL_NUTRITION.trigger(serverPlayer);
@@ -221,6 +216,13 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
         {
             // In order to get the exact saturation we want, apply this scaling factor here
             this.food.eat(food.hunger(), food.saturation() / (2f * food.hunger()));
+        }
+
+        // Add nutrients and update the hunger value in NutritionData
+        if (!player.level().isClientSide)
+        {
+            nutrition.addNutrients(food);
+            nutrition.setHunger(getFoodLevel());
         }
 
         modified = true;
@@ -301,8 +303,9 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
             }
         }
 
-        // Next, tick the original food stats
+        // Next, tick the original food stats and update the hunger value in NutritionData
         food.tick(player);
+        nutrition.setHunger(getFoodLevel());
 
         // Apply custom TFC regeneration
         if (player.tickCount % 10 == 0)


### PR DESCRIPTION
When eating food or losing hunger from exhaustion, the `NutritionData#hunger` value wasn't updated. This lead to incorrect nutrition and HP values on both server and client side, which only fixed themselves after leaving and re-joining the world (since saving / loading data _does_ set this value correctly). This PR fixes this bug by updating the hunger value in these missing cases.