### PR TITLE
Make forests respect new climate params

### DIFF
--- a/src/main/java/net/dries007/tfc/world/feature/tree/ForestConfig.java
+++ b/src/main/java/net/dries007/tfc/world/feature/tree/ForestConfig.java
@@ -50,17 +50,25 @@ public record ForestConfig(HolderSet<ConfiguredFeature<?, ?>> entries) implement
             ).apply(instance, Entry::new);
         });
 
-        public boolean isValid(float temperature, float groundwater, float rainVar)
+        public boolean isValid(float temperature, float groundwater, float rainVar, float elevation)
         {
             final float adjustedRainVar = climate.isRainVarianceAbsolute() ? Math.abs(rainVar) : rainVar;
             return groundwater >= climate.getMinGroundwater() && groundwater <= climate.getMaxGroundwater()
                 && adjustedRainVar >= climate.getMinRainVariance() && adjustedRainVar <= climate().getMaxRainVariance()
-                && temperature >= climate.getMinTemp() && temperature <= climate.getMaxTemp();
+                && temperature >= climate.getMinTemp() && temperature <= climate.getMaxTemp()
+                && elevation >= climate.getMinElevation() && elevation <= climate.getMaxElevation();
         }
 
-        public float distanceFromMean(float temperature, float groundwater, float rainVar)
+        public float distanceFromMean(float temperature, float groundwater, float rainVar, float elevation)
         {
-            return (groundwater + 10 * temperature - 10 * getAverageTemp() - getAverageGroundwater()) / 2;
+            final float adjustedRainVar = climate.isRainVarianceAbsolute() ? Math.abs(rainVar) : rainVar;
+
+            final float tempDist = (temperature - getAverageTemp()) * 10f; // Normalize everything to a 0-500 scale
+            final float waterDist = groundwater - getAverageGroundwater();
+            final float rainVarDist = (adjustedRainVar - getAverageRainVar()) * 250f;
+            final float elevationDistance = (elevation - getAverageElevation()) * 5;
+
+            return tempDist + waterDist + rainVarDist + elevationDistance;
         }
 
         public float getAverageTemp()
@@ -76,6 +84,16 @@ public record ForestConfig(HolderSet<ConfiguredFeature<?, ?>> entries) implement
         public float getAverageGroundwater()
         {
             return (climate.getMaxGroundwater() - climate.getMinGroundwater()) / 2;
+        }
+
+        public float getAverageRainVar()
+        {
+            return (climate.getMaxRainVariance() - climate.getMinRainVariance()) / 2;
+        }
+
+        public float getAverageElevation()
+        {
+            return (climate.getMaxElevation() - climate.getMinElevation()) / 2f;
         }
 
         public ConfiguredFeature<?, ?> getFeature()

--- a/src/main/java/net/dries007/tfc/world/feature/tree/ForestFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/tree/ForestFeature.java
@@ -81,20 +81,17 @@ public class ForestFeature extends Feature<ForestConfig>
 
     private boolean placeTree(WorldGenLevel level, ChunkGenerator generator, RandomSource random, BlockPos chunkBlockPos, ForestConfig config, ChunkData data, BlockPos.MutableBlockPos mutablePos, ForestType typeConfig)
     {
+        final int chunkX = chunkBlockPos.getX();
+        final int chunkZ = chunkBlockPos.getZ();
+
+        mutablePos.set(chunkX + random.nextInt(16), 0, chunkZ + random.nextInt(16));
+        mutablePos.setY(level.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, mutablePos.getX(), mutablePos.getZ()));
         final ForestConfig.Entry entry = getTree(data, random, config, mutablePos, typeConfig, level);
         if (entry != null)
         {
-            final int chunkX = chunkBlockPos.getX();
-            final int chunkZ = chunkBlockPos.getZ();
-
-            mutablePos.set(chunkX + random.nextInt(16), 0, chunkZ + random.nextInt(16));
             if (entry.floating())
             {
                 mutablePos.setY(level.getHeight(Heightmap.Types.WORLD_SURFACE_WG, mutablePos.getX(), mutablePos.getZ()) + random.nextInt(2));
-            }
-            else
-            {
-                mutablePos.setY(level.getHeight(Heightmap.Types.OCEAN_FLOOR_WG, mutablePos.getX(), mutablePos.getZ()));
             }
             ConfiguredFeature<?, ?> feature;
             final int oldChance = entry.oldGrowthChance();

--- a/src/main/java/net/dries007/tfc/world/feature/tree/ForestFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/tree/ForestFeature.java
@@ -349,10 +349,11 @@ public class ForestFeature extends Feature<ForestConfig>
         final float rainVariance = chunkData.getRainVariance(pos) * (SolarCalculator.getInNorthernHemisphere(pos, level.getLevel()) ? 1f : -1f);
 
         final float groundwater = chunkData.getGroundwater(pos);
-        final float averageTemperature = EnvironmentHelpers.adjustAvgTempForElev(pos.getY(), chunkData.getAverageSeaLevelTemp(pos));
+        final int elevation = pos.getY();
+        final float averageTemperature = EnvironmentHelpers.adjustAvgTempForElev(elevation, chunkData.getAverageSeaLevelTemp(pos));
         final List<ForestConfig.Entry> entries = config.entries().stream().map(configuredFeature -> configuredFeature.value().config()).map(cfg -> (ForestConfig.Entry) cfg)
-            .filter(entry -> entry.isValid(averageTemperature, groundwater, rainVariance))
-            .sorted(Comparator.comparingDouble(entry -> entry.distanceFromMean(averageTemperature, groundwater, rainVariance)))
+            .filter(entry -> entry.isValid(averageTemperature, groundwater, rainVariance, elevation))
+            .sorted(Comparator.comparingDouble(entry -> entry.distanceFromMean(averageTemperature, groundwater, rainVariance, elevation)))
             .collect(Collectors.toList());
 
         if (entries.isEmpty()) return null;


### PR DESCRIPTION
So basically:
1. Make forests correctly account for rain-variance distance from average when considering suitability of a tree
2. Make forests treat elevation as a full climate param, similar to temp, groundwater, and rainvar. No effect in vanilla TFC as all trees have the default elevation range, but useful for addon devs (like yours truly)