### PR TITLE
Try fluid transfer from block to item if block is full of fluid already

### DIFF
--- a/src/main/java/net/dries007/tfc/common/fluids/FluidHelpers.java
+++ b/src/main/java/net/dries007/tfc/common/fluids/FluidHelpers.java
@@ -154,11 +154,11 @@ public final class FluidHelpers
     /**
      * Invoked from a block entity when an item is interacting with it. Assumes:
      * <ul>
-     *     <li>The block entity has a arbitrary sized, continuous valued fluid tank</li>
+     *     <li>The block entity has an arbitrary sized, continuous valued fluid tank</li>
      *     <li>The item has an arbitrary sized, <strong>possibly discrete</strong>, possibly continuous valued fluid tank.</li>
      * </ul>
      * <br>
-     * If the item is empty, it will attempt to fill the item from the fluid tank. If the item contains any fluid, it will attempt to fill the fluid block entity from the item.
+     * If the item is empty or the block is full, it will attempt to fill the item from the fluid tank. Otherwise, it will attempt to fill the fluid block entity from the item.
      *
      * @return {@code true} if a transfer occurred.
      */
@@ -181,7 +181,7 @@ public final class FluidHelpers
         }
 
         final FluidStack aggressiveDrained = itemHandler.drain(Integer.MAX_VALUE, IFluidHandler.FluidAction.SIMULATE);
-        if (aggressiveDrained.isEmpty())
+        if (aggressiveDrained.isEmpty() || blockHandler.fill(aggressiveDrained, IFluidHandler.FluidAction.SIMULATE) <= 0)
         {
             // Transfer block -> item.
             return transferBetweenItemAndOther(originalStack, itemHandler, blockHandler, itemHandler, Transfer.FILL, level, pos, after);


### PR DESCRIPTION
PR is for 1.20, but the same change can be done in 1.21.

When interacting with a barrel, you can put fluid into it by right clicking it, and drain fluid from it by right clicking it if the item in your hand does not contain any fluid.

However, if the item in your hand isn't empty but contains any fluid (such as often happens with GregTech drums), the current code always tries to put this fluid into the barrel. If the barrel is already full, nothing happens. It doesn't try to drain from the barrel.

This PR checks if the barrel is full, and if so, it tries to drain the barrel into the item. This allows collecting fluids from multiple barrels very easily, where before it would be impossible to collect from more than one barrel in a row.

https://github.com/user-attachments/assets/ea30e673-9c98-4e05-b794-7f39ae7f2143

This also affects cauldrons, maybe also other blocks with fluids if there are any that use FluidHelper.