### PR TITLE
Empty Sewing Squares

### DIFF
--- a/src/data/java/net/dries007/tfc/data/recipes/SewingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/SewingRecipes.java
@@ -24,10 +24,10 @@ public interface SewingRecipes extends Recipes
             "  ## ##  ",
             "   # #   "
         ), List.of(
-            "   ##   ",
-            "  ####  ",
-            "  ####  ",
-            "   ##   "
+            "BBBWWBBB",
+            "BBWWWWBB",
+            "BBWWWWBB",
+            "BBBWWBBB"
         ), Items.FLOWER_BANNER_PATTERN);
         sewingRecipe(List.of(
             "  ## ##  ",
@@ -36,10 +36,10 @@ public interface SewingRecipes extends Recipes
             "  # # #  ",
             "  ## ##  "
         ), List.of(
-            "  #  #  ",
-            "        ",
-            "  ####  ",
-            "  #  #  "
+            "BBWBBWBB",
+            "BBBBBBBB",
+            "BBWWWWBB",
+            "BBWBBWBB"
         ), Items.CREEPER_BANNER_PATTERN);
         sewingRecipe(List.of(
             "  #   #  ",
@@ -48,10 +48,10 @@ public interface SewingRecipes extends Recipes
             "         ",
             "  #   #  "
         ), List.of(
-            "  ####  ",
-            "  #  #  ",
-            "  ####  ",
-            "  ####  "
+            "BBWWWWBB",
+            "BBWBBWBB",
+            "BBWWWWBB",
+            "BBWWWWBB"
         ), Items.SKULL_BANNER_PATTERN);
         sewingRecipe(List.of(
             "  ## ##  ",
@@ -60,10 +60,10 @@ public interface SewingRecipes extends Recipes
             "  ## ##  ",
             "  ## ##  "
         ), List.of(
-            "  ####  ",
-            "  #  #  ",
-            "  #  #  ",
-            "  ####  "
+            "BBWWWWBB",
+            "BBWBBWBB",
+            "BBWBBWBB",
+            "BBWWWWBB"
         ), Items.GLOBE_BANNER_PATTERN);
         sewingRecipe(List.of(
             "         ",
@@ -72,10 +72,10 @@ public interface SewingRecipes extends Recipes
             " # # # # ",
             "         "
         ), List.of(
-            "########",
-            "# #  # #",
-            "# #  # #",
-            "########"
+            "WWWWWWWW",
+            "WBWBBWBW",
+            "WBWBBWBW",
+            "WWWWWWWW"
         ), Items.PIGLIN_BANNER_PATTERN);
         sewingRecipe(List.of(
             "         ",
@@ -84,10 +84,10 @@ public interface SewingRecipes extends Recipes
             " # # # # ",
             "         "
         ), List.of(
-            "#####   ",
-            "#      #",
-            "#      #",
-            "########"
+            "WWWWBBBB",
+            "WBBBBBBW",
+            "WBBBBBBW",
+            "WWWWWWWW"
         ), Items.MOJANG_BANNER_PATTERN);
         sewingRecipe(List.of(
             "         ",
@@ -96,10 +96,10 @@ public interface SewingRecipes extends Recipes
             "    #    ",
             "    #    "
         ), List.of(
-            "   ##   ",
-            " ###### ",
-            "  ####  ",
-            "   ##   "
+            "BBBWWBBB",
+            "BWWWWWWB",
+            "BBWWWWBB",
+            "BBBWWBBB"
         ), Items.GUSTER_BANNER_PATTERN);
         sewingRecipe(List.of(
             "     # # ",
@@ -108,10 +108,10 @@ public interface SewingRecipes extends Recipes
             "    #    ",
             "     # # "
         ), List.of(
-            "     ## ",
-            "    ##  ",
-            "    ##  ",
-            "     ## "
+            "BBBBBWWB",
+            "BBBBWWBB",
+            "BBBBWWBB",
+            "BBBBBWWB"
         ), Items.COAST_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "         ",
@@ -120,10 +120,10 @@ public interface SewingRecipes extends Recipes
             "  #   #  ",
             " #     # "
         ), List.of(
-            "        ",
-            "   ##   ",
-            "  ####  ",
-            " ###### "
+            "BBBBBBBB",
+            "BBBWWBBB",
+            "BBWWWWBB",
+            "BWWWWWWB"
         ), Items.DUNE_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "   # #   ",
