### PR TITLE
Block Tag to Prevent Icicle Generation (1.21.1)

### DIFF
--- a/src/main/java/net/dries007/tfc/common/TFCTags.java
+++ b/src/main/java/net/dries007/tfc/common/TFCTags.java
@@ -257,6 +257,7 @@ public class TFCTags
         public static final TagKey<Block> THERMOMETER_READABLE = tag("thermometer_readable");
         /**  */
         public static final TagKey<Block> CLOCK_READABLE = tag("clock_readable");
+        public static final TagKey<Block> NO_ICICLE_GENERATION = tag("no_icicle_generation");
 
         private static TagKey<Block> tag(String name)
         {

--- a/src/main/java/net/dries007/tfc/util/tracker/WeatherHelpers.java
+++ b/src/main/java/net/dries007/tfc/util/tracker/WeatherHelpers.java
@@ -427,7 +427,7 @@ public final class WeatherHelpers
             {
                 BlockPos posAbove = iciclePos.above();
                 BlockState stateAbove = level.getBlockState(posAbove);
-                if (Helpers.isBlock(stateAbove, BlockTags.ICE))
+                if (Helpers.isBlock(stateAbove, BlockTags.ICE) || Helpers.isBlock(stateAbove, TFCTags.Blocks.NO_ICICLE_GENERATION))
                 {
                     return;
                 }


### PR DESCRIPTION
### What is the new behavior?
Adds a block tag that prevents icicles from generating under those blocks. Useful for mod/modpack developers to prevent icicles from generating underneath blocks (e.g. Monorails).

### Additional Information
- I made this as a Mixin in the TFG modpack, but I thought that this could be useful for everyone.
- 1.20.1 PR: https://github.com/TerraFirmaCraft/TerraFirmaCraft/pull/3568