### PR TITLE
Fixed vessel tooltips not appearing, and added error messages to redirect users trying to set weather via the `/weather ...` commands

### DIFF
--- a/src/main/java/net/dries007/tfc/common/commands/WeatherCommand.java
+++ b/src/main/java/net/dries007/tfc/common/commands/WeatherCommand.java
@@ -16,6 +16,8 @@ import net.dries007.tfc.util.tracker.WorldTracker;
 
 public class WeatherCommand
 {
+    private static final String DISABLED = "tfc.commands.disabled_by_tfc";
+
     public static LiteralArgumentBuilder<CommandSourceStack> create()
     {
         return Commands.literal("weather").requires(source -> source.hasPermission(2))
@@ -24,6 +26,12 @@ public class WeatherCommand
             )
             .then(Commands.literal("disable")
                 .executes(context -> setEnabled(context.getSource(), false))
+            )
+            .then(Commands.literal("clear")
+                .executes(context -> { context.getSource().sendFailure(Component.translatable(DISABLED, "/time set clear")); return 0; })
+            )
+            .then(Commands.literal("rain")
+                .executes(context -> { context.getSource().sendFailure(Component.translatable(DISABLED, "/time set rain")); return 0; })
             );
     }
 

--- a/src/main/java/net/dries007/tfc/common/items/VesselItem.java
+++ b/src/main/java/net/dries007/tfc/common/items/VesselItem.java
@@ -209,7 +209,7 @@ public class VesselItem extends Item
     public void appendHoverText(ItemStack stack, TooltipContext context, List<Component> tooltip, TooltipFlag tooltipFlag)
     {
         final @Nullable Vessel vessel = Vessel.get(stack);
-        if (vessel != null && vessel.isEmpty()) // Only show the 'contents' label if we actually have contents
+        if (vessel != null && !vessel.isEmpty()) // Only show the 'contents' label if we actually have contents
         {
             if (vessel.isInventory())
             {
@@ -219,7 +219,7 @@ public class VesselItem extends Item
                     Helpers.addInventoryTooltipInfo(vessel.contents(), tooltip);
                 }
             }
-            else if (!vessel.isEmpty())
+            else
             {
                 tooltip.add(Component.translatable("tfc.tooltip.small_vessel.contents").withStyle(ChatFormatting.DARK_GREEN));
                 tooltip.add(Tooltips.fluidUnitsAndCapacityOf(vessel.getFluidInTank(0).getHoverName(), vessel.getFluidInTank(0).getAmount(), containerInfo.fluidCapacity())


### PR DESCRIPTION
- Fixed vessel tooltips not appearing, and removed a superfluous check for whether the vessel is empty
- Added commands `/weather clear` and `/weather rain` to give error messages redirecting users to use the `/time set ...` commands, since multiple people in the discord thought TFC just outright removed the ability to set weather via command