### PR TITLE
Various fixes to jam, jars, and sandwiches + Small addition to `IPlayerInfo`

### DIFF
--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemSizes.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemSizes.java
@@ -116,8 +116,8 @@ public class BuiltinItemSizes extends DataManagerProvider<ItemSizeDefinition> im
         add("tuyeres", TFCTags.Items.BLAST_FURNACE_TUYERES, Size.LARGE, Weight.HEAVY);
         add("ores", TFCTags.Items.ORE_PIECES, Size.SMALL, Weight.MEDIUM);
         add("small_ores", TFCTags.Items.SMALL_ORE_PIECES, Size.SMALL, Weight.LIGHT);
-        add("jars", TFCTags.Items.JARS, Size.NORMAL, Weight.VERY_HEAVY);
-        add("empty_jars", Ingredient.of(TFCItems.EMPTY_JAR, TFCItems.EMPTY_JAR_WITH_LID), Size.NORMAL, Weight.LIGHT);
+        add("filled_jars", TFCTags.Items.FILLED_JARS, Size.VERY_LARGE, Weight.HEAVY);
+        add("empty_jars", TFCTags.Items.EMPTY_JARS, Size.TINY, Weight.MEDIUM);
         add("glass_bottles", TFCTags.Items.GLASS_BOTTLES, Size.NORMAL, Weight.MEDIUM);
         add("windmill_blades", TFCTags.Items.WINDMILL_BLADES, Size.VERY_LARGE, Weight.VERY_HEAVY);
         add("water_wheels", TFCTags.Items.WATER_WHEELS, Size.VERY_LARGE, Weight.VERY_HEAVY);

--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemSizes.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemSizes.java
@@ -116,8 +116,8 @@ public class BuiltinItemSizes extends DataManagerProvider<ItemSizeDefinition> im
         add("tuyeres", TFCTags.Items.BLAST_FURNACE_TUYERES, Size.LARGE, Weight.HEAVY);
         add("ores", TFCTags.Items.ORE_PIECES, Size.SMALL, Weight.MEDIUM);
         add("small_ores", TFCTags.Items.SMALL_ORE_PIECES, Size.SMALL, Weight.LIGHT);
-        add("filled_jars", TFCTags.Items.FILLED_JARS, Size.VERY_LARGE, Weight.HEAVY);
-        add("empty_jars", TFCTags.Items.EMPTY_JARS, Size.TINY, Weight.MEDIUM);
+        add("filled_jars", TFCTags.Items.FILLED_JARS, Size.NORMAL, Weight.HEAVY);
+        add("empty_jars", TFCTags.Items.EMPTY_JARS, Size.NORMAL, Weight.MEDIUM);
         add("glass_bottles", TFCTags.Items.GLASS_BOTTLES, Size.NORMAL, Weight.MEDIUM);
         add("windmill_blades", TFCTags.Items.WINDMILL_BLADES, Size.VERY_LARGE, Weight.VERY_HEAVY);
         add("water_wheels", TFCTags.Items.WATER_WHEELS, Size.VERY_LARGE, Weight.VERY_HEAVY);

--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
@@ -153,12 +153,13 @@ public class BuiltinItemTags extends TagsProvider<Item> implements Accessors
         tag(FOODS).addTag(JAM).add(TFCItems.FOOD).addTag(SOUPS).addTag(SALADS).addTag(SANDWICHES);
         tag(PRESERVES).add(TFCItems.UNSEALED_FRUIT_PRESERVES);
         tag(SEALED_PRESERVES).add(TFCItems.FRUIT_PRESERVES);
-        tag(JARS)
-            .addTags(SEALED_PRESERVES, PRESERVES)
+        tag(EMPTY_JARS)
             .add(
                 TFCItems.EMPTY_JAR,
                 TFCItems.EMPTY_JAR_WITH_LID
             );
+        tag(FILLED_JARS).addTags(SEALED_PRESERVES, PRESERVES);
+        tag(JARS).addTags(EMPTY_JARS, FILLED_JARS);
         tag(SWEETENERS).add(Items.SUGAR);
         tag(BOWLS).add(Items.BOWL, TFCBlocks.CERAMIC_BOWL);
         tag(SALAD_BOWLS).addTag(BOWLS);

