### PR TITLE
Barrel tweaks

### DIFF
--- a/src/main/java/net/dries007/tfc/client/ClientEventHandler.java
+++ b/src/main/java/net/dries007/tfc/client/ClientEventHandler.java
@@ -982,6 +982,7 @@ public final class ClientEventHandler
         event.registerSpriteSet(TFCParticles.FLUID_FALL.get(), set -> FluidDripParticle.provider(set, FluidDripParticle.FluidFallAndLandParticle::new));
         event.registerSpriteSet(TFCParticles.FLUID_LAND.get(), set -> FluidDripParticle.provider(set, FluidDripParticle.FluidLandParticle::new));
         event.registerSpriteSet(TFCParticles.BARREL_DRIP.get(), set -> FluidDripParticle.provider(set, FluidDripParticle.BarrelDripParticle::new));
+        event.registerSpriteSet(TFCParticles.BARREL_SPILL.get(), set -> FluidDripParticle.provider(set, FluidDripParticle.BarrelSpillParticle::new));
 
         for (int i = 0; i < 5; i++)
         {

--- a/src/main/java/net/dries007/tfc/client/particle/FluidDripParticle.java
+++ b/src/main/java/net/dries007/tfc/client/particle/FluidDripParticle.java
@@ -197,6 +197,15 @@ public class FluidDripParticle extends TextureSheetParticle
         }
     }
 
+    public static class BarrelSpillParticle extends FluidFallAndLandParticle
+    {
+        public BarrelSpillParticle(ClientLevel level, double x, double y, double z, Fluid fluid)
+        {
+            super(level, x, y, z, fluid);
+            gravity = 0.06f;
+        }
+    }
+
     public interface FluidParticleFactory
     {
         FluidDripParticle create(ClientLevel level, double x, double y, double z, Fluid fluid);

--- a/src/main/java/net/dries007/tfc/client/particle/TFCParticles.java
+++ b/src/main/java/net/dries007/tfc/client/particle/TFCParticles.java
@@ -58,6 +58,7 @@ public final class TFCParticles
     public static final Id<ParticleType<FluidParticleOption>> FLUID_FALL = register("fluid_fall", FluidParticleOption::codec, FluidParticleOption::streamCodec);
     public static final Id<ParticleType<FluidParticleOption>> FLUID_LAND = register("fluid_land", FluidParticleOption::codec, FluidParticleOption::streamCodec);
     public static final Id<ParticleType<FluidParticleOption>> BARREL_DRIP = register("barrel_drip", FluidParticleOption::codec, FluidParticleOption::streamCodec);
+    public static final Id<ParticleType<FluidParticleOption>> BARREL_SPILL = register("barrel_spill", FluidParticleOption::codec, FluidParticleOption::streamCodec);
 
     public static final List<Id<SimpleParticleType>> SMOKES = List.of(SMOKE_0, SMOKE_1, SMOKE_2, SMOKE_3, SMOKE_4);
 

--- a/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
 import net.minecraft.world.level.material.Fluids;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.common.util.INBTSerializable;
 import net.neoforged.neoforge.fluids.FluidStack;
@@ -397,6 +398,27 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
         super.ejectInventory();
         assert level != null;
         inventory.excess.stream().filter(item -> !item.isEmpty()).forEach(item -> Helpers.spawnItem(level, worldPosition, item));
+
+        final FluidStack fluid = inventory.tank.getFluid();
+        if (level instanceof ServerLevel server && !fluid.isEmpty())
+        {
+            final double fill = (double) inventory.getFluidInTank(0).getAmount() / inventory.getTankCapacity(0);
+            final VoxelShape shape = getBlockState().getShape(level, worldPosition);
+            Helpers.playSound(level, worldPosition, SoundEvents.PLAYER_SPLASH);
+
+            for (int i = 0; i < Math.ceil(25 * fill); i++)
+            {
+                RandomSource random = server.getRandom();
+                final double xMax = shape.max(Direction.Axis.X);
+                final double xMin = shape.min(Direction.Axis.X);
+                final double zMax = shape.max(Direction.Axis.Z);
+                final double zMin = shape.min(Direction.Axis.Z);
+                final double dx = xMin + (xMax - xMin) * random.nextDouble();
+                final double dy = shape.max(Direction.Axis.Y) * fill * random.nextDouble();
+                final double dz = zMin + (zMax - zMin) * random.nextDouble();
+                server.sendParticles(new FluidParticleOption(TFCParticles.BARREL_SPILL.get(), fluid.getFluid()), worldPosition.getX() + dx, worldPosition.getY() + dy, worldPosition.getZ() + dz, 1, 0, 0, 0, 1f);
+            }
+        }
     }
 
     public void tickPouring(Level level, BlockPos pos, boolean sealed, Direction facing)

--- a/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
@@ -344,6 +344,12 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
             inventory.setStackInSlot(SLOT_ITEM, iter.next()); // First slot goes into the item slot
             while (iter.hasNext()) inventory.excess.add(iter.next()); // Any others go into excess
             inventory.tank.setFluid(barrel.fluidContent().copy());
+
+            //TODO should we reset the recipe tick instead to prevent this?
+            // Currently, barrels are able to complete recipes while the barrel is in item form
+            // This does not change current behavior but prevents recipes from completing instantly when the barrel is picked up and placed again
+            sealedTick = barrel.sealedTick();
+            recipeTick = barrel.recipeTick();
         }
         super.applyImplicitComponents(components);
     }

--- a/src/main/resources/assets/tfc/particles/barrel_spill.json
+++ b/src/main/resources/assets/tfc/particles/barrel_spill.json
@@ -1,0 +1,5 @@
+{
+  "textures": [
+    "minecraft:drip_fall"
+  ]
+}


### PR DESCRIPTION
Adds liquid particles and plays a sound when barrels are broken while unsealed and holding fluid.
Currently, barrels can complete recipes while in item form and this does not change that. Let me know if that behavior should be changed.

Closes #3328