### PR TITLE
Small worldgen bugfixes

### DIFF
--- a/src/main/java/net/dries007/tfc/world/feature/plant/CreepingOceanPlantFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/plant/CreepingOceanPlantFeature.java
@@ -48,7 +48,7 @@ public class CreepingOceanPlantFeature extends Feature<CreepingPlantConfig>
             {
                 for (int y = 0; y < height; y++)
                 {
-                    if (x * x + z + z < radius * radius && context.random().nextFloat() < context.config().integrity())
+                    if ((x * x) + (z * z) < (radius * radius) && context.random().nextFloat() < context.config().integrity())
                     {
                         cursor.setWithOffset(pos, x, y, z);
                         if (EnvironmentHelpers.isWorldgenReplaceable(level, cursor) && cursor.getY() <= context.config().heightAboveTide() + maxTideHeight.noise(cursor.getX(), cursor.getZ()))
@@ -62,6 +62,7 @@ public class CreepingOceanPlantFeature extends Feature<CreepingPlantConfig>
                                 if (waterloggedState != null)
                                 {
                                     setBlock(level, cursor, waterloggedState.setValue(TFCBlockStateProperties.OPEN, isOpen));
+                                    return true;
                                 }
                             }
                         }

--- a/src/main/java/net/dries007/tfc/world/feature/plant/CreepingOceanPlantFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/plant/CreepingOceanPlantFeature.java
@@ -41,7 +41,8 @@ public class CreepingOceanPlantFeature extends Feature<CreepingPlantConfig>
         final int radius = context.config().radius();
         final int height = context.config().height();
         final BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
-
+        
+        boolean isSuccessful = false;
         for (int x = -radius; x <= radius; x++)
         {
             for (int z = -radius; z <= radius; z++)
@@ -62,7 +63,7 @@ public class CreepingOceanPlantFeature extends Feature<CreepingPlantConfig>
                                 if (waterloggedState != null)
                                 {
                                     setBlock(level, cursor, waterloggedState.setValue(TFCBlockStateProperties.OPEN, isOpen));
-                                    return true;
+                                    isSuccessful = true;
                                 }
                             }
                         }
@@ -70,7 +71,7 @@ public class CreepingOceanPlantFeature extends Feature<CreepingPlantConfig>
                 }
             }
         }
-
-        return false;
+        
+        return isSuccessful;
     }
 }

--- a/src/main/java/net/dries007/tfc/world/feature/plant/RotatableWaterPlantFeature.java
+++ b/src/main/java/net/dries007/tfc/world/feature/plant/RotatableWaterPlantFeature.java
@@ -41,7 +41,7 @@ public class RotatableWaterPlantFeature extends Feature<BlockConfig<RotatableWat
         if (!EnvironmentHelpers.isWorldgenReplaceable(level, pos))
             return false;
         BlockState state = context.config().block().defaultBlockState();
