### PR TITLE
Fix sea ice doesn't cool hot items

### DIFF
--- a/src/main/java/net/dries007/tfc/ForgeEventHandler.java
+++ b/src/main/java/net/dries007/tfc/ForgeEventHandler.java
@@ -1094,7 +1094,7 @@ public final class ForgeEventHandler
                             level.destroyBlock(belowPos, false);
                         }
                     }
-                    else if (belowState.getBlock() == Blocks.ICE || belowState.getBlock() == Blocks.FROSTED_ICE)
+                    else if (belowState.getBlock() == Blocks.ICE || belowState.getBlock() == Blocks.FROSTED_ICE || Helpers.isBlock(belowState, TFCBlocks.SEA_ICE.get()))
                     {
                         coolAmount = 100f;
                         if (level.random.nextFloat() < 0.01F)


### PR DESCRIPTION
Bugfix: The if statement does not allow sea ice, even though the body of the statement assumes that sea ice is included. PR fixes this.