@@ -132,10 +132,10 @@ public interface SewingRecipes extends Recipes
             "  #   #  ",
             "   # #   "
         ), List.of(
-            "   ##   ",
-            "  #  #  ",
-            "  #  #  ",
-            "   ##   "
+            "BBBWWBBB",
+            "BBWBBWBB",
+            "BBWBBWBB",
+            "BBBWWBBB"
         ), Items.EYE_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "         ",
@@ -144,10 +144,10 @@ public interface SewingRecipes extends Recipes
             "         ",
             "     ##  "
         ), List.of(
-            "        ",
-            "########",
-            "     #  ",
-            "     #  "
+            "BBBBBBBB",
+            "WWWWWWWW",
+            "BBBBBWBB",
+            "BBBBBWBB"
         ), Items.HOST_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "         ",
@@ -156,10 +156,10 @@ public interface SewingRecipes extends Recipes
             "#####    ",
             "         "
         ), List.of(
-            "     ###",
-            "   ###  ",
-            " ###    ",
-            "##      "
+            "BBBBBWWW",
+            "BBBWWWBB",
+            "BWWWBBBB",
+            "WWBBBBBB"
         ), Items.RAISER_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "  # # #  ",
@@ -168,10 +168,10 @@ public interface SewingRecipes extends Recipes
             "         ",
             " # # #   "
         ), List.of(
-            "  # # # ",
-            "  # # # ",
-            " # # #  ",
-            " # # #  "
+            "BBWBWBWB",
+            "BBWBWBWB",
+            "BWBWBWBB",
+            "BWBWBWBB"
         ), Items.RIB_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "   # #   ",
@@ -180,10 +180,10 @@ public interface SewingRecipes extends Recipes
             "         ",
             "   # #   "
         ), List.of(
-            "   ##   ",
-            "###  ###",
-            "  #  #  ",
-            "   ##   "
+            "BBBWWBBB",
+            "WWWBBWWW",
+            "BBWBBWBB",
+            "BBBWWBBB"
         ), Items.SENTRY_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "      #  ",
@@ -192,10 +192,10 @@ public interface SewingRecipes extends Recipes
             "  #      ",
             "   #     "
         ), List.of(
-            "      # ",
-            "   ###  ",
-            "   #    ",
-            "  #     "
+            "BBBBBBWB",
+            "BBBWWWBB",
+            "BBBWBBBB",
+            "BBWBBBBB"
         ), Items.SHAPER_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "  #      ",
@@ -204,10 +204,10 @@ public interface SewingRecipes extends Recipes
             "         ",
             "     ##  "
         ), List.of(
-            "  #     ",
-            "  ###   ",
-            "    #   ",
-            "    ##  "
+            "BBWBBBBB",
+            "BBWWWBBB",
+            "BBBBWBBB",
+            "BBBBWWBB"
         ), Items.SILENCE_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             " #     # ",
@@ -216,10 +216,10 @@ public interface SewingRecipes extends Recipes
             "# #   # #",
             " #     # "
         ), List.of(
-            "        ",
-            " #    # ",
-            " #    # ",
-            "        "
+            "BBBBBBBB",
+            "BWBBBBWB",
+            "BWBBBBWB",
+            "BBBBBBBB"
         ), Items.SNOUT_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "         ",
@@ -228,10 +228,10 @@ public interface SewingRecipes extends Recipes
             "  ## ##  ",
             "         "
         ), List.of(
-            "  #  #  ",
-            "  #  #  ",
-            "  #  #  ",
-            "  ####  "
+            "BBWBBWBB",
+            "BBWBBWBB",
+            "BBWBBWBB",
+            "BBWWWWBB"
         ), Items.SPIRE_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             " # #     ",
@@ -240,10 +240,10 @@ public interface SewingRecipes extends Recipes
             "    # #  ",
             " # #     "
         ), List.of(
-            " ###    ",
-            "    ### ",
-            "    ### ",
-            " ###    "
+            "BWWWBBBB",
+            "BBBBWWWB",
+            "BBBBWWWB",
+            "BWWWBBBB"
         ), Items.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "         ",
