### PR TITLE
Fix coral damaging items

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/plant/coral/TFCCoralPlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/coral/TFCCoralPlantBlock.java
@@ -9,6 +9,8 @@ package net.dries007.tfc.common.blocks.plant.coral;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.vehicle.VehicleEntity;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -103,7 +105,7 @@ public class TFCCoralPlantBlock extends Block implements IFluidLoggable
     @Override
     protected void entityInside(BlockState state, Level level, BlockPos pos, Entity entity)
     {
-        if (!(entity instanceof AquaticMob || entity instanceof AmphibiousAnimal))
+        if ((entity instanceof LivingEntity || entity instanceof VehicleEntity) && !(entity instanceof AquaticMob || entity instanceof AmphibiousAnimal))
         {
             TFCDamageTypes.coral(entity, 0.5f);
         }


### PR DESCRIPTION
Currently, coral fans damage items similar to cacti. I think with the existence of chest boats, and the increased frequency of coral generating near land in 1.21 that that's pretty harsh. Also, while it's consistent with cacti, none of our other spiky blocks that you can pass through damage items, which makes me think it's a bug.