### PR TITLE
Added a check for water/lava when attempting to light a campfire

### DIFF
--- a/src/main/java/net/dries007/tfc/util/events/StartFireEvent.java
+++ b/src/main/java/net/dries007/tfc/util/events/StartFireEvent.java
@@ -12,6 +12,7 @@ import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 import net.dries007.tfc.common.blocks.TFCBlocks;
 import net.dries007.tfc.common.blocks.devices.FirepitBlock;
 import net.dries007.tfc.util.Helpers;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerPlayer;
@@ -27,6 +28,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.BaseFireBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.AABB;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.ICancellableEvent;
@@ -76,6 +78,13 @@ public final class StartFireEvent extends Event implements ICancellableEvent
     // Pass in a firepitBaseChance of -1 to disable firepit creation for a given firestarter
     public static boolean startFire(Level level, BlockPos pos, BlockState state, Direction direction, @Nullable Player player, ItemStack stack, FireStrength strength, double firepitBaseChance)
     {
+        final BlockPos abovePos = pos.above();
+        BlockState aboveBlockState = level.getBlockState(abovePos);
+        FluidState aboveFluidState = level.getFluidState(abovePos);
+        if (!aboveFluidState.isEmpty() || !aboveBlockState.isAir())
+        {
+            return false;
+        }
         final StartFireEvent event = new StartFireEvent(level, pos, state, direction, player, stack, strength);
         final boolean cancelled = NeoForge.EVENT_BUS.post(event).isCanceled();
 
@@ -86,7 +95,6 @@ public final class StartFireEvent extends Event implements ICancellableEvent
 
         if (!cancelled && event.isStrong())
         {
-            final BlockPos abovePos = pos.above();
             // Check conditions for creating a firepit if a valid firestarter
             if (FirepitBlock.canSurvive(level, abovePos) && firepitBaseChance != -1)
             {
@@ -171,7 +179,7 @@ public final class StartFireEvent extends Event implements ICancellableEvent
                 return true;
             }
         }
-        return cancelled;
+        return !cancelled;
     }
 
     private final Level world;


### PR DESCRIPTION
This pull request updates the fire-starting logic in `StartFireEvent.java` to improve how fires are created and prevented in the game. The main change is the addition of a safety check to ensure that fire cannot be started if the block above is not empty or contains a fluid, which helps prevent unintended fire placement. There is also a fix to the return value logic to correctly indicate whether the fire-starting event was cancelled.

**Fire Placement Safety Improvements**
* Added a check in `startFire` to prevent starting a fire if the block above the target position is not air or contains any fluid. This prevents fires from being created in invalid locations.
* Imported `FluidState` and used it to check for fluids above the fire-starting position.

**Logic and Return Value Fixes**
* Changed the return value at the end of `startFire` to `!cancelled` instead of `cancelled`, ensuring the method returns `true` when the event is not cancelled.

**Code Organization**
* Moved the calculation of `abovePos` and related block/fluid state checks to the beginning of `startFire`, ensuring the check happens before the event is posted. [[1]](diffhunk://#diff-56edb4ff2105c6df0cd3845ccf2d0476e1ea2ef41544c7932277d6b5de98851bR81-R87) [[2]](diffhunk://#diff-56edb4ff2105c6df0cd3845ccf2d0476e1ea2ef41544c7932277d6b5de98851bL89)

**Imports**
* Added missing imports for `FluidState` and reorganized import statements for clarity. [[1]](diffhunk://#diff-56edb4ff2105c6df0cd3845ccf2d0476e1ea2ef41544c7932277d6b5de98851bR15) [[2]](diffhunk://#diff-56edb4ff2105c6df0cd3845ccf2d0476e1ea2ef41544c7932277d6b5de98851bR31)