--- a/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
+++ b/src/data/java/net/dries007/tfc/data/providers/BuiltinItemTags.java
@@ -168,8 +168,8 @@ public class BuiltinItemTags extends TagsProvider<Item> implements Accessors
         tag(USABLE_IN_SOUP)
             .addTags(FRUITS, VEGETABLES, MEATS, COOKED_MEATS)
             .add(Food.COOKED_RICE);
-        tag(USABLE_IN_SANDWICH).addTags(VEGETABLES, COOKED_MEATS, DAIRY);
-        tag(USABLE_IN_JAM_SANDWICH).addTags(COOKED_MEATS, DAIRY, PRESERVES);
+        tag(USABLE_IN_SANDWICH).addTags(VEGETABLES, COOKED_MEATS, COOKED_FISH, DAIRY);
+        tag(USABLE_IN_JAM_SANDWICH).addTags(COOKED_MEATS, COOKED_FISH, DAIRY, PRESERVES, JAM);
         tag(CAN_BE_SALTED).addTags(MEATS, COOKED_MEATS);
         tag(PIG_FOOD).addTag(FOODS);
         tag(COW_FOOD).addTag(GRAINS);

--- a/src/generated/resources/data/tfc/tags/item/foods/empty_jars.json
+++ b/src/generated/resources/data/tfc/tags/item/foods/empty_jars.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "tfc:empty_jar",
+    "tfc:empty_jar_with_lid"
+  ]
+}

--- a/src/generated/resources/data/tfc/tags/item/foods/filled_jars.json
+++ b/src/generated/resources/data/tfc/tags/item/foods/filled_jars.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "#tfc:foods/sealed_preserves",
+    "#tfc:foods/preserves"
+  ]
+}

--- a/src/generated/resources/data/tfc/tags/item/foods/jars.json
+++ b/src/generated/resources/data/tfc/tags/item/foods/jars.json
@@ -1,8 +1,6 @@
 {
   "values": [
-    "#tfc:foods/sealed_preserves",
-    "#tfc:foods/preserves",
-    "tfc:empty_jar",
-    "tfc:empty_jar_with_lid"
+    "#tfc:foods/empty_jars",
+    "#tfc:foods/filled_jars"
   ]
 }

--- a/src/generated/resources/data/tfc/tags/item/usable_in_jam_sandwich.json
+++ b/src/generated/resources/data/tfc/tags/item/usable_in_jam_sandwich.json
@@ -1,7 +1,9 @@
 {
   "values": [
     "#c:foods/cooked_meat",
+    "#c:foods/cooked_fish",
     "#c:foods/dairy",
-    "#tfc:foods/preserves"
+    "#tfc:foods/preserves",
+    "#tfc:foods/jam"
   ]
 }

--- a/src/generated/resources/data/tfc/tags/item/usable_in_sandwich.json
+++ b/src/generated/resources/data/tfc/tags/item/usable_in_sandwich.json
@@ -2,6 +2,7 @@
   "values": [
     "#c:foods/vegetable",
     "#c:foods/cooked_meat",
+    "#c:foods/cooked_fish",
     "#c:foods/dairy"
   ]
 }

--- a/src/generated/resources/data/tfc/tfc/item_size/empty_jars.json
+++ b/src/generated/resources/data/tfc/tfc/item_size/empty_jars.json
@@ -1,12 +1,7 @@
 {
-  "ingredient": [
-    {
-      "item": "tfc:empty_jar"
-    },
-    {
-      "item": "tfc:empty_jar_with_lid"
-    }
-  ],
-  "size": "normal",
-  "weight": "light"
+  "ingredient": {
+    "tag": "tfc:foods/empty_jars"
+  },
+  "size": "tiny",
+  "weight": "medium"
 }

--- a/src/generated/resources/data/tfc/tfc/item_size/empty_jars.json
+++ b/src/generated/resources/data/tfc/tfc/item_size/empty_jars.json
@@ -2,6 +2,6 @@
   "ingredient": {
     "tag": "tfc:foods/empty_jars"
   },
-  "size": "tiny",
+  "size": "normal",
   "weight": "medium"
 }

--- a/src/generated/resources/data/tfc/tfc/item_size/filled_jars.json
+++ b/src/generated/resources/data/tfc/tfc/item_size/filled_jars.json
@@ -2,6 +2,6 @@
   "ingredient": {
     "tag": "tfc:foods/filled_jars"
   },
-  "size": "very_large",
+  "size": "normal",
   "weight": "heavy"
 }

