### PR TITLE
(1.21) Add fallback for rock generation before surface height cache is loaded

### DIFF
--- a/src/main/java/net/dries007/tfc/world/chunkdata/RockData.java
+++ b/src/main/java/net/dries007/tfc/world/chunkdata/RockData.java
@@ -10,6 +10,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
 import org.jetbrains.annotations.Nullable;
 
+import net.dries007.tfc.TerraFirmaCraft;
 import net.dries007.tfc.world.region.Units;
 import net.dries007.tfc.world.settings.RockSettings;
 
@@ -53,8 +54,18 @@ public final class RockData
 
     public RockSettings getRock(int x, int y, int z)
     {
-        assert generator != null && surfaceHeight != null;
-        return generator.generateRock(x, y, z, surfaceHeight[Units.index(x, z)], cache);
+        assert generator != null;
+        if (surfaceHeight != null)
+        {
+            return generator.generateRock(x, y, z, surfaceHeight[Units.index(x, z)], cache);
+        }
+        else
+        {
+            // Fallback in case a mod is trying to generate a TFC chunk before the surface height cache is populated,
+            // which has caused many crashes and incompatibilities in the past.
+            TerraFirmaCraft.LOGGER.warn("Queried rock data for position ({}, {}, {}) before surface height cache was populated", x, y, z);
+            return generator.generateRock(x, y, z, 64, cache);
+        }
     }
 
     public int[] getSurfaceHeight()


### PR DESCRIPTION
(Copied from 1.20 PR)

The surface height cache has been a recurring issue with mods that want to use TFC's chunk generation outside of a world gen setting such as Distant Horizons, and weather2 as the issue mentions. I think it's well worth a fallback in these cases, the slight shift in rock types at different elevations aren't a big deal in this fallback case.

Closes #3479