### PR TITLE
Make food with similar creation dates almost always able to stack

### DIFF
--- a/resources/constants.py
+++ b/resources/constants.py
@@ -2191,7 +2191,7 @@ DEFAULT_LANG = {
     'tfc.config.server.fireboxEnableAutomation': 'Enable Automation',
     'tfc.config.server.firePitEnableAutomation': 'Enable Automation',
     'tfc.config.server.foodDecayModifier': 'Food Decay Modifier',
-    'tfc.config.server.foodDecayStackTicks': 'Food Decay Stack Ticks',
+    'tfc.config.server.foodDecayStackTicks1': 'Food Decay Stack Ticks',
     'tfc.config.server.fruitBranchGrowthTicks': 'Fruit Branch Growth Ticks',
     'tfc.config.server.fruitPickBloomDelayTicks': 'Fruit Pick Bloom Delay Ticks',
     'tfc.config.server.saplingGrowthModifier': 'Sapling Growth Modifier',

--- a/src/main/java/net/dries007/tfc/common/component/ItemStackHooks.java
+++ b/src/main/java/net/dries007/tfc/common/component/ItemStackHooks.java
@@ -17,6 +17,7 @@ import net.dries007.tfc.common.component.food.FoodDefinition;
 import net.dries007.tfc.common.component.heat.HeatCapability;
 import net.dries007.tfc.common.component.heat.HeatComponent;
 import net.dries007.tfc.common.component.heat.HeatDefinition;
+import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.mixin.accessor.PatchedDataComponentMapAccessor;
 
 /**
@@ -113,6 +114,61 @@ public final class ItemStackHooks
             final @Nullable FoodComponent otherFood = otherComponents.get(TFCComponents.FOOD.get());
             if (otherFood != null) otherFood.sanitize();
         }
+    }
+
+    private static final ThreadLocal<Boolean> IN_FOOD_STACK_CHECK = ThreadLocal.withInitial(() -> false);
+
+    /**
+     * Check if foods with slightly different expiration dates should be able to be stacked
+     * together anyways.
+     * @return true if the food should stack, false to defer to vanilla logic
+     */
+    public static boolean shouldFoodStacksStack(ItemStack stack, ItemStack other)
+    {
+        // Prevent recursion
+        if (IN_FOOD_STACK_CHECK.get())
+        {
+            return false;
+        }
+
+        if (TFCComponents.FOOD.holder().isBound())
+        {
+            final @Nullable FoodComponent food = stack.get(TFCComponents.FOOD);
+            final @Nullable FoodComponent otherFood = other.get(TFCComponents.FOOD);
+            if (food != null && otherFood != null)
+            {
+                try
+                {
+                    IN_FOOD_STACK_CHECK.set(true);
+                    // This would call back into isSameItemSameComponents, so we need to prevent recursion
+                    if (!FoodCapability.areStacksStackableExceptCreationDate(stack, other))
+                    {
+                        return false;
+                    }
+                }
+                finally 
+                {
+                    IN_FOOD_STACK_CHECK.set(false);
+                }
+
+                final long creationDate = food.getCreationDate();
+                final long otherCreationDate = otherFood.getCreationDate();
+
+                if (creationDate == otherCreationDate)
+                {
+                    return true;
+                }
+
+                if (creationDate < 0 || otherCreationDate < 0)
+                {
+                    // If one of the creation dates is a special flag, do not stack
+                    return false;
+                }
+
+                return Math.abs(creationDate - otherCreationDate) <= TFCConfig.SERVER.foodDecayStackTicks.get();
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/net/dries007/tfc/config/ServerConfig.java
+++ b/src/main/java/net/dries007/tfc/config/ServerConfig.java
@@ -651,7 +651,7 @@ public class ServerConfig extends BaseConfig
         foodDecayStackTicks = builder.comment(
             "How many ticks should different foods ignore when trying to stack together automatically?",
             "Food made with different creation dates doesn't stack by default, unless it's within a specific window. This is the number of ticks that different foods will try and stack together at the loss of a little extra expiry time."
-        ).define("foodDecayStackTicks", 6 * ICalendar.CALENDAR_TICKS_IN_DAY, 1, Integer.MAX_VALUE);
+        ).define("foodDecayStackTicks1", 6 * ICalendar.CALENDAR_TICKS_IN_HOUR, 1, Integer.MAX_VALUE);
         foodDecayModifier = builder.comment(
             "A multiplier for food decay, or expiration times. Larger values will result in naturally shorter expiration times.",
             "Setting this to zero will cause decay not to apply.",

--- a/src/main/java/net/dries007/tfc/mixin/ItemStackMixin.java
+++ b/src/main/java/net/dries007/tfc/mixin/ItemStackMixin.java
@@ -39,12 +39,18 @@ public abstract class ItemStackMixin
     /**
      * Before performing an equality comparison of components on item
      * stacks, make sure both are sanitized.
+     * Then, check if food with slightly different expiration dates
+     * should be able to be stacked together.
      * @see ItemStackHooks#onCompareItemStackComponents
      */
-    @Inject(method = "isSameItemSameComponents", at = @At("HEAD"))
-    private static void sanitizeComponentsBeforeComparing(ItemStack stack, ItemStack other, CallbackInfoReturnable<Boolean> cir)
+    @Inject(method = "isSameItemSameComponents", at = @At("HEAD"), cancellable = true)
+    private static void sanitizeComponentsAndStackFood(ItemStack stack, ItemStack other, CallbackInfoReturnable<Boolean> cir)
     {
         ItemStackHooks.onCompareItemStackComponents(stack, other);
+        if (ItemStackHooks.shouldFoodStacksStack(stack, other))
+        {
+            cir.setReturnValue(true);
+        }
     }
 
     /**

--- a/src/main/resources/assets/tfc/lang/de_de.json
+++ b/src/main/resources/assets/tfc/lang/de_de.json
@@ -1357,7 +1357,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/en_us.json
+++ b/src/main/resources/assets/tfc/lang/en_us.json
@@ -1356,7 +1356,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/es_es.json
+++ b/src/main/resources/assets/tfc/lang/es_es.json
@@ -1356,7 +1356,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/ja_jp.json
+++ b/src/main/resources/assets/tfc/lang/ja_jp.json
@@ -1356,7 +1356,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/ko_kr.json
+++ b/src/main/resources/assets/tfc/lang/ko_kr.json
@@ -1357,7 +1357,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/pl_pl.json
+++ b/src/main/resources/assets/tfc/lang/pl_pl.json
@@ -1356,7 +1356,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/pt_br.json
+++ b/src/main/resources/assets/tfc/lang/pt_br.json
@@ -1356,7 +1356,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/ru_ru.json
+++ b/src/main/resources/assets/tfc/lang/ru_ru.json
@@ -1361,7 +1361,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Включить автоматизацию кострища",
   "tfc.config.server.foodDecayModifier": "Модификатор порчи пищи",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/tr_tr.json
+++ b/src/main/resources/assets/tfc/lang/tr_tr.json
@@ -1356,7 +1356,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/uk_ua.json
+++ b/src/main/resources/assets/tfc/lang/uk_ua.json
@@ -1364,7 +1364,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/zh_cn.json
+++ b/src/main/resources/assets/tfc/lang/zh_cn.json
@@ -1365,7 +1365,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/zh_hk.json
+++ b/src/main/resources/assets/tfc/lang/zh_hk.json
@@ -1363,7 +1363,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",

--- a/src/main/resources/assets/tfc/lang/zh_tw.json
+++ b/src/main/resources/assets/tfc/lang/zh_tw.json
@@ -1363,7 +1363,7 @@
   "tfc.config.server.fireboxEnableAutomation": "Enable Automation",
   "tfc.config.server.firePitEnableAutomation": "Enable Automation",
   "tfc.config.server.foodDecayModifier": "Food Decay Modifier",
-  "tfc.config.server.foodDecayStackTicks": "Food Decay Stack Ticks",
+  "tfc.config.server.foodDecayStackTicks1": "Food Decay Stack Ticks",
   "tfc.config.server.fruitBranchGrowthTicks": "Fruit Branch Growth Ticks",
   "tfc.config.server.fruitPickBloomDelayTicks": "Fruit Pick Bloom Delay Ticks",
   "tfc.config.server.saplingGrowthModifier": "Sapling Growth Modifier",


### PR DESCRIPTION
Modifies the ItemStack mixin to make the existing food stacking mechanic work in almost all contexts. I also found that the default stacking window is much longer than it should be due to a 1.21 migration mistake, so I changed it to the correct value and changed its path so it overwrites the old value for players using previous beta versions.

This could be abused by automatically farming one new food item every ~6 ingame hours and using it to advance the creation date of a stash of other food items, there's no good way to fix that if we want this nice behavior. Not sure how big a deal that is.