### PR TITLE
Backport: Barrel Rack Dupe Fix

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/devices/BarrelBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/BarrelBlock.java
@@ -254,7 +254,7 @@ public class BarrelBlock extends SealableDeviceBlock
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving)
     {
-        if (!(Helpers.isBlock(state, newState.getBlock())) && state.getValue(RACK) && !(newState.getBlock() instanceof BarrelRackBlock))
+        if (!(Helpers.isBlock(state, newState.getBlock())) && state.getValue(RACK) && !(newState.getBlock() instanceof BarrelRackBlock) && !isMoving)
         {
             Helpers.spawnItem(level, pos, new ItemStack(TFCBlocks.BARREL_RACK.get()));
         }


### PR DESCRIPTION
prevent barrels dropping their racks if they are being moved
(cherry picked from commit e27793dab9c82fa4d850d9d4b02aa1721c011bd1)