### PR TITLE
Rework JEI compat to use recipe holders

### DIFF
--- a/src/main/java/net/dries007/tfc/compat/jei/JEIIntegration.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/JEIIntegration.java
@@ -115,50 +115,49 @@ public final class JEIIntegration implements IModPlugin
     public static final IIngredientTypeWithSubtypes<Item, ItemStack> ITEM_STACK = VanillaTypes.ITEM_STACK;
     public static final IIngredientType<FluidStack> FLUID_STACK = NeoForgeTypes.FLUID_STACK;
 
-    public static final RecipeType<HeatingRecipe> HEATING = type("heating", HeatingRecipe.class);
-    public static final RecipeType<ScrapingRecipe> SCRAPING = type("scraping", ScrapingRecipe.class);
-    public static final RecipeType<QuernRecipe> QUERN = type("quern", QuernRecipe.class);
-    public static final RecipeType<PotRecipe> SOUP_POT = type("soup_pot", PotRecipe.class);
-    public static final RecipeType<PotRecipe> SIMPLE_POT = type("simple_pot", PotRecipe.class);
-    public static final RecipeType<PotRecipe> JAM_POT = type("jam_pot", PotRecipe.class);
-    public static final RecipeType<CastingRecipe> CASTING = type("casting", CastingRecipe.class);
-    public static final RecipeType<LoomRecipe> LOOM = type("loom", LoomRecipe.class);
-    public static final RecipeType<AlloyRecipe> ALLOYING = type("alloying", AlloyRecipe.class);
-    public static final RecipeType<SealedBarrelRecipe> SEALED_BARREL = type("sealed_barrel", SealedBarrelRecipe.class);
-    public static final RecipeType<InstantBarrelRecipe> INSTANT_BARREL = type("instant_barrel", InstantBarrelRecipe.class);
-    public static final RecipeType<InstantFluidBarrelRecipe> INSTANT_FLUID_BARREL = type("instant_fluid_barrel", InstantFluidBarrelRecipe.class);
-    public static final RecipeType<BloomeryRecipe> BLOOMERY = type("bloomery", BloomeryRecipe.class);
-    public static final RecipeType<WeldingRecipe> WELDING = type("welding", WeldingRecipe.class);
-    public static final RecipeType<AnvilRecipe> ANVIL = type("anvil", AnvilRecipe.class);
-    public static final RecipeType<ChiselRecipe> CHISEL = type("chisel", ChiselRecipe.class);
-    public static final RecipeType<GlassworkingRecipe> GLASSWORKING = type("glassworking", GlassworkingRecipe.class);
-    public static final RecipeType<BlastFurnaceRecipe> BLAST_FURNACE = type("blast_furnace", BlastFurnaceRecipe.class);
-    public static final RecipeType<SewingRecipe> SEWING = type("sewing", SewingRecipe.class);
+    public static final RecipeType<RecipeHolder<HeatingRecipe>> HEATING = type("heating", HeatingRecipe.class);
+    public static final RecipeType<RecipeHolder<ScrapingRecipe>> SCRAPING = type("scraping", ScrapingRecipe.class);
+    public static final RecipeType<RecipeHolder<QuernRecipe>> QUERN = type("quern", QuernRecipe.class);
+    public static final RecipeType<RecipeHolder<PotRecipe>> SOUP_POT = type("soup_pot", PotRecipe.class);
+    public static final RecipeType<RecipeHolder<PotRecipe>> SIMPLE_POT = type("simple_pot", PotRecipe.class);
+    public static final RecipeType<RecipeHolder<PotRecipe>> JAM_POT = type("jam_pot", PotRecipe.class);
+    public static final RecipeType<RecipeHolder<CastingRecipe>> CASTING = type("casting", CastingRecipe.class);
+    public static final RecipeType<RecipeHolder<LoomRecipe>> LOOM = type("loom", LoomRecipe.class);
+    public static final RecipeType<RecipeHolder<AlloyRecipe>> ALLOYING = type("alloying", AlloyRecipe.class);
+    public static final RecipeType<RecipeHolder<SealedBarrelRecipe>> SEALED_BARREL = type("sealed_barrel", SealedBarrelRecipe.class);
+    public static final RecipeType<RecipeHolder<InstantBarrelRecipe>> INSTANT_BARREL = type("instant_barrel", InstantBarrelRecipe.class);
+    public static final RecipeType<RecipeHolder<InstantFluidBarrelRecipe>> INSTANT_FLUID_BARREL = type("instant_fluid_barrel", InstantFluidBarrelRecipe.class);
+    public static final RecipeType<RecipeHolder<BloomeryRecipe>> BLOOMERY = type("bloomery", BloomeryRecipe.class);
+    public static final RecipeType<RecipeHolder<WeldingRecipe>> WELDING = type("welding", WeldingRecipe.class);
+    public static final RecipeType<RecipeHolder<AnvilRecipe>> ANVIL = type("anvil", AnvilRecipe.class);
+    public static final RecipeType<RecipeHolder<ChiselRecipe>> CHISEL = type("chisel", ChiselRecipe.class);
+    public static final RecipeType<RecipeHolder<GlassworkingRecipe>> GLASSWORKING = type("glassworking", GlassworkingRecipe.class);
+    public static final RecipeType<RecipeHolder<BlastFurnaceRecipe>> BLAST_FURNACE = type("blast_furnace", BlastFurnaceRecipe.class);
+    public static final RecipeType<RecipeHolder<SewingRecipe>> SEWING = type("sewing", SewingRecipe.class);
 