--- a/src/generated/resources/data/tfc/tfc/item_size/filled_jars.json
+++ b/src/generated/resources/data/tfc/tfc/item_size/filled_jars.json
@@ -1,0 +1,7 @@
+{
+  "ingredient": {
+    "tag": "tfc:foods/filled_jars"
+  },
+  "size": "very_large",
+  "weight": "heavy"
+}

--- a/src/generated/resources/data/tfc/tfc/item_size/jars.json
+++ b/src/generated/resources/data/tfc/tfc/item_size/jars.json
@@ -1,7 +1,0 @@
-{
-  "ingredient": {
-    "tag": "tfc:foods/jars"
-  },
-  "size": "normal",
-  "weight": "very_heavy"
-}

--- a/src/main/java/net/dries007/tfc/common/TFCTags.java
+++ b/src/main/java/net/dries007/tfc/common/TFCTags.java
@@ -349,6 +349,8 @@ public class TFCTags
         public static final TagKey<Item> JAM = tag("foods/jam");
         public static final TagKey<Item> JARRED_FOOD = tag("foods/jarred_food");
         public static final TagKey<Item> SEALED_JARRED_FOOD = tag("foods/sealed_jarred_food");
+        public static final TagKey<Item> EMPTY_JARS = tag("foods/empty_jars");
+        public static final TagKey<Item> FILLED_JARS = tag("foods/filled_jars");
         /* Includes preserves, sealed preserves, and also empty jars (with and without lid) */
         public static final TagKey<Item> JARS = tag("foods/jars");
         public static final TagKey<Item> SWEETENERS = tag("foods/sweeteners");

--- a/src/main/java/net/dries007/tfc/common/player/IPlayerInfo.java
+++ b/src/main/java/net/dries007/tfc/common/player/IPlayerInfo.java
@@ -157,4 +157,9 @@ public interface IPlayerInfo
      * @param info The old info for the dead player
      */
     void copyOnDeath(IPlayerInfo info);
+
+    /**
+     * Force an update packet to be sent to the client
+     */
+    void forceUpdate();
 }

--- a/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
+++ b/src/main/java/net/dries007/tfc/common/player/PlayerInfo.java
@@ -390,6 +390,12 @@ public final class PlayerInfo extends net.minecraft.world.food.FoodData implemen
         tag.putLong("sleep", sleepTick);
     }
 
+    @Override
+    public void forceUpdate()
+    {
+        modified = true;
+    }
+
     // ===== Forward FoodData to original ===== //
 
 

--- a/src/main/java/net/dries007/tfc/common/recipes/RecipeHelpers.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/RecipeHelpers.java
@@ -82,6 +82,15 @@ public final class RecipeHelpers
         return CRAFTING_INPUT.get();
     }
 
+    /**
+     * Produces a {@code NonNullList} of the items that should remain after completing a recipe, taking an {@link ItemStackProvider} into account.
+     * For all items in the recipe that are not the primary input, we resort to the defined remainder of the item, if it exists
+     *
+     * @param input The items involved in the recipe
+     * @param provider A provider for an item that should have a non-default remainder
+     * @param primaryInput The item that should have a non-default remainder
+     * @return A list containing the remaining {@link ItemStack}s after a recipe has been completed
+     */
     public static NonNullList<ItemStack> getRemainderItemsWithProvider(CraftingInput input, ItemStackProvider provider, ItemStack primaryInput)
     {
         final NonNullList<ItemStack> results = NonNullList.withSize(input.size(), ItemStack.EMPTY);
@@ -94,8 +103,12 @@ public final class RecipeHelpers
                 if (!outputStack.isEmpty())
                 {
                     results.set(i, outputStack);
-                    break;
                 }
+            }
+            else if (stack.hasCraftingRemainingItem())
+            {
+                final ItemStack outputStack = stack.getCraftingRemainingItem();
+                results.set(i, outputStack);
             }
         }
         return results;


### PR DESCRIPTION
- Fixed cooked fish not being valid ingredients for sandwiches
- Fixed jam items not being valid ingredients for jam sandwiches, which had previously made it impossible to make sandwiches with multiple pieces of jam
- Fixed jam sandwich recipes using jam in a jar from consuming not just the jam, but the entire jar
- Made the `#tfc:foods/jars` item tag the union of two new item tags `#tfc:foods/empty_jars` and `#tfc:foods/filled_jars`
- Changed item weight of empty and filled jars to be the same as in 1.20.1
- Added a new method to `IPlayerInfo` to make it easier for addons to force the server to update the client nutrition