### PR TITLE
Makes water wheel model more easily extensible

### DIFF
--- a/src/main/java/net/dries007/tfc/client/render/blockentity/LoomBlockEntityRenderer.java
+++ b/src/main/java/net/dries007/tfc/client/render/blockentity/LoomBlockEntityRenderer.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
+import javax.annotation.Nullable;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
@@ -28,14 +29,12 @@ import net.dries007.tfc.util.Helpers;
 
 public class LoomBlockEntityRenderer implements BlockEntityRenderer<LoomBlockEntity>
 {
-    public static final Map<Block, ResourceLocation> TEXTURES = RenderHelpers.mapOf(map ->
-        TFCBlocks.WOODS.forEach((wood, m) ->
-            map.accept(m.get(Wood.BlockType.LOOM), Helpers.identifier("block/wood/planks/" + wood.getSerializedName()))));
-
     @Override
     public void render(LoomBlockEntity loom, float partialTicks, PoseStack poseStack, MultiBufferSource buffer, int combinedLight, int combinedOverlay)
     {
-        final ResourceLocation texture = TEXTURES.get(loom.getBlockState().getBlock());
+        Block block = loom.getBlockState().getBlock();
+        assert block instanceof TFCLoomBlock;
+        final @Nullable ResourceLocation texture = ((TFCLoomBlock) block).getTextureLocation();
         if (texture == null)
         {
             return;

--- a/src/main/java/net/dries007/tfc/client/render/blockentity/WaterWheelBlockEntityRenderer.java
+++ b/src/main/java/net/dries007/tfc/client/render/blockentity/WaterWheelBlockEntityRenderer.java
@@ -29,10 +29,6 @@ import net.dries007.tfc.util.Helpers;
 
 public class WaterWheelBlockEntityRenderer implements BlockEntityRenderer<WaterWheelBlockEntity>
 {
-    public static final Map<Block, ResourceLocation> TEXTURES = RenderHelpers.mapOf(map ->
-        TFCBlocks.WOODS.forEach((wood, m) ->
-            map.accept(m.get(Wood.BlockType.WATER_WHEEL), Helpers.identifier("textures/entity/water_wheel/" + wood.getSerializedName() + ".png"))));
-
     private final WaterWheelModel model;
 
     public WaterWheelBlockEntityRenderer(BlockEntityRendererProvider.Context context)
@@ -44,7 +40,8 @@ public class WaterWheelBlockEntityRenderer implements BlockEntityRenderer<WaterW
     public void render(WaterWheelBlockEntity wheel, float partialTick, PoseStack stack, MultiBufferSource buffer, int packedLight, int packedOverlay)
     {
         final Block block = wheel.getBlockState().getBlock();
-        final @Nullable ResourceLocation texture = TEXTURES.get(block);
+        assert block instanceof WaterWheelBlock;
+        final @Nullable ResourceLocation texture = ((WaterWheelBlock) block).getTextureLocation();
         if (wheel.getLevel() == null || texture == null)
         {
             return;

--- a/src/main/java/net/dries007/tfc/common/blocks/rotation/WaterWheelBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/rotation/WaterWheelBlock.java
@@ -9,6 +9,7 @@ package net.dries007.tfc.common.blocks.rotation;
 import java.util.function.Supplier;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -35,14 +36,21 @@ public class WaterWheelBlock extends ExtendedBlock implements EntityBlockExtensi
     public static final VoxelShape SHAPE = box(0, 0.125, 0, 16, 15.875, 16);
 
     private final Supplier<? extends AxleBlock> axle;
+    private final ResourceLocation textureLocation;
 
-    public WaterWheelBlock(ExtendedProperties properties, Supplier<? extends AxleBlock> axle)
+    public WaterWheelBlock(ExtendedProperties properties, Supplier<? extends AxleBlock> axle, ResourceLocation textureLocation)
     {
         super(properties);
 
         this.axle = axle;
+        this.textureLocation = textureLocation;
 
         registerDefaultState(getStateDefinition().any().setValue(AXIS, Direction.Axis.X));
+    }
+
+    public ResourceLocation getTextureLocation()
+    {
+        return textureLocation;
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/TFCLoomBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/TFCLoomBlock.java
@@ -50,9 +50,12 @@ public class TFCLoomBlock extends BottomSupportedDeviceBlock implements IFluidLo
     private static final VoxelShape SHAPE_SOUTH = box(1, 0, 2, 15, 16, 8);
     private static final VoxelShape SHAPE_NORTH = box(1, 0, 8, 15, 16, 14);
 
-    public TFCLoomBlock(ExtendedProperties properties)
+    private final ResourceLocation textureLocation;
+
+    public TFCLoomBlock(ExtendedProperties properties, ResourceLocation textureLocation)
     {
         super(properties, InventoryRemoveBehavior.DROP);
+        this.textureLocation = textureLocation;
         registerDefaultState(getStateDefinition().any().setValue(FACING, Direction.NORTH).setValue(getFluidProperty(), getFluidProperty().keyFor(Fluids.EMPTY)));
     }
 
@@ -135,5 +138,10 @@ public class TFCLoomBlock extends BottomSupportedDeviceBlock implements IFluidLo
     protected boolean isPathfindable(BlockState state, PathComputationType pathComputationType)
     {
         return false;
+    }
+
+    public ResourceLocation getTextureLocation()
+    {
+        return textureLocation;
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/Wood.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/Wood.java
@@ -212,7 +212,7 @@ public enum Wood implements RegistryWood
         WORKBENCH(wood -> new TFCCraftingTableBlock(properties(wood).strength(2.5F).flammableLikeLogs())),
         TRAPPED_CHEST((self, wood) -> new TFCTrappedChestBlock(properties(wood).strength(2.5F).flammableLikeLogs().blockEntity(TFCBlockEntities.TRAPPED_CHEST).clientTicks(ChestBlockEntity::lidAnimateTick), wood.getSerializedName()), ChestBlockItem::new),
         CHEST((self, wood) -> new TFCChestBlock(properties(wood).strength(2.5F).flammableLikeLogs().blockEntity(TFCBlockEntities.CHEST).clientTicks(ChestBlockEntity::lidAnimateTick), wood.getSerializedName()), ChestBlockItem::new),
-        LOOM((self, wood) -> new TFCLoomBlock(properties(wood).strength(2.5F).noOcclusion().flammableLikePlanks().blockEntity(TFCBlockEntities.LOOM).ticks(LoomBlockEntity::tick))),
+        LOOM((self, wood) -> new TFCLoomBlock(properties(wood).strength(2.5F).noOcclusion().flammableLikePlanks().blockEntity(TFCBlockEntities.LOOM).ticks(LoomBlockEntity::tick), self.planksTexture(wood))),
         SLUICE(wood -> new SluiceBlock(properties(wood).strength(3F).noOcclusion().flammableLikeLogs().blockEntity(TFCBlockEntities.SLUICE).serverTicks(SluiceBlockEntity::serverTick))),
         SIGN(wood -> new TFCStandingSignBlock(properties(wood).noCollission().strength(1F).flammableLikePlanks().blockEntity(TFCBlockEntities.SIGN).ticks(SignBlockEntity::tick), wood.getVanillaWoodType())),
         WALL_SIGN(wood -> new TFCWallSignBlock(properties(wood).noCollission().strength(1F).dropsLike(wood.getBlock(SIGN)).flammableLikePlanks().blockEntity(TFCBlockEntities.SIGN).ticks(SignBlockEntity::tick), wood.getVanillaWoodType())),

--- a/src/main/java/net/dries007/tfc/common/blocks/wood/Wood.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/wood/Wood.java
@@ -227,7 +227,7 @@ public enum Wood implements RegistryWood
         CLUTCH((self, wood) -> new ClutchBlock(properties(wood).strength(2.5F).flammableLikeLogs().pushReaction(PushReaction.DESTROY).blockEntity(TFCBlockEntities.CLUTCH), getBlock(wood, self.axle()))),
         GEAR_BOX((self, wood) -> new GearBoxBlock(properties(wood).strength(2f).noOcclusion().blockEntity(TFCBlockEntities.GEAR_BOX), getBlock(wood, self.axle()))),
         WINDMILL((self, wood) -> new WindmillBlock(properties(wood).strength(9f).noOcclusion().blockEntity(TFCBlockEntities.WINDMILL).ticks(WindmillBlockEntity::serverTick, WindmillBlockEntity::clientTick), getBlock(wood, self.axle()))),
-        WATER_WHEEL((self, wood) -> new WaterWheelBlock(properties(wood).strength(9f).noOcclusion().blockEntity(TFCBlockEntities.WATER_WHEEL).ticks(WaterWheelBlockEntity::serverTick, WaterWheelBlockEntity::clientTick), getBlock(wood, self.axle())))
+        WATER_WHEEL((self, wood) -> new WaterWheelBlock(properties(wood).strength(9f).noOcclusion().blockEntity(TFCBlockEntities.WATER_WHEEL).ticks(WaterWheelBlockEntity::serverTick, WaterWheelBlockEntity::clientTick), getBlock(wood, self.axle()), self.waterWheelTexture(wood)))
         ;
 
         private static ExtendedProperties properties(RegistryWood wood)
@@ -305,6 +305,11 @@ public enum Wood implements RegistryWood
         private ResourceLocation planksTexture(RegistryWood wood)
         {
             return Helpers.identifier("block/wood/planks/" + wood.getSerializedName());
+        }
+
+        private ResourceLocation waterWheelTexture(RegistryWood wood)
+        {
+            return Helpers.identifier("textures/entity/water_wheel/" + wood.getSerializedName() + ".png");
         }
 
         private BlockType twig() { return TWIG; }


### PR DESCRIPTION
For when additional wood types are given the block entity. Based on how the Axle block entity renderer works. I can always just register my own block entity renderer for the AFC waterwheels instead, this just feels more consistent to me.