### PR TITLE
[1.21.1] Fix crash when trying to get weather in singleplayer on shutdown.

### DIFF
--- a/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/BiomeMixin.java
@@ -9,6 +9,7 @@ package net.dries007.tfc.mixin;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.CommonLevelAccessor;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
@@ -58,6 +59,10 @@ public abstract class BiomeMixin implements BiomeBridge
     @ModifyReturnValue(method = "getPrecipitationAt", at = @At("RETURN"))
     private Biome.Precipitation getPrecipitaitionFromClimate(Biome.Precipitation original, @Local BlockPos pos)
     {
-        return WeatherHelpers.getPrecipitationAt(Minecraft.getInstance().level, pos, original);
+        Level level = Minecraft.getInstance().level;
+        if (level == null) {
+            return original;
+        }
+        return WeatherHelpers.getPrecipitationAt(level, pos, original);
     }
 }


### PR DESCRIPTION
<details>
<summary>While testing a 1.21.1 TFC Modpack  I'm making that is WIP I got the following crash:</summary>

```
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.level.Level.getData(java.util.function.Supplier)" because "level" is null
	at TRANSFORMER/tfc@4.0.3-beta/net.dries007.tfc.util.tracker.WorldTracker.get(WorldTracker.java:65) ~[TerraFirmaCraft-NeoForge-1.21.1-4.0.3-beta.jar%23287!/:4.0.3-beta] {re:classloading}
	at TRANSFORMER/tfc@4.0.3-beta/net.dries007.tfc.util.tracker.WeatherHelpers.getPrecipitationAt(WeatherHelpers.java:85) ~[TerraFirmaCraft-NeoForge-1.21.1-4.0.3-beta.jar%23287!/:4.0.3-beta] {re:mixin,re:classloading}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.biome.Biome.modifyReturnValue$bhm000$tfc$getPrecipitaitionFromClimate(Biome.java:2561) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:default,re:classloading,pl:accesstransformer:B,xf:fml:default,pl:mixin:APP:lithium.mixins.json:world.chunk_ticking.spread_ice.BiomeMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.temperature_cache.BiomeMixin from mod lithium,pl:mixin:APP:modernfix-common.mixins.json:perf.remove_biome_temperature_cache.BiomeMixin from mod modernfix,pl:mixin:APP:sodium-neoforge.mixins.json:features.world.biome.BiomeMixin from mod sodium,pl:mixin:APP:tfc.mixins.json:BiomeMixin from mod tfc,pl:mixin:APP:tfc.mixins.json:accessor.BiomeAccessor from mod tfc,pl:mixin:APP:mixin.nostalgic_tweaks.json:candy.world_sky.BiomeMixin from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.biome.Biome.getPrecipitationAt(Biome.java:103) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,xf:fml:default,re:classloading,pl:accesstransformer:B,xf:fml:default,pl:mixin:APP:lithium.mixins.json:world.chunk_ticking.spread_ice.BiomeMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.temperature_cache.BiomeMixin from mod lithium,pl:mixin:APP:modernfix-common.mixins.json:perf.remove_biome_temperature_cache.BiomeMixin from mod modernfix,pl:mixin:APP:sodium-neoforge.mixins.json:features.world.biome.BiomeMixin from mod sodium,pl:mixin:APP:tfc.mixins.json:BiomeMixin from mod tfc,pl:mixin:APP:tfc.mixins.json:accessor.BiomeAccessor from mod tfc,pl:mixin:APP:mixin.nostalgic_tweaks.json:candy.world_sky.BiomeMixin from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.mixinextras$bridge$getPrecipitationAt$165(Level.java) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.intersection.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.collisions.empty_space.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.LevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.block_entity_retrieval.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.data_storage.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.chunk_tickable.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.chunk_access.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.inline_block_access.LevelMixin from mod lithium,pl:mixin:APP:lithium-neoforge.mixins.json:block.hopper.LevelMixin from mod lithium,pl:mixin:APP:mixins.sodiumdynamiclights.json:LevelMixin from mod sodiumdynamiclights,pl:mixin:APP:tfc.mixins.json:LevelMixin from mod tfc,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.wrapOperation$bii000$tfc$isRainingAtWithClimate(Level.java:7332) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.intersection.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.collisions.empty_space.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.LevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.block_entity_retrieval.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.data_storage.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.chunk_tickable.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.chunk_access.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.inline_block_access.LevelMixin from mod lithium,pl:mixin:APP:lithium-neoforge.mixins.json:block.hopper.LevelMixin from mod lithium,pl:mixin:APP:mixins.sodiumdynamiclights.json:LevelMixin from mod sodiumdynamiclights,pl:mixin:APP:tfc.mixins.json:LevelMixin from mod tfc,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.isRainingAt(Level.java:1025) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.intersection.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.collisions.empty_space.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.LevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.block_entity_retrieval.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.data_storage.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.chunk_tickable.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.chunk_access.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.inline_block_access.LevelMixin from mod lithium,pl:mixin:APP:lithium-neoforge.mixins.json:block.hopper.LevelMixin from mod lithium,pl:mixin:APP:mixins.sodiumdynamiclights.json:LevelMixin from mod sodiumdynamiclights,pl:mixin:APP:tfc.mixins.json:LevelMixin from mod tfc,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Entity.isInRain(Entity.java:1218) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.deep_passengers.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:block.hopper.EntityAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:collections.fluid_submersion.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.movement.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.unpushable_cramming.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.sprinting_particles.EntityMixin from mod lithium,pl:mixin:APP:modernfix-common.mixins.json:bugfix.chunk_deadlock.EntityMixin from mod modernfix,pl:mixin:APP:ichunutil.mixins.json:EntityMixin from mod ichunutil,pl:mixin:APP:mixins.sodiumdynamiclights.json:lightsource.EntityMixin from mod sodiumdynamiclights,pl:mixin:APP:entity_model_features.mixins.json:MixinEntity from mod entity_model_features,pl:mixin:APP:tfc.mixins.json:EntityMixin from mod tfc,pl:mixin:APP:entity_texture_features.mixins.json:entity.misc.MixinEntity from mod entity_texture_features,pl:mixin:APP:jade.mixins.json:EntityAccess from mod jade,pl:mixin:APP:entityculling.mixins.json:CullableMixin from mod entityculling,pl:mixin:APP:multimine.mixins.json:EntityMixin from mod multimine,pl:mixin:APP:transition.mixins.json:ExtensionMixin from mod transition,pl:mixin:APP:mixin.nostalgic_tweaks-access.json:EntityAccess from mod nostalgic_tweaks,pl:mixin:APP:sound_physics_remastered.mixins.json:EntityMixin from mod (unknown),pl:mixin:APP:mixin.nostalgic_tweaks.json:candy.player_particles.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_minecart.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:sound.entity_step.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:forge-badoptimizations.mixins.json:renderer.entity.MixinEntity from mod badoptimizations,pl:mixin:APP:notenoughcrashes.mixins.json:MixinEntity from mod notenoughcrashes,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Entity.isInWaterRainOrBubble(Entity.java:1231) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.deep_passengers.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:block.hopper.EntityAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:collections.fluid_submersion.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.movement.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.unpushable_cramming.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.sprinting_particles.EntityMixin from mod lithium,pl:mixin:APP:modernfix-common.mixins.json:bugfix.chunk_deadlock.EntityMixin from mod modernfix,pl:mixin:APP:ichunutil.mixins.json:EntityMixin from mod ichunutil,pl:mixin:APP:mixins.sodiumdynamiclights.json:lightsource.EntityMixin from mod sodiumdynamiclights,pl:mixin:APP:entity_model_features.mixins.json:MixinEntity from mod entity_model_features,pl:mixin:APP:tfc.mixins.json:EntityMixin from mod tfc,pl:mixin:APP:entity_texture_features.mixins.json:entity.misc.MixinEntity from mod entity_texture_features,pl:mixin:APP:jade.mixins.json:EntityAccess from mod jade,pl:mixin:APP:entityculling.mixins.json:CullableMixin from mod entityculling,pl:mixin:APP:multimine.mixins.json:EntityMixin from mod multimine,pl:mixin:APP:transition.mixins.json:ExtensionMixin from mod transition,pl:mixin:APP:mixin.nostalgic_tweaks-access.json:EntityAccess from mod nostalgic_tweaks,pl:mixin:APP:sound_physics_remastered.mixins.json:EntityMixin from mod (unknown),pl:mixin:APP:mixin.nostalgic_tweaks.json:candy.player_particles.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_minecart.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:sound.entity_step.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:forge-badoptimizations.mixins.json:renderer.entity.MixinEntity from mod badoptimizations,pl:mixin:APP:notenoughcrashes.mixins.json:MixinEntity from mod notenoughcrashes,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.LivingEntity.baseTick(LivingEntity.java:459) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:entity.collisions.unpushable_cramming.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.equipment_tracking.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.equipment_tracking.enchantment_ticking.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.equipment_tracking.equipment_changes.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.fast_elytra_check.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.fast_hand_swing.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.fast_powder_snow_check.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.LivingEntityMixin from mod lithium,pl:mixin:APP:mixins.sodiumdynamiclights.json:lightsource.LivingEntityMixin from mod sodiumdynamiclights,pl:mixin:APP:mixin.nostalgic_tweaks-access.json:LivingEntityAccess from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:candy.item_merge.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.bugs.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.combat_player.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.food_health.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_player.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_swim.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mob_drops.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:animation.held_item.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:animation.player.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:sound.damage_sound.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:swing.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Mob.baseTick(Mob.java:278) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:entity.equipment_tracking.MobMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.MobMixin from mod lithium,pl:mixin:APP:tfc.mixins.json:MobMixin from mod tfc,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mob_drops.MobMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.monster_rule.MobMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.monster_spawn.MobMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:animation.entity.MobMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks-duck.json:MobImpl from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Entity.tick(Entity.java:425) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.deep_passengers.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:block.hopper.EntityAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:collections.fluid_submersion.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.movement.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.unpushable_cramming.EntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.sprinting_particles.EntityMixin from mod lithium,pl:mixin:APP:modernfix-common.mixins.json:bugfix.chunk_deadlock.EntityMixin from mod modernfix,pl:mixin:APP:ichunutil.mixins.json:EntityMixin from mod ichunutil,pl:mixin:APP:mixins.sodiumdynamiclights.json:lightsource.EntityMixin from mod sodiumdynamiclights,pl:mixin:APP:entity_model_features.mixins.json:MixinEntity from mod entity_model_features,pl:mixin:APP:tfc.mixins.json:EntityMixin from mod tfc,pl:mixin:APP:entity_texture_features.mixins.json:entity.misc.MixinEntity from mod entity_texture_features,pl:mixin:APP:jade.mixins.json:EntityAccess from mod jade,pl:mixin:APP:entityculling.mixins.json:CullableMixin from mod entityculling,pl:mixin:APP:multimine.mixins.json:EntityMixin from mod multimine,pl:mixin:APP:transition.mixins.json:ExtensionMixin from mod transition,pl:mixin:APP:mixin.nostalgic_tweaks-access.json:EntityAccess from mod nostalgic_tweaks,pl:mixin:APP:sound_physics_remastered.mixins.json:EntityMixin from mod (unknown),pl:mixin:APP:mixin.nostalgic_tweaks.json:candy.player_particles.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_minecart.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:sound.entity_step.EntityMixin from mod nostalgic_tweaks,pl:mixin:APP:forge-badoptimizations.mixins.json:renderer.entity.MixinEntity from mod badoptimizations,pl:mixin:APP:notenoughcrashes.mixins.json:MixinEntity from mod notenoughcrashes,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.LivingEntity.tick(LivingEntity.java:2393) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:entity.collisions.unpushable_cramming.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.equipment_tracking.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.equipment_tracking.enchantment_ticking.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.equipment_tracking.equipment_changes.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.fast_elytra_check.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.fast_hand_swing.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.fast_powder_snow_check.LivingEntityMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.LivingEntityMixin from mod lithium,pl:mixin:APP:mixins.sodiumdynamiclights.json:lightsource.LivingEntityMixin from mod sodiumdynamiclights,pl:mixin:APP:mixin.nostalgic_tweaks-access.json:LivingEntityAccess from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:candy.item_merge.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.bugs.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.combat_player.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.food_health.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_player.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_swim.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mob_drops.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:animation.held_item.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:animation.player.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:sound.damage_sound.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:swing.LivingEntityMixin from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.entity.Mob.tick(Mob.java:351) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:entity.equipment_tracking.MobMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.MobMixin from mod lithium,pl:mixin:APP:tfc.mixins.json:MobMixin from mod tfc,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mob_drops.MobMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.monster_rule.MobMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.monster_spawn.MobMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:animation.entity.MobMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks-duck.json:MobImpl from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/tfc@4.0.3-beta/net.dries007.tfc.common.entities.prey.WildAnimal.tick(WildAnimal.java:64) ~[TerraFirmaCraft-NeoForge-1.21.1-4.0.3-beta.jar%23287!/:4.0.3-beta] {re:classloading}
	at TRANSFORMER/tfc@4.0.3-beta/net.dries007.tfc.common.entities.prey.Prey.tick(Prey.java:95) ~[TerraFirmaCraft-NeoForge-1.21.1-4.0.3-beta.jar%23287!/:4.0.3-beta] {re:classloading}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ServerLevel.tickNonPassenger(ServerLevel.java:774) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.ServerLevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.ServerLevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.spawning.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.entity_movement_tracking.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.ServerLevelMixin from mod lithium,pl:mixin:APP:xaeroworldmap.mixins.json:MixinServerWorld from mod xaeroworldmap,pl:mixin:APP:modernfix-common.mixins.json:bugfix.chunk_deadlock.ServerLevelMixin from mod modernfix,pl:mixin:APP:modernfix-common.mixins.json:perf.cache_strongholds.ServerLevelMixin from mod modernfix,pl:mixin:APP:tfc.mixins.json:ServerLevelMixin from mod tfc,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.experience_orb.ServerLevelMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_player.ServerLevelMixin from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.Level.guardEntityTick(Level.java:576) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:computing_frames,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.collisions.intersection.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.collisions.empty_space.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.LevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.block_entity_retrieval.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:util.data_storage.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.chunk_tickable.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.chunk_access.LevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:world.inline_block_access.LevelMixin from mod lithium,pl:mixin:APP:lithium-neoforge.mixins.json:block.hopper.LevelMixin from mod lithium,pl:mixin:APP:mixins.sodiumdynamiclights.json:LevelMixin from mod sodiumdynamiclights,pl:mixin:APP:tfc.mixins.json:LevelMixin from mod tfc,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ServerLevel.lambda$tick$2(ServerLevel.java:420) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.ServerLevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.ServerLevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.spawning.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.entity_movement_tracking.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.ServerLevelMixin from mod lithium,pl:mixin:APP:xaeroworldmap.mixins.json:MixinServerWorld from mod xaeroworldmap,pl:mixin:APP:modernfix-common.mixins.json:bugfix.chunk_deadlock.ServerLevelMixin from mod modernfix,pl:mixin:APP:modernfix-common.mixins.json:perf.cache_strongholds.ServerLevelMixin from mod modernfix,pl:mixin:APP:tfc.mixins.json:ServerLevelMixin from mod tfc,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.experience_orb.ServerLevelMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_player.ServerLevelMixin from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.world.level.entity.EntityTickList.forEach(EntityTickList.java:54) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,re:classloading,pl:mixin:APP:lithium.mixins.json:collections.entity_ticking.EntityTickListMixin from mod lithium,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.level.ServerLevel.tick(ServerLevel.java:400) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:lithium.mixins.json:alloc.chunk_random.ServerLevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:entity.inactive_navigations.ServerLevelMixin from mod lithium,pl:mixin:APP:lithium.mixins.json:minimal_nonvanilla.spawning.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.accessors.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:util.entity_movement_tracking.ServerLevelAccessor from mod lithium,pl:mixin:APP:lithium.mixins.json:world.block_entity_ticking.sleeping.ServerLevelMixin from mod lithium,pl:mixin:APP:xaeroworldmap.mixins.json:MixinServerWorld from mod xaeroworldmap,pl:mixin:APP:modernfix-common.mixins.json:bugfix.chunk_deadlock.ServerLevelMixin from mod modernfix,pl:mixin:APP:modernfix-common.mixins.json:perf.cache_strongholds.ServerLevelMixin from mod modernfix,pl:mixin:APP:tfc.mixins.json:ServerLevelMixin from mod tfc,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.experience_orb.ServerLevelMixin from mod nostalgic_tweaks,pl:mixin:APP:mixin.nostalgic_tweaks.json:gameplay.mechanics_player.ServerLevelMixin from mod nostalgic_tweaks,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1037) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:917) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.server.IntegratedServer.tickServer(IntegratedServer.java:110) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:runtimedistcleaner:A,re:classloading,pl:mixin:APP:modernfix-common.mixins.json:perf.thread_priorities.IntegratedServerMixin from mod modernfix,pl:mixin:A,pl:runtimedistcleaner:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:707) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:267) ~[client-1.21.1-20240808.144430-srg.jar%23234!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
	at java.base/java.lang.Thread.run(Thread.java:1575) ~[?:?] {re:mixin}
```
</details>

The issue is caused by the client only mixin in `Biome.getPrecipitaitionFromClimate()` assuming there is always a client side level when it is called, but the minecraft "internal server" can still be running while the client world is `null`, especially when quitting the game.

The crash only affect singleplayer, when the client connect to a dedicated server it does not create an "internal server" so there is no risk of this specific crash from occuring in multiplayer.

This PR just add a simple `null` check to fix the crash.