### PR TITLE
Fixed roses spawning

### DIFF
--- a/src/main/resources/data/tfc/tags/worldgen/placed_feature/feature/land_plants.json
+++ b/src/main/resources/data/tfc/tags/worldgen/placed_feature/feature/land_plants.json
@@ -72,6 +72,7 @@
     "tfc:plant/pulsatilla_patch",
     "tfc:plant/red_sealing_wax_palm_patch",
     "tfc:plant/reindeer_lichen_patch",
+    "tfc:plant/rose_patch",
     "tfc:plant/sacred_datura_patch",
     "tfc:plant/sagebrush_patch",
     "tfc:plant/sago_patch",


### PR DESCRIPTION
Roses were missing from the `#tfc:land_plants` feature, so they were never being placed.

Noticed by @Froffy025 in https://github.com/TerraFirmaGreg-Team/Modpack-Modern/pull/3760