### PR TITLE
Fix #3508

### DIFF
--- a/src/main/java/net/dries007/tfc/common/fluids/TFCFluids.java
+++ b/src/main/java/net/dries007/tfc/common/fluids/TFCFluids.java
@@ -126,7 +126,8 @@ public final class TFCFluids
             .canHydrate(false)
             .canPushEntity(false)
             .canSwim(false)
-            .supportsBoating(false);
+            .supportsBoating(false)
+            .fallDistanceModifier(0);
     }
 
     private static FluidType.Properties waterLike()
@@ -141,7 +142,8 @@ public final class TFCFluids
             .canHydrate(true)
             .canPushEntity(true)
             .canSwim(true)
-            .supportsBoating(true);
+            .supportsBoating(true)
+            .fallDistanceModifier(0);
     }
 
     private static <F extends FlowingFluid> FluidHolder<F> register(String name, Consumer<BaseFlowingFluid.Properties> builder, FluidType.Properties typeProperties, Function<BaseFlowingFluid.Properties, F> sourceFactory, Function<BaseFlowingFluid.Properties, F> flowingFactory)


### PR DESCRIPTION
fixes tfc fluids not preventing fall damage, for both waterLike and lavaLike