### PR TITLE
Add a custom item display context for placed items

### DIFF
--- a/src/main/java/net/dries007/tfc/client/RenderHelpers.java
+++ b/src/main/java/net/dries007/tfc/client/RenderHelpers.java
@@ -47,9 +47,9 @@ import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.FastColor.ARGB32;
 import net.minecraft.util.Mth;
 import net.minecraft.util.RandomSource;
-import net.minecraft.util.FastColor.ARGB32;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.inventory.InventoryMenu;
@@ -64,7 +64,6 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.client.extensions.common.IClientFluidTypeExtensions;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.fluids.FluidStack;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.joml.Matrix4f;
 
@@ -78,6 +77,11 @@ import net.dries007.tfc.util.Helpers;
 
 public final class RenderHelpers
 {
+    /**
+     * Optional transform for items to used when placed on the ground.
+     * Name controlled via resources/META-INF/enumextensions.json
+     */
+    public static final ItemDisplayContext PLACED_ITEM_CONTEXT = ItemDisplayContext.valueOf("TFC_PLACED_ITEM");
     @SuppressWarnings("deprecation") public static final ResourceLocation BLOCKS_ATLAS = TextureAtlas.LOCATION_BLOCKS;
     public static final Button.CreateNarration NARRATION = Supplier::get;
 

--- a/src/main/java/net/dries007/tfc/client/render/blockentity/PlacedItemBlockEntityRenderer.java
+++ b/src/main/java/net/dries007/tfc/client/render/blockentity/PlacedItemBlockEntityRenderer.java
@@ -31,7 +31,6 @@ import net.dries007.tfc.client.RenderHelpers;
 import net.dries007.tfc.common.blockentities.PlacedItemBlockEntity;
 import net.dries007.tfc.common.items.JavelinItem;
 import net.dries007.tfc.common.items.TFCItems;
-import net.dries007.tfc.common.items.TFCShieldItem;
 
 public class PlacedItemBlockEntityRenderer<T extends PlacedItemBlockEntity> implements BlockEntityRenderer<T>
 {
@@ -119,6 +118,8 @@ public class PlacedItemBlockEntityRenderer<T extends PlacedItemBlockEntity> impl
             }
             pose.translate(0, -0.0001, 0);
 
+            baked.applyTransform(RenderHelpers.PLACED_ITEM_CONTEXT, pose, false);
+
             blockRenderer.tesselateWithAO(entity.getLevel(), baked, entity.getBlockState(), entity.getBlockPos(), pose, buffer, true, random, packedLight, packedOverlay, ModelData.EMPTY, RenderType.translucent());
         }
         else
@@ -169,12 +170,7 @@ public class PlacedItemBlockEntityRenderer<T extends PlacedItemBlockEntity> impl
                 pose.mulPose(Axis.ZP.rotationDegrees(entity.getRotations(slot)));
             }
 
-            // Our shields are very large when rendered with their in hand model, so we scale them down here. There might be a better way to do this,
-            // but we're already giving shields a special case, so this is good enough.
-            if (stack.getItem() instanceof TFCShieldItem)
-            {
-                pose.scale(0.5f, 0.5f, 0.5f);
-            }
+            model.applyTransform(RenderHelpers.PLACED_ITEM_CONTEXT, pose, false);
 
             // Then render the model
             // This is copying what renderStatic() would've done

--- a/src/main/resources/META-INF/enumextensions.json
+++ b/src/main/resources/META-INF/enumextensions.json
@@ -1,0 +1,10 @@
+{
+  "entries": [
+    {
+      "enum": "net/minecraft/world/item/ItemDisplayContext",
+      "name": "TFC_PLACED_ITEM",
+      "constructor": "(ILjava/lang/String;Ljava/lang/String;)V",
+      "parameters": [ -1, "tfc:placed_item", null ]
+    }
+  ]
+}

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze.json
@@ -385,6 +385,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   },
   "overrides": [

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bismuth_bronze_blocking.json
@@ -385,6 +385,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze.json
@@ -385,6 +385,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   },
   "overrides": [

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_bronze_blocking.json
@@ -385,6 +385,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_steel.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_steel.json
@@ -186,6 +186,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   },
   "overrides": [

--- a/src/main/resources/assets/tfc/models/item/metal/shield/black_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/black_steel_blocking.json
@@ -186,6 +186,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel.json
@@ -348,6 +348,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   },
   "overrides": [

--- a/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/blue_steel_blocking.json
@@ -348,6 +348,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bronze.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bronze.json
@@ -385,6 +385,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   },
   "overrides": [

--- a/src/main/resources/assets/tfc/models/item/metal/shield/bronze_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/bronze_blocking.json
@@ -385,6 +385,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/copper.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/copper.json
@@ -277,6 +277,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   },
   "overrides": [

--- a/src/main/resources/assets/tfc/models/item/metal/shield/copper_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/copper_blocking.json
@@ -277,6 +277,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/red_steel.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/red_steel.json
@@ -361,6 +361,9 @@
 		"fixed": {
 			"translation": [0, 0, -0.38],
 			"scale": [2, 2, 2]
+		},
+		"tfc:placed_item": {
+			"scale": [0.5, 0.5, 0.5]
 		}
 	},
     "overrides": [  {

--- a/src/main/resources/assets/tfc/models/item/metal/shield/red_steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/red_steel_blocking.json
@@ -361,6 +361,9 @@
 		"fixed": {
 			"translation": [0, 0, -0.38],
 			"scale": [2, 2, 2]
+		},
+		"tfc:placed_item": {
+			"scale": [0.5, 0.5, 0.5]
 		}
 	}
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/steel.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/steel.json
@@ -495,6 +495,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   },
   "overrides": [

--- a/src/main/resources/assets/tfc/models/item/metal/shield/steel_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/steel_blocking.json
@@ -495,6 +495,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   }
 }

--- a/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron.json
@@ -253,6 +253,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   },
   "overrides": [

--- a/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron_blocking.json
+++ b/src/main/resources/assets/tfc/models/item/metal/shield/wrought_iron_blocking.json
@@ -253,6 +253,9 @@
     "fixed": {
       "translation": [0, 0, -0.38],
       "scale": [2, 2, 2]
+    },
+    "tfc:placed_item": {
+      "scale": [0.5, 0.5, 0.5]
     }
   }
 }

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -12,6 +12,7 @@ issueTrackerURL = "https://github.com/TerraFirmaCraft/TerraFirmaCraft/issues"
     credits = "By AlcatrazEscapee, Disastermoo, Dries007, Bunsan, Claycorp, DavidTriphon, EERussianguy, Gaelmare, and many others. Based on the original work by Bioxx, Dunk, and Kitty. Music by Mike \"Menoch\" Pelaez"
     authors = "AlcatrazEscapee"
     description = '''TerraFirmaCraft - The Next Generation'''
+    enumExtensions = "META-INF/enumextensions.json"
 
 # Dependencies
 [[dependencies.tfc]]


### PR DESCRIPTION
Allows for models to apply their own transforms when they are placed on the ground instead of hard coding it, like shields currently do.