### PR TITLE
Finding a spawn biome only ever attempts at the positive max radius

### DIFF
--- a/src/main/java/net/dries007/tfc/world/biome/BiomeSourceExtension.java
+++ b/src/main/java/net/dries007/tfc/world/biome/BiomeSourceExtension.java
@@ -76,7 +76,7 @@ public interface BiomeSourceExtension
         BlockPos found = null;
         int count = 0;
 
-        for (int radius = maxRadius; radius <= maxRadius; radius += step)
+        for (int radius = -maxRadius; radius <= maxRadius; radius += step)
         {
             for (int dx = -radius; dx <= radius; dx += step)
             {


### PR DESCRIPTION
TFG found this while doing some custom spawn selection stuff, and it looked like a bug.
This is in 1.20 as well.