### PR TITLE
Fixed EmptyBowlModifier returning wrong input parameter stack

### DIFF
--- a/src/main/java/net/dries007/tfc/common/recipes/outputs/EmptyBowlModifier.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/outputs/EmptyBowlModifier.java
@@ -18,7 +18,7 @@ public enum EmptyBowlModifier implements ItemStackModifier
     @Override
     public ItemStack apply(ItemStack stack, ItemStack input, Context context)
     {
-        return stack.getOrDefault(TFCComponents.BOWL, Bowl.DISPLAY).stack();
+        return input.getOrDefault(TFCComponents.BOWL, Bowl.DISPLAY).stack();
     }
 
     @Override


### PR DESCRIPTION
https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues/3218

the EmptyBowlModifier.java file was returning the wrong Input parameter ItemStack. 
Fixed it to return the correct one.