### PR TITLE
Fix kaolin heating recipe randomizing entire stacks at once

### DIFF
--- a/src/main/java/net/dries007/tfc/common/recipes/HeatingRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/HeatingRecipe.java
@@ -115,7 +115,7 @@ public class HeatingRecipe implements INoopInputRecipe, IRecipePredicate<ItemSta
      */
     public ItemStack assembleStacked(ItemStack inputStack, int stackSizeCap, boolean isDisplay)
     {
-        final ItemStack outputStack = isDisplay ? outputItem.getSingleStackDisplayOnly(inputStack) : outputItem.getSingleStack(inputStack);
+        final ItemStack outputStack = isDisplay ? outputItem.getStackDisplayOnly(inputStack) : outputItem.getStack(inputStack);
 
         // We always upgrade the heat regardless
         final @Nullable IHeat inputHeat = HeatCapability.get(inputStack);
@@ -124,9 +124,9 @@ public class HeatingRecipe implements INoopInputRecipe, IRecipePredicate<ItemSta
             HeatCapability.setTemperature(outputStack, inputHeat.getTemperature());
         }
 
-        // Set the stack size to the best possible (output count * input count), then limit to stack size / inventory limit
+        // Set the stack size to the best possible, then limit to stack size / inventory limit
         outputStack.setCount(Math.min(
-            outputStack.getCount() * inputStack.getCount(),
+            outputStack.getCount(),
             Math.min(outputStack.getMaxStackSize(), stackSizeCap)
         ));
 

--- a/src/main/java/net/dries007/tfc/common/recipes/outputs/ItemStackProvider.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/outputs/ItemStackProvider.java
@@ -126,6 +126,14 @@ public record ItemStackProvider(
     }
 
     /**
+     * {@link ItemStackProvider#getStack(ItemStack)} but for JEI
+     */
+    public ItemStack getStackDisplayOnly(ItemStack input)
+    {
+        return getStack(input, ItemStackModifier.Context.NO_RANDOM_CHANCE);
+    }
+
+    /**
      * Gets the output stack from this provider, for the given input stack, and allows providing a non-typical
      * context to the provider.
      * @return A new stack, possibly dependent on the input stack
@@ -133,6 +141,13 @@ public record ItemStackProvider(
     public ItemStack getStack(ItemStack input, ItemStackModifier.Context context)
     {
         ItemStack output = stack.copy();
+
+        // Since we might need to be able to apply modifiers to the entire output at once, set the count here.
+        if (!input.isEmpty())
+        {
+            output.setCount(output.getCount() * input.getCount());
+        }
+
         for (ItemStackModifier modifier : modifiers)
         {
             output = modifier.apply(output, input, context);


### PR DESCRIPTION
Fixes issue #3228 by making `ItemStackProvider` return the number of output items that come from the entire input stack, not just one recipe. These changes seem a bit sketchy to me, but I tested everything I could think of that this might break, including:
- other heating recipes, working on stacked and unstacked items
- barrel recipes working on stacks, as an example of recipes being applied to a whole stack at once
- the bloomery recipe, as an example of a recipe that requires multiple input items per recipe
- shift clicking TFC advanced crafting recipe types
- JEI recipe viewing for all of the above recipes

The way I implemented the changes to `ItemStackProvider` can probably break some recipes with a stack of multiple input items as a primary ingredient, but I'm pretty sure we don't support that anyways and the bloomery recipe still worked.