### PR TITLE
Calendar fixes / Additions

### DIFF
--- a/resources/constants.py
+++ b/resources/constants.py
@@ -1469,7 +1469,7 @@ DEFAULT_LANG = {
 
     # Commands
 
-    'tfc.commands.disabled_by_tfc': 'This command has been disabled by TerraFirmaCraft, use /time instead',
+    'tfc.commands.disabled_by_tfc': 'This command has been disabled by TerraFirmaCraft, use "%s" instead',
     'tfc.commands.time.set_day_length': 'Day length has been set to %s minutes/day',
     'tfc.commands.time.set_day_length_disabled': 'Daylight cycle has been disabled',
     'tfc.commands.time.set_month_length': 'Month length has been set to %s days/month',

--- a/src/main/java/net/dries007/tfc/client/ClientCalendar.java
+++ b/src/main/java/net/dries007/tfc/client/ClientCalendar.java
@@ -6,6 +6,8 @@
 
 package net.dries007.tfc.client;
 
+import net.minecraft.client.Minecraft;
+
 import net.dries007.tfc.util.calendar.Calendar;
 
 public final class ClientCalendar extends Calendar
@@ -16,7 +18,12 @@ public final class ClientCalendar extends Calendar
      */
     void onClientTick()
     {
-        playerTicks++;
-        advanceCalendarTick();
+        // Tick freeze is automatically synchronized to the client already, we just have to fetch it.
+        // Keep in mind that the level will never be null, since the client must be in a world to get ticked
+        if (!Minecraft.getInstance().level.tickRateManager().isFrozen())
+        {
+            playerTicks++;
+            advanceCalendarTick();
+        }
     }
 }

--- a/src/main/java/net/dries007/tfc/common/commands/TFCCommands.java
+++ b/src/main/java/net/dries007/tfc/common/commands/TFCCommands.java
@@ -22,7 +22,7 @@ import net.dries007.tfc.util.Helpers;
 @SuppressWarnings("unused")
 public final class TFCCommands
 {
-    private static final Component DISABLED = Component.translatable("tfc.commands.disabled_by_tfc");
+    private static final String DISABLED = "tfc.commands.disabled_by_tfc";
 
     public static void registerCommands(CommandDispatcher<CommandSourceStack> dispatcher, CommandBuildContext context)
     {
@@ -50,7 +50,16 @@ public final class TFCCommands
             .removeIf(node -> node.getName().equals("day"));
         dispatcher.register(Commands.literal("neoforge")
             .then(Commands.literal("day")
-                .executes(c -> { c.getSource().sendFailure(DISABLED); return 0; })));
+                .executes(c -> { c.getSource().sendFailure(Component.translatable(DISABLED, "/time")); return 0; })));
+
+        // We do the same with the `/gamerule doDaylightCycle` command, since this has been effectively replaced by `/time set dayLength` already
+        dispatcher.getRoot()
+            .getChild("gamerule")
+            .getChildren()
+            .removeIf(node -> node.getName().equals("doDaylightCycle"));
+        dispatcher.register(Commands.literal("gamerule")
+            .then(Commands.literal("doDaylightCycle")
+                .executes(c -> { c.getSource().sendFailure(Component.translatable(DISABLED, "/time set dayLength")); return 0; })));
     }
 
     public static <S extends SharedSuggestionProvider> Supplier<SuggestionProvider<S>> register(String id, SuggestionProvider<SharedSuggestionProvider> provider)

