### PR TITLE
Bandaid Fix for hoppers extracting infinite compost

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/ComposterBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/ComposterBlockEntity.java
@@ -54,7 +54,15 @@ public class ComposterBlockEntity extends InventoryBlockEntity<ItemStackHandler>
     public void randomTick()
     {
         assert level != null;
-        if (green >= MAX_AMOUNT && brown >= MAX_AMOUNT & !isRotten())
+
+        // If the compost is ready but the item has been already been extracted, empty the composter
+        // TODO: This avoids item duplications, but does not instantaneously update the blockstate when an item is extracted
+        if (isReady() && inventory.getStackInSlot(0).isEmpty())
+        {
+            reset();
+            markForSync();
+        }
+        else if (green >= MAX_AMOUNT && brown >= MAX_AMOUNT & !isRotten())
         {
             if (getTicksSinceUpdate() > getReadyTicks())
             {


### PR DESCRIPTION
The issue with this approach is that it does not immediately empty the composter on the item being extracted, which is visually confusing. This class should probably be re-written so that this check is run whenever an item is removed. But, I'm not sure how to do that, and this does work as an immediate fix.

closes #3327