-        for (Direction direction : Direction.allShuffled(RandomSource.create()))
+        for (Direction direction : Direction.allShuffled(random))
         {
             state = state.setValue(RotatableWaterPlantBlock.FACING, direction);
             if (state.canSurvive(level, pos))

--- a/src/main/java/net/dries007/tfc/world/layer/MoreShoresLayer.java
+++ b/src/main/java/net/dries007/tfc/world/layer/MoreShoresLayer.java
@@ -30,7 +30,7 @@ public enum MoreShoresLayer implements AdjacentTransformLayer
             {
                 return TFCLayers.SEA_STACKS;
             }
-            if (matcher.test(layer -> layer == TFCLayers.TIDAL_FLATS && layer == TFCLayers.SHORE))
+            if (matcher.test(layer -> layer == TFCLayers.TIDAL_FLATS || layer == TFCLayers.SHORE))
             {
                 return TFCLayers.SHORE;
             }

--- a/src/main/java/net/dries007/tfc/world/region/ChooseBiomes.java
+++ b/src/main/java/net/dries007/tfc/world/region/ChooseBiomes.java
@@ -166,7 +166,7 @@ public enum ChooseBiomes implements RegionTask
             final byte age = point.hotSpotAge;
             if (age > 0)
             {
-                if (age == 4 && point.biome == OCEAN || point.biome == DEEP_OCEAN || point.biome == OCEAN_REEF || point.biome == DEEP_OCEAN_TRENCH)
+                if (age == 4 && (point.biome == OCEAN || point.biome == DEEP_OCEAN || point.biome == OCEAN_REEF || point.biome == DEEP_OCEAN_TRENCH))
                 {
                     point.biome = SUNKEN_SHIELD_VOLCANO;
                 }

--- a/src/main/java/net/dries007/tfc/world/region/ChooseRocks.java
+++ b/src/main/java/net/dries007/tfc/world/region/ChooseRocks.java
@@ -40,7 +40,7 @@ public enum ChooseRocks implements RegionTask
         int type = center.land() ? LAND : OCEAN, minDist = Integer.MAX_VALUE;
         for (int dx = -2; dx <= 2; dx++)
         {
-            for (int dz = 0; dz <= 2; dz++)
+            for (int dz = -2; dz <= 2; dz++)
             {
                 final @Nullable Region.Point point = region.atOffset(index, dx, dz);
                 final int dist = Math.abs(dx) + Math.abs(dz);

--- a/src/main/java/net/dries007/tfc/world/surface/builder/TuyaSurfaceBuilder.java
+++ b/src/main/java/net/dries007/tfc/world/surface/builder/TuyaSurfaceBuilder.java
@@ -68,7 +68,7 @@ public class TuyaSurfaceBuilder implements SurfaceBuilder
             }
             else if (context.isDefaultBlock(stateAt))
             {
-                if (y > context.biome().getCenteredFeatureRockHeight() + noise)
+                if (y > context.tuyaBiome().getCenteredFeatureRockHeight() + noise)
                 {
                     if (surfaceDepth == -1)
                     {


### PR DESCRIPTION
TFG's recently been backporting the new 1.21 worldgen code, and one of our team members (@Mqrius) [found a bunch of things](https://github.com/TerraFirmaGreg-Team/Core-Modern/pull/364) that looked bug-shaped. Here's some potential fixes for some of the ones that looked like bugs -- please let me know if any of them are intentional.

Here's a few other things he found that we aren't sure about:

* [BiomeBuilder.cinderCones](https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1f51ee70b19e9c654d1f5f75320b6ce2fa292e94/src/main/java/net/dries007/tfc/world/biome/BiomeBuilder.java#L193)
The `additive` parameter is unused

* [ChunkNoiseFiller.calculateNoiseAtHeight](https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1f51ee70b19e9c654d1f5f75320b6ce2fa292e94/src/main/java/net/dries007/tfc/world/ChunkNoiseFiller.java#L538) 
from mqrius' review:
> There's something off here. The river and the shore both add to the noise without any reset inbetween, but that results in the noise summing up to 2 instead of to 1. It's notably different from how ChunkHeightFiller does it. The practical result would be that it's easier for AIR_THRESHOLD to be exceeded (it's as if it's set to 0.2 instead of 0.4), which would make more blocks air. It's also harder for cave carvers to cross the threshold, so caves are rarer and smaller than intended.
> But maybe all the other values are already jiggled such that this doesn't show up as a bug. If the worldgen looks good this way then you could leave it.


* [ChunkHeightFiller.sampleColumnHeightAndBiome](https://github.com/TerraFirmaCraft/TerraFirmaCraft/blob/1f51ee70b19e9c654d1f5f75320b6ce2fa292e94/src/main/java/net/dries007/tfc/world/ChunkHeightFiller.java#L114)
`shoreBaseHeight` and `oceanHeight` are written to but never read

(mqrius deserves all the credit/blame for these, I'm just putting them into TFC to a) check if they're actually bugs, and b) to keep parity)