-    private static final Map<KnappingType, RecipeType<KnappingRecipe>> KNAPPING_TYPES = new HashMap<>();
+    private static final Map<KnappingType, RecipeType<RecipeHolder<KnappingRecipe>>> KNAPPING_TYPES = new HashMap<>();
 
-    public static RecipeType<KnappingRecipe> getKnappingType(Map.Entry<ResourceLocation, KnappingType> entry)
+    public static RecipeType<RecipeHolder<KnappingRecipe>> getKnappingType(Map.Entry<ResourceLocation, KnappingType> entry)
     {
         return KNAPPING_TYPES.computeIfAbsent(entry.getValue(), key -> type(entry.getKey().getPath() + "_knapping", KnappingRecipe.class));
     }
 
-    private static <T> RecipeType<T> type(String name, Class<T> clazz)
+    private static <T extends Recipe<?>> RecipeType<RecipeHolder<T>> type(String name, Class<T> kind)
     {
-        return RecipeType.create(TerraFirmaCraft.MOD_ID, name, clazz);
+        return RecipeType.createRecipeHolderType(ResourceLocation.fromNamespaceAndPath(TerraFirmaCraft.MOD_ID, name));
     }
 
-    private static <C extends RecipeInput, T extends Recipe<C>> List<T> recipes(Supplier<net.minecraft.world.item.crafting.RecipeType<T>> type)
+    private static <C extends RecipeInput, T extends Recipe<C>> List<RecipeHolder<T>> recipes(Supplier<net.minecraft.world.item.crafting.RecipeType<T>> type)
     {
         return recipes(type, e -> true);
     }
 
-    private static <C extends RecipeInput, T extends Recipe<C>> List<T> recipes(Supplier<net.minecraft.world.item.crafting.RecipeType<T>> type, Predicate<T> filter)
+    private static <C extends RecipeInput, T extends Recipe<C>> List<RecipeHolder<T>> recipes(Supplier<net.minecraft.world.item.crafting.RecipeType<T>> type, Predicate<T> filter)
     {
         return ClientHelpers.getLevelOrThrow().getRecipeManager()
             .getAllRecipesFor(type.get())
             .stream()
-            .map(RecipeHolder::value)
-            .filter(filter)
+            .filter(holder -> filter.test(holder.value()))
             .toList();
     }
 