@@ -252,10 +252,10 @@ public interface SewingRecipes extends Recipes
             "####     ",
             "         "
         ), List.of(
-            "        ",
-            "###  #  ",
-            "### #   ",
-            "#####   "
+            "BBBBBBBB",
+            "WWWBBWBB",
+            "WWWBWBBB",
+            "WWWWWBBB"
         ), Items.VEX_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "     ##  ",
@@ -264,10 +264,10 @@ public interface SewingRecipes extends Recipes
             " #       ",
             "     ##  "
         ), List.of(
-            "     #  ",
-            " ##  #  ",
-            " ##  #  ",
-            "     #  "
+            "BBBBBWBB",
+            "BWWBBWBB",
+            "BWWBBWBB",
+            "BBBBBWBB"
         ), Items.WARD_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             " #       ",
@@ -276,10 +276,10 @@ public interface SewingRecipes extends Recipes
             "  # #    ",
             "       # "
         ), List.of(
-            " #   ## ",
-            " ##  # #",
-            "  # # # ",
-            "  ##   #"
+            "BWBBBWWB",
+            "BWWBBWBW",
+            "BBWBWBWB",
+            "BBWWBBBW"
         ), Items.WAYFINDER_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "         ",
@@ -288,10 +288,10 @@ public interface SewingRecipes extends Recipes
             "   # #   ",
             "   # #   "
         ), List.of(
-            "##    ##",
-            " ##  ## ",
-            "   ##   ",
-            "   ##   "
+            "WWBBBBWW",
+            "BWWBBWWB",
+            "BBBWWBBB",
+            "BBBWWBBB"
         ), Items.WILD_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "  #      ",
@@ -300,10 +300,10 @@ public interface SewingRecipes extends Recipes
             "   #  #  ",
             "         "
         ), List.of(
-            "  ####  ",
-            "  # ##  ",
-            "  #     ",
-            "  ####  "
+            "BBWWWWBB",
+            "BBWBWWBB",
+            "BBWBBBBB",
+            "BBWWWWBB"
         ), Items.FLOW_ARMOR_TRIM_SMITHING_TEMPLATE);
         sewingRecipe(List.of(
             "         ",
@@ -312,10 +312,10 @@ public interface SewingRecipes extends Recipes
             "  #      ",
             "      #  "
         ), List.of(
-            " # #    ",
-            " # #  # ",
-            " #    # ",
-            " #### # "
+            "BWBWBBBB",
+            "BWBWBBWB",
+            "BWBBBBWB",
+            "BWWWWBWB"
         ), Items.BOLT_ARMOR_TRIM_SMITHING_TEMPLATE);
     }
 

