### PR TITLE
Backport: Fix #3508 

### DIFF
--- a/src/main/java/net/dries007/tfc/common/fluids/TFCFluids.java
+++ b/src/main/java/net/dries007/tfc/common/fluids/TFCFluids.java
@@ -164,7 +164,8 @@ public final class TFCFluids
             .canHydrate(false)
             .canPushEntity(false)
             .canSwim(false)
-            .supportsBoating(false);
+            .supportsBoating(false)
+            .fallDistanceModifier(0);
     }
 
     private static FluidType.Properties waterLike()
@@ -179,7 +180,8 @@ public final class TFCFluids
             .canHydrate(true)
             .canPushEntity(true)
             .canSwim(true)
-            .supportsBoating(true);
+            .supportsBoating(true)
+            .fallDistanceModifier(0);
     }
 
     private static <F extends FlowingFluid> FluidRegistryObject<F> register(String name, Consumer<ForgeFlowingFluid.Properties> builder, FluidType.Properties typeProperties, FluidTypeClientProperties clientProperties, Function<ForgeFlowingFluid.Properties, F> sourceFactory, Function<ForgeFlowingFluid.Properties, F> flowingFactory)


### PR DESCRIPTION
add fall damage prevention to TFC fluids
(cherry picked from commit 25714c4c78782776af80206ca7a7e493b43e1cb9)