### PR TITLE
Sync anvil updates to bystanders

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/AnvilBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/AnvilBlockEntity.java
@@ -189,7 +189,7 @@ public class AnvilBlockEntity extends InventoryBlockEntity<AnvilBlockEntity.Anvi
                 }
             }
         }
-        setChanged();
+        markForSync();
     }
 
     @Override


### PR DESCRIPTION
Currently when one player puts items in the anvil, a bystander doesn't see those items rendered on the anvil until they interact with it. Same with removing items.

This PR fixes that by marking the anvil for client syncing, rather than just updating it serverside.

Fixes part of https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/1855