--- a/src/generated/resources/data/tfc/recipe/sewing/bolt_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/bolt_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:bolt_armor_trim_smithing_template"
   },
   "squares": [
-    " # #    ",
-    " # #  # ",
-    " #    # ",
-    " #### # "
+    "BWBWBBBB",
+    "BWBWBBWB",
+    "BWBBBBWB",
+    "BWWWWBWB"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/coast_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/coast_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:coast_armor_trim_smithing_template"
   },
   "squares": [
-    "     ## ",
-    "    ##  ",
-    "    ##  ",
-    "     ## "
+    "BBBBBWWB",
+    "BBBBWWBB",
+    "BBBBWWBB",
+    "BBBBBWWB"
   ],
   "stitches": [
     "     # # ",

--- a/src/generated/resources/data/tfc/recipe/sewing/creeper_banner_pattern.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/creeper_banner_pattern.json
@@ -5,10 +5,10 @@
     "id": "minecraft:creeper_banner_pattern"
   },
   "squares": [
-    "  #  #  ",
-    "        ",
-    "  ####  ",
-    "  #  #  "
+    "BBWBBWBB",
+    "BBBBBBBB",
+    "BBWWWWBB",
+    "BBWBBWBB"
   ],
   "stitches": [
     "  ## ##  ",

--- a/src/generated/resources/data/tfc/recipe/sewing/dune_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/dune_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:dune_armor_trim_smithing_template"
   },
   "squares": [
-    "        ",
-    "   ##   ",
-    "  ####  ",
-    " ###### "
+    "BBBBBBBB",
+    "BBBWWBBB",
+    "BBWWWWBB",
+    "BWWWWWWB"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/eye_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/eye_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:eye_armor_trim_smithing_template"
   },
   "squares": [
-    "   ##   ",
-    "  #  #  ",
-    "  #  #  ",
-    "   ##   "
+    "BBBWWBBB",
+    "BBWBBWBB",
+    "BBWBBWBB",
+    "BBBWWBBB"
   ],
   "stitches": [
     "   # #   ",

--- a/src/generated/resources/data/tfc/recipe/sewing/flow_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/flow_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:flow_armor_trim_smithing_template"
   },
   "squares": [
-    "  ####  ",
-    "  # ##  ",
-    "  #     ",
-    "  ####  "
+    "BBWWWWBB",
+    "BBWBWWBB",
+    "BBWBBBBB",
+    "BBWWWWBB"
   ],
   "stitches": [
     "  #      ",

--- a/src/generated/resources/data/tfc/recipe/sewing/flower_banner_pattern.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/flower_banner_pattern.json
@@ -5,10 +5,10 @@
     "id": "minecraft:flower_banner_pattern"
   },
   "squares": [
-    "   ##   ",
-    "  ####  ",
-    "  ####  ",
-    "   ##   "
+    "BBBWWBBB",
+    "BBWWWWBB",
+    "BBWWWWBB",
+    "BBBWWBBB"
   ],
   "stitches": [
     "   # #   ",

--- a/src/generated/resources/data/tfc/recipe/sewing/globe_banner_pattern.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/globe_banner_pattern.json
@@ -5,10 +5,10 @@
     "id": "minecraft:globe_banner_pattern"
   },
   "squares": [
-    "  ####  ",
-    "  #  #  ",
-    "  #  #  ",
-    "  ####  "
+    "BBWWWWBB",
+    "BBWBBWBB",
+    "BBWBBWBB",
+    "BBWWWWBB"
   ],
   "stitches": [
     "  ## ##  ",

--- a/src/generated/resources/data/tfc/recipe/sewing/guster_banner_pattern.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/guster_banner_pattern.json
@@ -5,10 +5,10 @@
     "id": "minecraft:guster_banner_pattern"
   },
   "squares": [
-    "   ##   ",
-    " ###### ",
-    "  ####  ",
-    "   ##   "
+    "BBBWWBBB",
+    "BWWWWWWB",
+    "BBWWWWBB",
+    "BBBWWBBB"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/host_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/host_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:host_armor_trim_smithing_template"
   },
   "squares": [
-    "        ",
-    "########",
-    "     #  ",
-    "     #  "
+    "BBBBBBBB",
+    "WWWWWWWW",
+    "BBBBBWBB",
+    "BBBBBWBB"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/mojang_banner_pattern.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/mojang_banner_pattern.json
@@ -5,10 +5,10 @@
     "id": "minecraft:mojang_banner_pattern"
   },
   "squares": [
-    "#####   ",
-    "#      #",
-    "#      #",
-    "########"
+    "WWWWBBBB",
+    "WBBBBBBW",
+    "WBBBBBBW",
+    "WWWWWWWW"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/piglin_banner_pattern.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/piglin_banner_pattern.json
@@ -5,10 +5,10 @@
     "id": "minecraft:piglin_banner_pattern"
   },
   "squares": [
-    "########",
-    "# #  # #",
-    "# #  # #",
-    "########"
+    "WWWWWWWW",
+    "WBWBBWBW",
+    "WBWBBWBW",
+    "WWWWWWWW"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/raiser_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/raiser_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:raiser_armor_trim_smithing_template"
   },
   "squares": [
-    "     ###",
-    "   ###  ",
-    " ###    ",
-    "##      "
+    "BBBBBWWW",
+    "BBBWWWBB",
+    "BWWWBBBB",
+    "WWBBBBBB"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/rib_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/rib_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:rib_armor_trim_smithing_template"
   },
   "squares": [
-    "  # # # ",
-    "  # # # ",
-    " # # #  ",
-    " # # #  "
+    "BBWBWBWB",
+    "BBWBWBWB",
+    "BWBWBWBB",
+    "BWBWBWBB"
   ],
   "stitches": [
     "  # # #  ",

--- a/src/generated/resources/data/tfc/recipe/sewing/sentry_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/sentry_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:sentry_armor_trim_smithing_template"
   },
   "squares": [
-    "   ##   ",
-    "###  ###",
-    "  #  #  ",
-    "   ##   "
+    "BBBWWBBB",
+    "WWWBBWWW",
+    "BBWBBWBB",
+    "BBBWWBBB"
   ],
   "stitches": [
     "   # #   ",

--- a/src/generated/resources/data/tfc/recipe/sewing/shaper_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/shaper_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:shaper_armor_trim_smithing_template"
   },
   "squares": [
-    "      # ",
-    "   ###  ",
-    "   #    ",
-    "  #     "
+    "BBBBBBWB",
+    "BBBWWWBB",
+    "BBBWBBBB",
+    "BBWBBBBB"
   ],
   "stitches": [
     "      #  ",

--- a/src/generated/resources/data/tfc/recipe/sewing/silence_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/silence_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:silence_armor_trim_smithing_template"
   },
   "squares": [
-    "  #     ",
-    "  ###   ",
-    "    #   ",
-    "    ##  "
+    "BBWBBBBB",
+    "BBWWWBBB",
+    "BBBBWBBB",
+    "BBBBWWBB"
   ],
   "stitches": [
     "  #      ",

--- a/src/generated/resources/data/tfc/recipe/sewing/skull_banner_pattern.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/skull_banner_pattern.json
@@ -5,10 +5,10 @@
     "id": "minecraft:skull_banner_pattern"
   },
   "squares": [
-    "  ####  ",
-    "  #  #  ",
-    "  ####  ",
-    "  ####  "
+    "BBWWWWBB",
+    "BBWBBWBB",
+    "BBWWWWBB",
+    "BBWWWWBB"
   ],
   "stitches": [
     "  #   #  ",

--- a/src/generated/resources/data/tfc/recipe/sewing/snout_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/snout_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:snout_armor_trim_smithing_template"
   },
   "squares": [
-    "        ",
-    " #    # ",
-    " #    # ",
-    "        "
+    "BBBBBBBB",
+    "BWBBBBWB",
+    "BWBBBBWB",
+    "BBBBBBBB"
   ],
   "stitches": [
     " #     # ",

--- a/src/generated/resources/data/tfc/recipe/sewing/spire_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/spire_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:spire_armor_trim_smithing_template"
   },
   "squares": [
-    "  #  #  ",
-    "  #  #  ",
-    "  #  #  ",
-    "  ####  "
+    "BBWBBWBB",
+    "BBWBBWBB",
+    "BBWBBWBB",
+    "BBWWWWBB"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/tide_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/tide_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:tide_armor_trim_smithing_template"
   },
   "squares": [
-    " ###    ",
-    "    ### ",
-    "    ### ",
-    " ###    "
+    "BWWWBBBB",
+    "BBBBWWWB",
+    "BBBBWWWB",
+    "BWWWBBBB"
   ],
   "stitches": [
     " # #     ",

--- a/src/generated/resources/data/tfc/recipe/sewing/vex_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/vex_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:vex_armor_trim_smithing_template"
   },
   "squares": [
-    "        ",
-    "###  #  ",
-    "### #   ",
-    "#####   "
+    "BBBBBBBB",
+    "WWWBBWBB",
+    "WWWBWBBB",
+    "WWWWWBBB"
   ],
   "stitches": [
     "         ",

--- a/src/generated/resources/data/tfc/recipe/sewing/ward_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/ward_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:ward_armor_trim_smithing_template"
   },
   "squares": [
-    "     #  ",
-    " ##  #  ",
-    " ##  #  ",
-    "     #  "
+    "BBBBBWBB",
+    "BWWBBWBB",
+    "BWWBBWBB",
+    "BBBBBWBB"
   ],
   "stitches": [
     "     ##  ",

--- a/src/generated/resources/data/tfc/recipe/sewing/wayfinder_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/wayfinder_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:wayfinder_armor_trim_smithing_template"
   },
   "squares": [
-    " #   ## ",
-    " ##  # #",
-    "  # # # ",
-    "  ##   #"
+    "BWBBBWWB",
+    "BWWBBWBW",
+    "BBWBWBWB",
+    "BBWWBBBW"
   ],
   "stitches": [
     " #       ",

--- a/src/generated/resources/data/tfc/recipe/sewing/wild_armor_trim_smithing_template.json
+++ b/src/generated/resources/data/tfc/recipe/sewing/wild_armor_trim_smithing_template.json
@@ -5,10 +5,10 @@
     "id": "minecraft:wild_armor_trim_smithing_template"
   },
   "squares": [
-    "##    ##",
-    " ##  ## ",
-    "   ##   ",
-    "   ##   "
+    "WWBBBBWW",
+    "BWWBBWWB",
+    "BBBWWBBB",
+    "BBBWWBBB"
   ],
   "stitches": [
     "         ",

--- a/src/main/java/net/dries007/tfc/client/screen/SewingTableScreen.java
+++ b/src/main/java/net/dries007/tfc/client/screen/SewingTableScreen.java
@@ -219,14 +219,14 @@ public class SewingTableScreen extends TFCContainerScreen<SewingTableContainer>
         super.renderBg(graphics, partialTick, mouseX, mouseY);
         forEachClothSquare((x, y, i) -> {
             final int mat = menu.getPlacedMaterial(i);
-            if (mat != -1)
+            if (mat != SewingTableContainer.EMPTY_ID)
             {
                 graphics.blit(TEXTURE, getScreenX(x * 12 + 6), getScreenY(y * 12 + 6), 208, mat == SewingTableContainer.BURLAP_ID ? 16 : 0, 12, 12);
             }
             else if (selectedRecipe != null)
             {
                 final int recipeMat = selectedRecipe.getSquare(i);
-                if (recipeMat != -1)
+                if (recipeMat != SewingTableContainer.EMPTY_ID)
                 {
                     graphics.blit(TEXTURE, getScreenX(x * 12 + 6), getScreenY(y * 12 + 6), 208, recipeMat == SewingTableContainer.BURLAP_ID ? 80 : 64, 12, 12);
                 }

--- a/src/main/java/net/dries007/tfc/common/container/SewingTableContainer.java
+++ b/src/main/java/net/dries007/tfc/common/container/SewingTableContainer.java
@@ -65,6 +65,7 @@ public class SewingTableContainer extends Container implements ISlotCallback, Bu
     public static final int SLOT_INPUT_1 = 2;
     public static final int SLOT_INPUT_2 = 3;
     public static final int SLOT_RESULT = 4;
+    public static final int EMPTY_ID = -1;
     public static final int BURLAP_ID = 0;
     public static final int WOOL_ID = 1;
     public static final int REMOVE_ID = 2;
@@ -96,9 +97,9 @@ public class SewingTableContainer extends Container implements ISlotCallback, Bu
         super(TFCContainerTypes.SEWING_TABLE.get(), windowId);
         this.access = access;
         this.inventory = new InventoryItemHandler(this, NUM_SLOTS);
-        addDataSlot(activeMaterialData).set(-1);
+        addDataSlot(activeMaterialData).set(EMPTY_ID);
         for (int i = 0; i < MAX_SQUARES; i++)
-            placedMaterialData.set(i, -1);
+            placedMaterialData.set(i, EMPTY_ID);
         for (int i = 0; i < MAX_STITCHES; i++)
             stitchData.set(i, 0);
         addDataSlots(placedMaterialData);
@@ -135,7 +136,7 @@ public class SewingTableContainer extends Container implements ISlotCallback, Bu
                 if (result.getItem() != inventory.getStackInSlot(SLOT_RESULT).getItem())
                 {
                     inventory.setStackInSlot(SLOT_RESULT, result);
-                    activeMaterialData.set(-1);
+                    activeMaterialData.set(EMPTY_ID);
                 }
             }, () -> inventory.setStackInSlot(SLOT_RESULT, ItemStack.EMPTY));
         });