@@ -276,7 +275,7 @@ public final class JEIIntegration implements IModPlugin
 
         for (var entry : KnappingType.MANAGER.getElements().entrySet())
         {
-            final RecipeType<KnappingRecipe> recipeType = getKnappingType(entry);
+            final RecipeType<RecipeHolder<KnappingRecipe>> recipeType = getKnappingType(entry);
             for (ItemStack item : entry.getValue().inputItem().ingredient().getItems())
             {
                 registry.addRecipeCatalyst(item, recipeType);

--- a/src/main/java/net/dries007/tfc/compat/jei/category/AlloyRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/AlloyRecipeCategory.java
@@ -19,6 +19,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.fluids.FluidStack;
 
 import net.dries007.tfc.common.blocks.TFCBlocks;
@@ -35,7 +36,7 @@ public class AlloyRecipeCategory extends BaseRecipeCategory<AlloyRecipe>
     private static final int FIRST_COLUMN_X = 4;
     private static final int SECOND_COLUMN_X = 70;
 
-    public AlloyRecipeCategory(RecipeType<AlloyRecipe> type, IGuiHelper helper)
+    public AlloyRecipeCategory(RecipeType<RecipeHolder<AlloyRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 170, MAX_HEIGHT, new ItemStack(TFCBlocks.CRUCIBLE.get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/AnvilRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/AnvilRecipeCategory.java
@@ -16,6 +16,7 @@ import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.common.recipes.AnvilRecipe;
@@ -24,7 +25,7 @@ import net.dries007.tfc.util.tooltip.Tooltips;
 
 public class AnvilRecipeCategory extends BaseRecipeCategory<AnvilRecipe>
 {
-    public AnvilRecipeCategory(RecipeType<AnvilRecipe> type, IGuiHelper helper)
+    public AnvilRecipeCategory(RecipeType<RecipeHolder<AnvilRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 98, 26, new ItemStack(TFCBlocks.METALS.get(Metal.BRONZE).get(Metal.BlockType.ANVIL).get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/BarrelRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/BarrelRecipeCategory.java
@@ -16,6 +16,7 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.fluids.FluidStack;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,12 +32,12 @@ public class BarrelRecipeCategory<T extends BarrelRecipe> extends BaseRecipeCate
     protected @Nullable IRecipeSlotBuilder outputFluidSlot;
     protected @Nullable IRecipeSlotBuilder outputItemSlot;
 
-    public BarrelRecipeCategory(RecipeType<T> type, IGuiHelper helper, int width, int height, Wood iconType)
+    public BarrelRecipeCategory(RecipeType<RecipeHolder<T>> type, IGuiHelper helper, int width, int height, Wood iconType)
     {
         this(type, helper, width, height, new ItemStack(TFCBlocks.WOODS.get(iconType).get(Wood.BlockType.BARREL).get()));
     }
 
-    public BarrelRecipeCategory(RecipeType<T> type, IGuiHelper helper, int width, int height, ItemStack iconType)
+    public BarrelRecipeCategory(RecipeType<RecipeHolder<T>> type, IGuiHelper helper, int width, int height, ItemStack iconType)
     {
         super(type, helper, width, height, iconType);
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/BaseRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/BaseRecipeCategory.java
@@ -8,16 +8,22 @@ package net.dries007.tfc.compat.jei.category;
 
 import java.util.Arrays;
 import java.util.List;
+import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
 import mezz.jei.api.gui.drawable.IDrawableStatic;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
 import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.AbstractRecipeCategory;
+import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.common.crafting.SizedIngredient;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
@@ -30,9 +36,32 @@ import net.dries007.tfc.common.recipes.outputs.ItemStackProvider;
 import net.dries007.tfc.compat.jei.JEIIntegration;
 import net.dries007.tfc.util.Helpers;
 
-public abstract class BaseRecipeCategory<T> extends AbstractRecipeCategory<T>
+public abstract class BaseRecipeCategory<T extends Recipe<?>> extends AbstractRecipeCategory<RecipeHolder<T>>
 {
     public static final ResourceLocation ICONS = Helpers.identifier("textures/gui/jei/icons.png");
+
+    @Override
+    public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<T> recipe, IFocusGroup focuses)
+    {
+        setRecipe(builder, recipe.value(), focuses);
+    }
+
+    public void setRecipe(IRecipeLayoutBuilder builder, T holder, IFocusGroup focuses)
+    {
+
+    }
+
+    @Override
+    public void draw(RecipeHolder<T> holder, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY)
+    {
+        draw(holder.value(), recipeSlotsView, graphics, mouseX, mouseY);
+    }
+
+    public void draw(T recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics graphics, double mouseX, double mouseY)
+    {
+
+    }
+
 
     /**
      * Do not call outside the level. Duh.
@@ -84,7 +113,7 @@ public abstract class BaseRecipeCategory<T> extends AbstractRecipeCategory<T>
     protected final IDrawableStatic arrow;
     protected final IDrawableAnimated arrowAnimated;
 
-    public BaseRecipeCategory(RecipeType<T> type, IGuiHelper helper, int width, int height, ItemStack icon)
+    public BaseRecipeCategory(RecipeType<RecipeHolder<T>> type, IGuiHelper helper, int width, int height, ItemStack icon)
     {
         super(type, Component.translatable(TerraFirmaCraft.MOD_ID + ".jei." + type.getUid().getPath()), helper.createDrawableIngredient(JEIIntegration.ITEM_STACK, FoodCapability.setNonDecaying(icon)), width, height);
         this.slot = helper.getSlotDrawable();
@@ -99,4 +128,3 @@ public abstract class BaseRecipeCategory<T> extends AbstractRecipeCategory<T>
     }
 
 }
-

--- a/src/main/java/net/dries007/tfc/compat/jei/category/BlastFurnaceRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/BlastFurnaceRecipeCategory.java
@@ -14,6 +14,7 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.common.recipes.BlastFurnaceRecipe;
@@ -21,7 +22,7 @@ import net.dries007.tfc.compat.jei.JEIIntegration;
 
 public class BlastFurnaceRecipeCategory extends BaseRecipeCategory<BlastFurnaceRecipe>
 {
-    public BlastFurnaceRecipeCategory(RecipeType<BlastFurnaceRecipe> type, IGuiHelper helper)
+    public BlastFurnaceRecipeCategory(RecipeType<RecipeHolder<BlastFurnaceRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 98, 26, new ItemStack(TFCBlocks.BLAST_FURNACE.get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/BloomeryRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/BloomeryRecipeCategory.java
@@ -14,6 +14,7 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.common.recipes.BloomeryRecipe;
@@ -24,7 +25,7 @@ import net.dries007.tfc.compat.jei.JEIIntegration;
  */
 public class BloomeryRecipeCategory extends BaseRecipeCategory<BloomeryRecipe>
 {
-    public BloomeryRecipeCategory(RecipeType<BloomeryRecipe> type, IGuiHelper helper)
+    public BloomeryRecipeCategory(RecipeType<RecipeHolder<BloomeryRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 98, 26, new ItemStack(TFCBlocks.BLOOMERY.get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/CastingRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/CastingRecipeCategory.java
@@ -17,7 +17,7 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.component.heat.Heat;
 import net.dries007.tfc.common.component.heat.HeatCapability;
-import net.dries007.tfc.common.component.mold.IMold;
 import net.dries007.tfc.common.items.TFCItems;
 import net.dries007.tfc.common.recipes.CastingRecipe;
 import net.dries007.tfc.compat.jei.JEIIntegration;
@@ -35,7 +34,7 @@ public class CastingRecipeCategory extends BaseRecipeCategory<CastingRecipe>
 {
     private static final String INPUT_SLOT = "input";
 
-    public CastingRecipeCategory(RecipeType<CastingRecipe> type, IGuiHelper helper)
+    public CastingRecipeCategory(RecipeType<RecipeHolder<CastingRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 98, 26, new ItemStack(TFCItems.MOLDS.get(Metal.ItemType.INGOT).get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/ChiselRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/ChiselRecipeCategory.java
@@ -8,7 +8,6 @@ package net.dries007.tfc.compat.jei.category;
 
 import java.util.Map;
 import java.util.stream.Collectors;
-import com.google.common.collect.ImmutableMap;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawableStatic;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
@@ -19,8 +18,8 @@ import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
-import net.dries007.tfc.client.IngameOverlays;
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.items.TFCItems;
 import net.dries007.tfc.common.player.ChiselMode;
@@ -31,7 +30,7 @@ public class ChiselRecipeCategory extends BaseRecipeCategory<ChiselRecipe>
 {
     private final Map<ChiselMode, IDrawableStatic> modes;
 
-    public ChiselRecipeCategory(RecipeType<ChiselRecipe> type, IGuiHelper helper)
+    public ChiselRecipeCategory(RecipeType<RecipeHolder<ChiselRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 118, 26, new ItemStack(TFCItems.METAL_ITEMS.get(Metal.BLACK_BRONZE).get(Metal.ItemType.CHISEL).get()));
         modes = ChiselMode.REGISTRY.stream()

--- a/src/main/java/net/dries007/tfc/compat/jei/category/GlassworkingRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/GlassworkingRecipeCategory.java
@@ -21,6 +21,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.blocks.PouredGlassBlock;
 import net.dries007.tfc.common.component.glass.GlassOperation;
@@ -33,7 +34,7 @@ import net.dries007.tfc.common.recipes.GlassworkingRecipe;
 public class GlassworkingRecipeCategory extends BaseRecipeCategory<GlassworkingRecipe>
 {
 
-    public GlassworkingRecipeCategory(RecipeType<GlassworkingRecipe> type, IGuiHelper helper)
+    public GlassworkingRecipeCategory(RecipeType<RecipeHolder<GlassworkingRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 175, 110, new ItemStack(TFCItems.BLOWPIPE_WITH_GLASS.get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/HeatingRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/HeatingRecipeCategory.java
@@ -16,13 +16,12 @@ import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
-import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.fluids.FluidStack;
 
 import net.dries007.tfc.common.blocks.TFCBlocks;
@@ -33,7 +32,7 @@ import net.dries007.tfc.config.TFCConfig;
 
 public class HeatingRecipeCategory extends BaseRecipeCategory<HeatingRecipe>
 {
-    public HeatingRecipeCategory(RecipeType<HeatingRecipe> type, IGuiHelper helper)
+    public HeatingRecipeCategory(RecipeType<RecipeHolder<HeatingRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 120, 38, new ItemStack(TFCBlocks.FIREPIT.get()));
     }
@@ -45,7 +44,7 @@ public class HeatingRecipeCategory extends BaseRecipeCategory<HeatingRecipe>
         IRecipeSlotBuilder outputSlot = builder.addSlot(RecipeIngredientRole.OUTPUT, 85, 17);
 
         inputSlot.addIngredients(recipe.getIngredient());
-        inputSlot.setBackground(slot, -1,-1);
+        inputSlot.setBackground(slot, -1, -1);
 
         final List<ItemStack> outputItems = Arrays.stream(recipe.getIngredient().getItems())
             .map(stack -> recipe.assembleStacked(stack, Integer.MAX_VALUE, true))
@@ -64,7 +63,7 @@ public class HeatingRecipeCategory extends BaseRecipeCategory<HeatingRecipe>
             outputSlot.addIngredient(JEIIntegration.FLUID_STACK, resultFluid);
             outputSlot.setFluidRenderer(1, false, 16, 16);
         }
-        outputSlot.setBackground(slot, -1,-1);
+        outputSlot.setBackground(slot, -1, -1);
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/compat/jei/category/InstantBarrelRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/InstantBarrelRecipeCategory.java
@@ -8,13 +8,14 @@ package net.dries007.tfc.compat.jei.category;
 
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.RecipeType;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.blocks.wood.Wood;
 import net.dries007.tfc.common.recipes.InstantBarrelRecipe;
 
 public class InstantBarrelRecipeCategory extends BarrelRecipeCategory<InstantBarrelRecipe>
 {
-    public InstantBarrelRecipeCategory(RecipeType<InstantBarrelRecipe> type, IGuiHelper helper)
+    public InstantBarrelRecipeCategory(RecipeType<RecipeHolder<InstantBarrelRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 118, 26, Wood.DOUGLAS_FIR);
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/InstantFluidBarrelRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/InstantFluidBarrelRecipeCategory.java
@@ -11,6 +11,7 @@ import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import net.dries007.tfc.common.blocks.wood.Wood;
@@ -19,7 +20,7 @@ import net.dries007.tfc.compat.jei.JEIIntegration;
 
 public class InstantFluidBarrelRecipeCategory extends BarrelRecipeCategory<InstantFluidBarrelRecipe>
 {
-    public InstantFluidBarrelRecipeCategory(RecipeType<InstantFluidBarrelRecipe> type, IGuiHelper helper)
+    public InstantFluidBarrelRecipeCategory(RecipeType<RecipeHolder<InstantFluidBarrelRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 118, 26, Wood.KAPOK);
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/JamPotRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/JamPotRecipeCategory.java
@@ -14,12 +14,13 @@ import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.recipes.PotRecipe;
 
 public class JamPotRecipeCategory extends PotRecipeCategory<PotRecipe>
 {
-    public JamPotRecipeCategory(RecipeType<PotRecipe> type, IGuiHelper helper)
+    public JamPotRecipeCategory(RecipeType<RecipeHolder<PotRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 175, 50);
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/KnappingRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/KnappingRecipeCategory.java
@@ -16,6 +16,7 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.common.crafting.SizedIngredient;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,7 +32,7 @@ public class KnappingRecipeCategory<T extends KnappingRecipe> extends BaseRecipe
     private final KnappingType knappingType;
     private final IGuiHelper helper;
 
-    public KnappingRecipeCategory(RecipeType<T> type, IGuiHelper helper, KnappingType knappingType)
+    public KnappingRecipeCategory(RecipeType<RecipeHolder<T>> type, IGuiHelper helper, KnappingType knappingType)
     {
         super(type, helper, 155, 82, knappingType.icon());
 

--- a/src/main/java/net/dries007/tfc/compat/jei/category/LoomRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/LoomRecipeCategory.java
@@ -15,13 +15,14 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.items.TFCItems;
 import net.dries007.tfc.common.recipes.LoomRecipe;
 
 public class LoomRecipeCategory extends BaseRecipeCategory<LoomRecipe>
 {
-    public LoomRecipeCategory(RecipeType<LoomRecipe> type, IGuiHelper helper)
+    public LoomRecipeCategory(RecipeType<RecipeHolder<LoomRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 78, 26, new ItemStack(TFCItems.BURLAP_CLOTH.get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/PotRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/PotRecipeCategory.java
@@ -9,12 +9,12 @@ package net.dries007.tfc.compat.jei.category;
 
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.builder.IRecipeSlotBuilder;
-import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.items.TFCItems;
 import net.dries007.tfc.common.recipes.PotRecipe;
@@ -22,7 +22,7 @@ import net.dries007.tfc.compat.jei.JEIIntegration;
 
 public abstract class PotRecipeCategory<T extends PotRecipe> extends BaseRecipeCategory<T>
 {
-    public PotRecipeCategory(RecipeType<T> type, IGuiHelper helper, int width, int height)
+    public PotRecipeCategory(RecipeType<RecipeHolder<T>> type, IGuiHelper helper, int width, int height)
     {
         super(type, helper, width, height, new ItemStack(TFCItems.POT.get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/QuernRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/QuernRecipeCategory.java
@@ -11,6 +11,7 @@ import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.blocks.TFCBlocks;
@@ -18,7 +19,7 @@ import net.dries007.tfc.common.recipes.QuernRecipe;
 
 public class QuernRecipeCategory extends SimpleItemRecipeCategory<QuernRecipe>
 {
-    public QuernRecipeCategory(RecipeType<QuernRecipe> type, IGuiHelper helper)
+    public QuernRecipeCategory(RecipeType<RecipeHolder<QuernRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, new ItemStack(TFCBlocks.QUERN.get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/ScrapingRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/ScrapingRecipeCategory.java
@@ -13,6 +13,7 @@ import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.items.TFCItems;
@@ -21,7 +22,7 @@ import net.dries007.tfc.util.Metal;
 
 public class ScrapingRecipeCategory extends SimpleItemRecipeCategory<ScrapingRecipe>
 {
-    public ScrapingRecipeCategory(RecipeType<ScrapingRecipe> type, IGuiHelper helper)
+    public ScrapingRecipeCategory(RecipeType<RecipeHolder<ScrapingRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, new ItemStack(TFCItems.METAL_ITEMS.get(Metal.BLACK_BRONZE).get(Metal.ItemType.KNIFE).get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/SealedBarrelRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/SealedBarrelRecipeCategory.java
@@ -21,6 +21,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.fluids.FluidStack;
 
 import net.dries007.tfc.common.blocks.wood.Wood;
@@ -29,7 +30,7 @@ import net.dries007.tfc.util.calendar.Calendars;
 
 public class SealedBarrelRecipeCategory extends BarrelRecipeCategory<SealedBarrelRecipe>
 {
-    public SealedBarrelRecipeCategory(RecipeType<SealedBarrelRecipe> type, IGuiHelper helper)
+    public SealedBarrelRecipeCategory(RecipeType<RecipeHolder<SealedBarrelRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 148, 32, Wood.MAPLE);
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/SewingRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/SewingRecipeCategory.java
@@ -15,6 +15,7 @@ import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.client.screen.SewingTableScreen;
 import net.dries007.tfc.common.container.SewingTableContainer;
@@ -28,7 +29,7 @@ public class SewingRecipeCategory extends BaseRecipeCategory<SewingRecipe>
     private final IDrawable wool;
     private final IDrawable burlap;
 
-    public SewingRecipeCategory(RecipeType<SewingRecipe> type, IGuiHelper helper)
+    public SewingRecipeCategory(RecipeType<RecipeHolder<SewingRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 144, 70, new ItemStack(TFCItems.BONE_NEEDLE.get()));
 

--- a/src/main/java/net/dries007/tfc/compat/jei/category/SimpleItemRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/SimpleItemRecipeCategory.java
@@ -19,6 +19,7 @@ import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.recipes.ItemRecipe;
@@ -26,7 +27,7 @@ import net.dries007.tfc.compat.jei.JEIIntegration;
 
 public abstract class SimpleItemRecipeCategory<T extends ItemRecipe> extends BaseRecipeCategory<T>
 {
-    public SimpleItemRecipeCategory(RecipeType<T> type, IGuiHelper helper, ItemStack icon)
+    public SimpleItemRecipeCategory(RecipeType<RecipeHolder<T>> type, IGuiHelper helper, ItemStack icon)
     {
         super(type, helper, 98, 26, icon);
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/SimplePotRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/SimplePotRecipeCategory.java
@@ -17,6 +17,7 @@ import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.fluids.FluidStack;
 
 import net.dries007.tfc.common.recipes.PotRecipe;
@@ -31,7 +32,7 @@ public class SimplePotRecipeCategory extends PotRecipeCategory<PotRecipe>
     private static final int[] OUTPUT_X = {75, 65, 85, 65, 85};
     private static final int[] OUTPUT_Y = {5, 25, 25, 45, 45};
 
-    public SimplePotRecipeCategory(RecipeType<PotRecipe> type, IGuiHelper helper)
+    public SimplePotRecipeCategory(RecipeType<RecipeHolder<PotRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 110, 100);
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/SoupPotRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/SoupPotRecipeCategory.java
@@ -16,6 +16,7 @@ import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.items.TFCItems;
 import net.dries007.tfc.common.recipes.PotRecipe;
@@ -24,7 +25,7 @@ import net.dries007.tfc.common.recipes.SoupPotRecipe;
 
 public class SoupPotRecipeCategory extends PotRecipeCategory<PotRecipe>
 {
-    public SoupPotRecipeCategory(RecipeType<PotRecipe> type, IGuiHelper helper)
+    public SoupPotRecipeCategory(RecipeType<RecipeHolder<PotRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 175, 50);
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/category/WeldingRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/WeldingRecipeCategory.java
@@ -15,6 +15,7 @@ import mezz.jei.api.recipe.RecipeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import net.dries007.tfc.common.TFCTags;
 import net.dries007.tfc.common.items.TFCItems;
@@ -23,7 +24,7 @@ import net.dries007.tfc.util.Metal;
 
 public class WeldingRecipeCategory extends BaseRecipeCategory<WeldingRecipe>
 {
-    public WeldingRecipeCategory(RecipeType<WeldingRecipe> type, IGuiHelper helper)
+    public WeldingRecipeCategory(RecipeType<RecipeHolder<WeldingRecipe>> type, IGuiHelper helper)
     {
         super(type, helper, 118, 26, new ItemStack(TFCItems.METAL_ITEMS.get(Metal.WROUGHT_IRON).get(Metal.ItemType.HAMMER).get()));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/transfer/AnvilRecipeTransferHandler.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/transfer/AnvilRecipeTransferHandler.java
@@ -12,23 +12,23 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.recipes.AnvilRecipe;
-import net.dries007.tfc.network.PacketHandler;
 import net.dries007.tfc.network.SelectAnvilPlanPacket;
 
 /**
  * Custom transfer handler which selects the anvil plan as part of the transfer process
  */
 public class AnvilRecipeTransferHandler<C extends AbstractContainerMenu>
-    extends BaseTransferInfo<C, AnvilRecipe>
-    implements IRecipeTransferHandler<C, AnvilRecipe>
+    extends BaseTransferInfo<C, RecipeHolder<AnvilRecipe>>
+    implements IRecipeTransferHandler<C, RecipeHolder<AnvilRecipe>>
 {
-    private final IRecipeTransferHandler<C, AnvilRecipe> transferHandler;
+    private final IRecipeTransferHandler<C, RecipeHolder<AnvilRecipe>> transferHandler;
 
-    public AnvilRecipeTransferHandler(IRecipeTransferHandler<C, AnvilRecipe> transferHandler)
+    public AnvilRecipeTransferHandler(IRecipeTransferHandler<C, RecipeHolder<AnvilRecipe>> transferHandler)
     {
         super(transferHandler.getContainerClass(), transferHandler.getMenuType(), transferHandler.getRecipeType(), -1);
         this.transferHandler = transferHandler;
@@ -36,9 +36,10 @@ public class AnvilRecipeTransferHandler<C extends AbstractContainerMenu>
 
     @Nullable
     @Override
-    public IRecipeTransferError transferRecipe(C container, AnvilRecipe recipe, IRecipeSlotsView recipeSlots, Player player, boolean maxTransfer, boolean doTransfer)
+    public IRecipeTransferError transferRecipe(C container, RecipeHolder<AnvilRecipe> holder, IRecipeSlotsView recipeSlots, Player player, boolean maxTransfer, boolean doTransfer)
     {
-        final IRecipeTransferError transferError = transferHandler.transferRecipe(container, recipe, recipeSlots, player, maxTransfer, doTransfer);
+        AnvilRecipe recipe = holder.value();
+        final IRecipeTransferError transferError = transferHandler.transferRecipe(container, holder, recipeSlots, player, maxTransfer, doTransfer);
         // Non-null return means some sort of error happened and nothing will get transferred
         if (transferError != null)
         {

--- a/src/main/java/net/dries007/tfc/compat/jei/transfer/AnvilRecipeTransferInfo.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/transfer/AnvilRecipeTransferInfo.java
@@ -11,6 +11,7 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferError;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.blockentities.AnvilBlockEntity;
@@ -20,8 +21,8 @@ import net.dries007.tfc.common.recipes.AnvilRecipe;
 import net.dries007.tfc.compat.jei.JEIIntegration;
 
 public class AnvilRecipeTransferInfo
-    extends BaseTransferInfo<AnvilContainer, AnvilRecipe>
-    implements IRecipeTransferInfo<AnvilContainer, AnvilRecipe>
+    extends BaseTransferInfo<AnvilContainer, RecipeHolder<AnvilRecipe>>
+    implements IRecipeTransferInfo<AnvilContainer, RecipeHolder<AnvilRecipe>>
 {
     private final IRecipeTransferHandlerHelper transferHelper;
 
@@ -32,14 +33,14 @@ public class AnvilRecipeTransferInfo
     }
 
     @Override
-    public boolean canHandle(AnvilContainer container, AnvilRecipe recipe)
+    public boolean canHandle(AnvilContainer container, RecipeHolder<AnvilRecipe> recipe)
     {
-        return recipe.isCorrectTier(container.getBlockEntity().getTier());
+        return recipe.value().isCorrectTier(container.getBlockEntity().getTier());
     }
 
     @Nullable
     @Override
-    public IRecipeTransferError getHandlingError(AnvilContainer container, AnvilRecipe recipe)
+    public IRecipeTransferError getHandlingError(AnvilContainer container, RecipeHolder<AnvilRecipe> recipe)
     {
         return transferHelper.createUserErrorWithTooltip(Component.translatable("tfc.jei.transfer.error.anvil_forging_tier_too_low"));
     }

--- a/src/main/java/net/dries007/tfc/compat/jei/transfer/PotTransferInfo.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/transfer/PotTransferInfo.java
@@ -7,12 +7,12 @@
 package net.dries007.tfc.compat.jei.transfer;
 
 import java.util.Optional;
-import java.util.stream.Collectors;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.transfer.IRecipeTransferError;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 import org.jetbrains.annotations.Nullable;
@@ -21,7 +21,6 @@ import net.dries007.tfc.common.blockentities.PotBlockEntity;
 import net.dries007.tfc.common.container.PotContainer;
 import net.dries007.tfc.common.container.TFCContainerTypes;
 import net.dries007.tfc.common.recipes.PotRecipe;
-import net.dries007.tfc.util.Helpers;
 
 import static net.dries007.tfc.common.blockentities.GrillBlockEntity.*;
 
@@ -30,19 +29,19 @@ import static net.dries007.tfc.common.blockentities.GrillBlockEntity.*;
  * {@link PotBlockEntity#hasRecipeStarted()} as the slots get locked
  */
 public class PotTransferInfo
-    extends BaseTransferInfo<PotContainer, PotRecipe>
-    implements IRecipeTransferInfo<PotContainer, PotRecipe>
+    extends BaseTransferInfo<PotContainer, RecipeHolder<PotRecipe>>
+    implements IRecipeTransferInfo<PotContainer, RecipeHolder<PotRecipe>>
 {
     private final IRecipeTransferHandlerHelper transferHelper;
 
-    public PotTransferInfo(IRecipeTransferHandlerHelper transferHelper, RecipeType<PotRecipe> recipeType)
+    public PotTransferInfo(IRecipeTransferHandlerHelper transferHelper, RecipeType<RecipeHolder<PotRecipe>> recipeType)
     {
         super(PotContainer.class, Optional.of(TFCContainerTypes.POT.get()), recipeType, 9, SLOT_EXTRA_INPUT_START, 5, 6, 7, SLOT_EXTRA_INPUT_END);
         this.transferHelper = transferHelper;
     }
 
     @Override
-    public boolean canHandle(PotContainer container, PotRecipe recipe)
+    public boolean canHandle(PotContainer container, RecipeHolder<PotRecipe> recipe)
     {
         if (container.getBlockEntity().hasRecipeStarted())
         {
@@ -50,15 +49,15 @@ public class PotTransferInfo
         }
 
         final var inventory = container.getBlockEntity().getInventory();
-        return recipe.getFluidIngredient().test(inventory.getFluidInTank(0));
+        return recipe.value().getFluidIngredient().test(inventory.getFluidInTank(0));
     }
 
     @Nullable
     @Override
-    public IRecipeTransferError getHandlingError(PotContainer container, PotRecipe recipe)
+    public IRecipeTransferError getHandlingError(PotContainer container, RecipeHolder<PotRecipe> recipe)
     {
         final var inventory = container.getBlockEntity().getInventory();
-        final SizedFluidIngredient fluidIngredient = recipe.getFluidIngredient();
+        final SizedFluidIngredient fluidIngredient = recipe.value().getFluidIngredient();
         final FluidStack fluidInTank = inventory.getFluidInTank(0);
 
         if (!fluidIngredient.ingredient().test(fluidInTank))

--- a/src/main/java/net/dries007/tfc/compat/jei/transfer/WeldingRecipeTransferInfo.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/transfer/WeldingRecipeTransferInfo.java
@@ -11,6 +11,7 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferError;
 import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.crafting.RecipeHolder;
 import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.common.blockentities.AnvilBlockEntity;
@@ -20,8 +21,8 @@ import net.dries007.tfc.common.recipes.WeldingRecipe;
 import net.dries007.tfc.compat.jei.JEIIntegration;
 
 public class WeldingRecipeTransferInfo
-    extends BaseTransferInfo<AnvilContainer, WeldingRecipe>
-    implements IRecipeTransferInfo<AnvilContainer, WeldingRecipe>
+    extends BaseTransferInfo<AnvilContainer, RecipeHolder<WeldingRecipe>>
+    implements IRecipeTransferInfo<AnvilContainer, RecipeHolder<WeldingRecipe>>
 {
     private final IRecipeTransferHandlerHelper transferHelper;
 
@@ -32,14 +33,14 @@ public class WeldingRecipeTransferInfo
     }
 
     @Override
-    public boolean canHandle(AnvilContainer container, WeldingRecipe recipe)
+    public boolean canHandle(AnvilContainer container, RecipeHolder<WeldingRecipe> recipe)
     {
-        return recipe.isCorrectTier(container.getBlockEntity().getTier());
+        return recipe.value().isCorrectTier(container.getBlockEntity().getTier());
     }
 
     @Nullable
     @Override
-    public IRecipeTransferError getHandlingError(AnvilContainer container, WeldingRecipe recipe)
+    public IRecipeTransferError getHandlingError(AnvilContainer container, RecipeHolder<WeldingRecipe> recipe)
     {
         return transferHelper.createUserErrorWithTooltip(Component.translatable("tfc.jei.transfer.error.anvil_welding_tier_too_low"));
     }


### PR DESCRIPTION
Turns out JEI expects recipes to know what their resource location is. Breaking change for mods that extend TFC's JEI categories.

Closes #3396