### PR TITLE
Fix quern diagram in field guide not visually connecting to the axle

### DIFF
--- a/src/main/java/net/dries007/tfc/client/render/blockentity/QuernBlockEntityRenderer.java
+++ b/src/main/java/net/dries007/tfc/client/render/blockentity/QuernBlockEntityRenderer.java
@@ -17,7 +17,7 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-
+import net.minecraft.world.level.block.Block;
 import net.dries007.tfc.client.RenderHelpers;
 import net.dries007.tfc.common.blockentities.QuernBlockEntity;
 import net.dries007.tfc.common.blocks.rotation.ConnectedAxleBlock;
@@ -88,7 +88,7 @@ public class QuernBlockEntityRenderer implements BlockEntityRenderer<QuernBlockE
         final float rotationAngle = quern.getRotationAngle(partialTicks);
 
         // If connected to the network, with a connected axle above, then render the axle connection to the quern
-        if (isConnectedToNetwork && level.getBlockState(quern.getBlockPos().above()).getBlock() instanceof ConnectedAxleBlock axleBlock)
+        if (isConnectedToNetwork && getBlockAboveQuern(level, quern) instanceof ConnectedAxleBlock axleBlock)
         {
             final VertexConsumer buffer = bufferSource.getBuffer(RenderType.cutout());
             final TextureAtlasSprite sprite = RenderHelpers.blockTexture(axleBlock.getAxleTextureLocation());
@@ -139,5 +139,15 @@ public class QuernBlockEntityRenderer implements BlockEntityRenderer<QuernBlockE
 
             stack.popPose();
         }
+    }
+
+    private Block getBlockAboveQuern(Level level, QuernBlockEntity quern)
+    {
+        Block blockAbove = quern.getAxleAboveOverride();
+        if (blockAbove != null)
+        {
+            return blockAbove;
+        }
+        return level.getBlockState(quern.getBlockPos().above()).getBlock();
     }
 }

--- a/src/main/java/net/dries007/tfc/common/blockentities/QuernBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/QuernBlockEntity.java
@@ -12,7 +12,6 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -20,8 +19,11 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.items.ItemStackHandler;
+
+import org.jetbrains.annotations.Nullable;
 
 import net.dries007.tfc.client.TFCSounds;
 import net.dries007.tfc.common.TFCTags;
@@ -35,8 +37,6 @@ import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.rotation.NetworkAction;
 import net.dries007.tfc.util.rotation.Node;
 import net.dries007.tfc.util.rotation.SinkNode;
-
-import static net.dries007.tfc.TerraFirmaCraft.*;
 
 public class QuernBlockEntity extends TickableInventoryBlockEntity<ItemStackHandler> implements RotationSinkBlockEntity
 {
@@ -129,6 +129,7 @@ public class QuernBlockEntity extends TickableInventoryBlockEntity<ItemStackHand
     private boolean needsStateUpdate = false;
     private float previousRotationDirection = 1;
     private float previousRotationSpeed = MANUAL_SPEED;
+    @Nullable private Block axleAboveOverride = null; // For rendering in the field guide
 
     public QuernBlockEntity(BlockPos pos, BlockState state)
     {
@@ -280,6 +281,22 @@ public class QuernBlockEntity extends TickableInventoryBlockEntity<ItemStackHand
     public void setHandstoneFromOutsideWorld()
     {
         inventory.setStackInSlot(SLOT_HANDSTONE, new ItemStack(TFCItems.HANDSTONE.get()));
+    }
+
+    public void setAxleAboveFromOutsideWorld(Block axle)
+    {
+        this.axleAboveOverride = axle;
+    }
+
+    /**
+     * Returns the axle block above, if set from the outside world for
+     * rendering in the field guide.
+     * @return The axle block above, or null
+     */
+    @Nullable
+    public Block getAxleAboveOverride()
+    {
+        return axleAboveOverride;
     }
 
     private void finishGrinding()

--- a/src/main/java/net/dries007/tfc/compat/patchouli/PatchouliIntegration.java
+++ b/src/main/java/net/dries007/tfc/compat/patchouli/PatchouliIntegration.java
@@ -338,6 +338,7 @@ public final class PatchouliIntegration
             access.getBlockEntity(new BlockPos(0, 1, 0), TFCBlockEntities.QUERN.get()).ifPresent(quern -> {
                 quern.getRotationNode().setRotationFromOutsideWorld();
                 quern.setHandstoneFromOutsideWorld();
+                quern.setAxleAboveFromOutsideWorld(TFCBlocks.WOODS.get(Wood.OAK).get(Wood.BlockType.AXLE).get());
             });
             access.getBlockEntity(new BlockPos(0, 2, 0), TFCBlockEntities.AXLE.get()).ifPresent(axle -> axle.getRotationNode().setRotationFromOutsideWorld());
         });


### PR DESCRIPTION
The quern doesn't render the little axle connection between the quern and its axle, because when it tries to query the block above it sees void air. This adds a field in the quern block entity to manually override which type of axle is above, so it can close that little gap. This is slightly sillier than the existing special handling of blockentities in the field guide diagrams, but I spent a while thinking about this and couldn't find a better solution. 