@@ -230,7 +231,7 @@ public class SewingTableContainer extends Container implements ISlotCallback, Bu
             {
                 access.execute((level, pos) -> Helpers.playSound(level, pos, SoundEvents.WOOL_BREAK));
             }
-            placedMaterialData.set(buttonID - PLACED_SLOTS_OFFSET, activeMaterial == REMOVE_ID ? -1 : activeMaterial);
+            placedMaterialData.set(buttonID - PLACED_SLOTS_OFFSET, activeMaterial == REMOVE_ID ? EMPTY_ID : activeMaterial);
         }
         else if (buttonID == PLACE_STITCH_ID && extraNBT != null && !inventory.getStackInSlot(SLOT_TOOL).isEmpty())
         {
@@ -281,7 +282,7 @@ public class SewingTableContainer extends Container implements ISlotCallback, Bu
             usedString.set(0);
             activeMaterialData.set(-1);
             for (int i = 0; i < MAX_SQUARES; i++)
-                placedMaterialData.set(i, -1);
+                placedMaterialData.set(i, EMPTY_ID);
             for (int i = 0; i < MAX_STITCHES; i++)
                 stitchData.set(i, 0);
             Helpers.damageItem(inventory.getStackInSlot(SLOT_TOOL), player.level());

--- a/src/main/java/net/dries007/tfc/common/recipes/SewingRecipe.java
+++ b/src/main/java/net/dries007/tfc/common/recipes/SewingRecipe.java
@@ -6,6 +6,10 @@
 
 package net.dries007.tfc.common.recipes;
 
+import java.util.List;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import com.google.common.base.Splitter;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
@@ -26,6 +30,8 @@ public class SewingRecipe implements ISimpleRecipe<SewingTableContainer.Input>
 {
     private static final int MAX_STITCHES = SewingTableContainer.MAX_STITCHES;
 
+    private static final Pattern INVALID_SQUARES = Pattern.compile("[^ BW]+");
+
     private static Codec<String> flatCodec(int width, int height)
     {
         return Codec.string(width, width)
@@ -45,7 +51,21 @@ public class SewingRecipe implements ISimpleRecipe<SewingTableContainer.Input>
                 return builder.toString();
             }
         ).fieldOf("stitches").forGetter(c -> c.stitches),
-        flatCodec(8, 4).fieldOf("squares").forGetter(c -> c.squares),
+        flatCodec(8, 4).validate(squares -> {
+            final Matcher match = INVALID_SQUARES.matcher(squares);
+            if (match.find())
+            {
+                final List<Character> chars = match.results()
+                    .map(MatchResult::group)
+                    .<Character>mapMulti((s, c) -> {
+                        for (char ch : s.toCharArray()) c.accept(ch);
+                    })
+                    .distinct()
+                    .toList();
+                return DataResult.error(() -> "Invalid char(s) for cloth squares: " + chars);
+            }
+            return DataResult.success(squares);
+        }).fieldOf("squares").forGetter(c -> c.squares),
         ItemStack.CODEC.fieldOf("result").forGetter(c -> c.result)
     ).apply(i, SewingRecipe::new));
 
