### PR TITLE
Backport: Fix Blast Furnace Fuel Leak

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/BlastFurnaceBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/BlastFurnaceBlockEntity.java
@@ -362,19 +362,21 @@ public class BlastFurnaceBlockEntity extends TickableInventoryBlockEntity<BlastF
     public void onCalendarUpdate(long ticks)
     {
         assert level != null;
-
-        final HeatCapability.Remainder remainder = HeatCapability.consumeFuelForTicks(ticks, burnTicks, burnTemperature, fuelStacks);
-
-        burnTicks = remainder.burnTicks();
-        burnTemperature = remainder.burnTemperature();
-
-        if (remainder.ticks() > 0)
+        if(level.getBlockState(worldPosition).getValue(BlastFurnaceBlock.LIT))
         {
-            // Consumed all fuel, so extinguish and cool instantly
-            extinguish(getBlockState());
-            for (ItemStack stack : inputStacks)
+            final HeatCapability.Remainder remainder = HeatCapability.consumeFuelForTicks(ticks, burnTicks, burnTemperature, fuelStacks);
+
+            burnTicks = remainder.burnTicks();
+            burnTemperature = remainder.burnTemperature();
+
+            if (remainder.ticks() > 0)
             {
-                HeatCapability.setTemperature(stack, 0);
+                // Consumed all fuel, so extinguish and cool instantly
+                extinguish(getBlockState());
+                for (ItemStack stack : inputStacks)
+                {
+                    HeatCapability.setTemperature(stack, 0);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes blast furnace consuming fuel on time skips when non lit
(cherry picked from commit 5194da44fe1fa0d66bd6b84de1ad5fa06b6a98dd)