--- a/src/main/java/net/dries007/tfc/util/calendar/ServerCalendar.java
+++ b/src/main/java/net/dries007/tfc/util/calendar/ServerCalendar.java
@@ -118,7 +118,7 @@ public final class ServerCalendar extends Calendar
      */
     void onServerTick()
     {
-        if (arePlayersLoggedOn)
+        if (!getServer().tickRateManager().isFrozen() && arePlayersLoggedOn)
         {
             playerTicks++;
         }
@@ -135,7 +135,7 @@ public final class ServerCalendar extends Calendar
      */
     void onOverworldTick(ServerLevel level)
     {
-        if (arePlayersLoggedOn)
+        if (!getServer().tickRateManager().isFrozen() && arePlayersLoggedOn)
         {
             advanceCalendarTick();
             if ((calendarTicks & 0x100) == 0) checkIfInTheFuture(level);

--- a/src/main/resources/assets/tfc/lang/de_de.json
+++ b/src/main/resources/assets/tfc/lang/de_de.json
@@ -555,7 +555,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/en_us.json
+++ b/src/main/resources/assets/tfc/lang/en_us.json
@@ -554,7 +554,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/es_es.json
+++ b/src/main/resources/assets/tfc/lang/es_es.json
@@ -554,7 +554,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/ja_jp.json
+++ b/src/main/resources/assets/tfc/lang/ja_jp.json
@@ -554,7 +554,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/ko_kr.json
+++ b/src/main/resources/assets/tfc/lang/ko_kr.json
@@ -555,7 +555,7 @@
   "config.jade.plugin_tfc.ocelot": "오실롯",
   "config.jade.plugin_tfc.rabbit": "토끼",
   "config.jade.plugin_tfc.fishing_hook": "낚싯 바늘",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/pl_pl.json
+++ b/src/main/resources/assets/tfc/lang/pl_pl.json
@@ -554,7 +554,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Króli",
   "config.jade.plugin_tfc.fishing_hook": "Haczyk na ryby",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/pt_br.json
+++ b/src/main/resources/assets/tfc/lang/pt_br.json
@@ -554,7 +554,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/ru_ru.json
+++ b/src/main/resources/assets/tfc/lang/ru_ru.json
@@ -559,7 +559,7 @@
   "config.jade.plugin_tfc.ocelot": "Оцелот",
   "config.jade.plugin_tfc.rabbit": "Кролик",
   "config.jade.plugin_tfc.fishing_hook": "Рыболовный крючок",
-  "tfc.commands.disabled_by_tfc": "Эта команда была отключена TerraFirmaCraft, используйте /time вместо неё",
+  "tfc.commands.disabled_by_tfc": "Эта команда была отключена TerraFirmaCraft, используйте \"%s\" вместо неё",
   "tfc.commands.time.set_day_length": "Длина дня установлена на %s минут/день",
   "tfc.commands.time.set_day_length_disabled": "Цикл светового дня отключён",
   "tfc.commands.time.set_month_length": "Длина месяца установлена на %s дней/месяц",

--- a/src/main/resources/assets/tfc/lang/tr_tr.json
+++ b/src/main/resources/assets/tfc/lang/tr_tr.json
@@ -554,7 +554,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/uk_ua.json
+++ b/src/main/resources/assets/tfc/lang/uk_ua.json
@@ -562,7 +562,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/zh_cn.json
+++ b/src/main/resources/assets/tfc/lang/zh_cn.json
@@ -563,7 +563,7 @@
   "config.jade.plugin_tfc.ocelot": "豹猫",
   "config.jade.plugin_tfc.rabbit": "兔",
   "config.jade.plugin_tfc.fishing_hook": "鱼钩",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/zh_hk.json
+++ b/src/main/resources/assets/tfc/lang/zh_hk.json
@@ -561,7 +561,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",

--- a/src/main/resources/assets/tfc/lang/zh_tw.json
+++ b/src/main/resources/assets/tfc/lang/zh_tw.json
@@ -561,7 +561,7 @@
   "config.jade.plugin_tfc.ocelot": "Ocelot",
   "config.jade.plugin_tfc.rabbit": "Rabbit",
   "config.jade.plugin_tfc.fishing_hook": "Fishing Hook",
-  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use /time instead",
+  "tfc.commands.disabled_by_tfc": "This command has been disabled by TerraFirmaCraft, use \"%s\" instead",
   "tfc.commands.time.set_day_length": "Day length has been set to %s minutes/day",
   "tfc.commands.time.set_day_length_disabled": "Daylight cycle has been disabled",
   "tfc.commands.time.set_month_length": "Month length has been set to %s days/month",


### PR DESCRIPTION
- Stops the calendar from continuing to tick even when the ticks are frozen, on both client and server side
- Disabled the `/gamerule doDaylightCycle` command and replaced it with a notice to use `/time set dayLength` instead