@@ -79,7 +99,7 @@ public class SewingRecipe implements ISimpleRecipe<SewingTableContainer.Input>
     }
 
     private final long stitches; // A bitset of 45 total stitches, where 0 = false, 1 = true
-    private final String squares; // A string of 32 total squares (characters), where ' ' = none, 'B' = burlap, 'N' = normal
+    private final String squares; // A string of 32 total squares (characters), where ' ' = none, 'B' = burlap, 'W' = wool
 
     private final ItemStack result;
 
@@ -97,7 +117,13 @@ public class SewingRecipe implements ISimpleRecipe<SewingTableContainer.Input>
 
     public int getSquare(int index)
     {
-        return squares.charAt(index) == '#' ? 1 : 0;
+        return switch (squares.charAt(index))
+        {
+            case ' ' -> SewingTableContainer.EMPTY_ID;
+            case 'B' -> SewingTableContainer.BURLAP_ID;
+            case 'W' -> SewingTableContainer.WOOL_ID;
+            default -> throw new IllegalStateException("Sewing Recipe has invalid square at index " + index);
+        };
     }
 
     @Override


### PR DESCRIPTION
Changes sewing recipes to accept empty squares

- The `squares` pattern now only accepts ` `, `B`, and `W` for empty, burlap, and wool cloths respectively
- The sewing recipe now has a validator for the `squares` pattern which enforces only those three chars may be used

Existing sewing recipes have been updated to match the new cloth chars