### PR TITLE
Make salting food round its creation date

### DIFF
--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -1131,6 +1131,7 @@ public interface CraftingRecipes extends Recipes
             .input(TFCItems.POWDERS.get(Powder.SALT))
             .copyInput()
             .addTrait(FoodTraits.SALTED)
+            .roundCreationDate()
             .shapeless("salting");
         recipe()
             .input(Items.PAPER)

--- a/src/generated/resources/data/tfc/recipe/crafting/salting.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/salting.json
@@ -43,6 +43,9 @@
       {
         "type": "tfc:add_trait",
         "trait": "tfc:salted"
+      },
+      {
+        "type": "tfc:round_creation_date"
       }
     ]
   }

--- a/src/main/java/net/dries007/tfc/common/component/food/FoodCapability.java
+++ b/src/main/java/net/dries007/tfc/common/component/food/FoodCapability.java
@@ -336,6 +336,25 @@ public final class FoodCapability
         return ((tick - 1) / window + 1) * window;
     }
 
+    public static ItemStack roundCreationDate(ItemStack stack)
+    {
+        final @Nullable FoodComponent food = stack.get(TFCComponents.FOOD);
+        
+        if (food != null)
+        {
+            if (food.getCreationDate() == IFood.ROTTEN_FLAG
+                || food.getCreationDate() == IFood.NEVER_DECAY_FLAG
+                || food.getCreationDate() == IFood.INVISIBLE_NEVER_DECAY_FLAG
+                || food.getCreationDate() == IFood.TRANSIENT_NEVER_DECAY_FLAG)
+            {
+                return stack;
+            }
+            
+            stack.set(TFCComponents.FOOD, food.with(getRoundedCreationDate(food.getCreationDate())));
+        }
+        return stack;
+    }
+
     /**
      * @return {@code true} if the food is rotten based on the internal (flagged) creation date, and the decay date modifier
      */
@@ -402,7 +421,7 @@ public final class FoodCapability
      *
      * @param ci The initial creation date
      * @param p  The decay date modifier (1 / standard decay modifier)
-     * @return cf the final creation date, rounded to the nearest hour, for ease of stackability.
+     * @return cf the final creation date
      */
     private static long calculateNewCreationDate(long ci, float p)
     {

--- a/src/main/java/net/dries007/tfc/common/recipes/outputs/ItemStackModifiers.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/outputs/ItemStackModifiers.java
@@ -41,6 +41,7 @@ public class ItemStackModifiers
 
     public static final Id<AddTraitModifier> ADD_TRAIT = register("add_trait", AddTraitModifier.CODEC, AddTraitModifier.STREAM_CODEC);
     public static final Id<RemoveTraitModifier> REMOVE_TRAIT = register("remove_trait", RemoveTraitModifier.CODEC, RemoveTraitModifier.STREAM_CODEC);
+    public static final Id<RoundCreationDateModifier> ROUND_CREATION_DATE = register("round_creation_date", RoundCreationDateModifier.INSTANCE);
     public static final Id<AddHeatModifier> ADD_HEAT = register("add_heat", AddHeatModifier.CODEC, AddHeatModifier.STREAM_CODEC);
     public static final Id<DyeLeatherModifier> DYE_LEATHER = register("dye_leather", DyeLeatherModifier.CODEC, DyeLeatherModifier.STREAM_CODEC);
     public static final Id<RemoveDyeModifier> REMOVE_DYE = register("remove_dye", RemoveDyeModifier.INSTANCE);

--- a/src/main/java/net/dries007/tfc/common/recipes/outputs/RoundCreationDateModifier.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/outputs/RoundCreationDateModifier.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the EUPL, Version 1.2.
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+package net.dries007.tfc.common.recipes.outputs;
+
+import net.dries007.tfc.common.component.food.FoodCapability;
+import net.minecraft.world.item.ItemStack;
+
+public enum RoundCreationDateModifier implements ItemStackModifier
+{
+    INSTANCE;
+
+    @Override
+    public ItemStack apply(ItemStack stack, ItemStack input, Context context)
+    {
+        return FoodCapability.roundCreationDate(stack);
+    }
+
+    @Override
+    public ItemStackModifierType<?> type()
+    {
+        return ItemStackModifiers.ROUND_CREATION_DATE.get();
+    }
+}

--- a/src/main/java/net/dries007/tfc/util/DataGenerationHelpers.java
+++ b/src/main/java/net/dries007/tfc/util/DataGenerationHelpers.java
@@ -41,6 +41,7 @@ import net.dries007.tfc.common.recipes.outputs.DamageCraftingRemainderModifier;
 import net.dries007.tfc.common.recipes.outputs.ExtraProductModifier;
 import net.dries007.tfc.common.recipes.outputs.ItemStackModifier;
 import net.dries007.tfc.common.recipes.outputs.ItemStackProvider;
+import net.dries007.tfc.common.recipes.outputs.RoundCreationDateModifier;
 
 public interface DataGenerationHelpers
 {
@@ -146,6 +147,8 @@ public interface DataGenerationHelpers
         }
 
         public Builder addTrait(Holder<FoodTrait> trait) {return addOutputModifier(AddTraitModifier.of(trait));}
+
+        public Builder roundCreationDate() {return addOutputModifier(RoundCreationDateModifier.INSTANCE);}
 
         public Builder addOutputModifier(ItemStackModifier modifier)
         {


### PR DESCRIPTION
As stated in issue #3244, shift clicking on the result of the food salting recipe creates two different item stacks with slightly different expiry dates. Rounding the creation date only solves this most of the time, but it's consistent with how we handle creation dates elsewhere and it's by far the simplest solution.