### PR TITLE
Molds and Channels

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/ChannelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/ChannelBlockEntity.java
@@ -16,6 +16,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.apache.commons.lang3.tuple.Pair;
 
 import net.dries007.tfc.common.blocks.devices.ChannelBlock;
+import net.dries007.tfc.util.ChannelFlow;
 import net.dries007.tfc.util.Helpers;
 
 public class ChannelBlockEntity extends TFCBlockEntity
@@ -137,11 +138,11 @@ public class ChannelBlockEntity extends TFCBlockEntity
      * Returns true iff the link from this channel to the source crucible
      * has been broken.
      */
-    public boolean isLinkBroken()
+    public boolean isFlowing()
     {
         if (flowSource.isEmpty() || recursion_visiting)
         {
-            return true;
+            return false;
         }
         try
         {
@@ -165,7 +166,7 @@ public class ChannelBlockEntity extends TFCBlockEntity
 
                 if (blockEntity.isEmpty())
                 {
-                    return true;
+                    return false;
                 }
 
                 for (byte i = 1; i < flowSource.get().getRight(); i++)
@@ -173,11 +174,17 @@ public class ChannelBlockEntity extends TFCBlockEntity
                     BlockPos rel = worldPosition.relative(flowSource.get().getLeft(), i);
                     if (!level.getBlockState(rel).isAir())
                     {
-                        return true;
+                        return false;
                     }
                 }
 
-                return blockEntity.get().isLinkBroken();
+                if (blockEntity.get().isFlowing())
+                {
+                    if (flowSource.get().getLeft() == Direction.UP && flowSource.get().getRight() > 1)
+                        ChannelFlow.damageEntities(level, worldPosition, flowSource.get().getRight());
+                    return true;
+                }
+                return false;
             }
             else // If expecting a crucible, then set broken only if crucible is not there
             {
@@ -185,7 +192,7 @@ public class ChannelBlockEntity extends TFCBlockEntity
                     expectedSourcePos,
                     TFCBlockEntities.CRUCIBLE.get());
 
-                return blockEntity.isEmpty();
+                return blockEntity.isPresent();
             }
 
         }

--- a/src/main/java/net/dries007/tfc/common/blockentities/ChannelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/ChannelBlockEntity.java
@@ -135,8 +135,7 @@ public class ChannelBlockEntity extends TFCBlockEntity
     }
 
     /***
-     * Returns true iff the link from this channel to the source crucible
-     * has been broken.
+     * Returns true if linked to the source crucible
      */
     public boolean isFlowing()
     {

--- a/src/main/java/net/dries007/tfc/common/blockentities/ChannelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/ChannelBlockEntity.java
@@ -53,6 +53,8 @@ public class ChannelBlockEntity extends TFCBlockEntity
     /*** Fluid to render */
     private ResourceLocation fluid = ResourceLocation.fromNamespaceAndPath("", "");
 
+    private boolean recursion_visiting = false;
+
     public boolean hasFlow()
     {
         return flowSource.isPresent();
@@ -108,8 +110,11 @@ public class ChannelBlockEntity extends TFCBlockEntity
      */
     public void notifyBrokenLink(int linksBroken)
     {
-        if (level == null)
+        if (level == null || recursion_visiting)
             return;
+
+        recursion_visiting = true;
+
         numFlows -= linksBroken;
 
         flowSource.ifPresent(
@@ -124,6 +129,8 @@ public class ChannelBlockEntity extends TFCBlockEntity
             level.setBlock(worldPosition, getBlockState().setValue(ChannelBlock.WITH_METAL, false), 3);
             markForSync();
         }
+
+        recursion_visiting = false;
     }
 
     /***
@@ -132,50 +139,59 @@ public class ChannelBlockEntity extends TFCBlockEntity
      */
     public boolean isLinkBroken()
     {
-        if (flowSource.isEmpty())
+        if (flowSource.isEmpty() || recursion_visiting)
         {
             return true;
         }
-
-        Direction expectedDirection = flowSource.get().getLeft();
-        int expectedDistance = flowSource.get().getRight();
-        BlockPos expectedSourcePos = worldPosition.relative(expectedDirection, expectedDistance);
-
-        // If expecting a channel, find the channel block entity
-        // If it's not present (the channel was broken, for example),
-        // then return true (broken link). Otherwise, recursively
-        // call this function for the channel block entity found.
-        // Also break if distance from source is >1 and there is no
-        // air in-between
-        if (isConnectedToAnotherChannel)
+        try
         {
-            Optional<ChannelBlockEntity> blockEntity = level.getBlockEntity(
-                expectedSourcePos,
-                TFCBlockEntities.CHANNEL.get());
+            recursion_visiting = true;
 
-            if (blockEntity.isEmpty())
-            {
-                return true;
-            }
+            Direction expectedDirection = flowSource.get().getLeft();
+            int expectedDistance = flowSource.get().getRight();
+            BlockPos expectedSourcePos = worldPosition.relative(expectedDirection, expectedDistance);
 
-            for (byte i = 1; i < flowSource.get().getRight(); i++)
+            // If expecting a channel, find the channel block entity
+            // If it's not present (the channel was broken, for example),
+            // then return true (broken link). Otherwise, recursively
+            // call this function for the channel block entity found.
+            // Also break if distance from source is >1 and there is no
+            // air in-between
+            if (isConnectedToAnotherChannel)
             {
-                BlockPos rel = worldPosition.relative(flowSource.get().getLeft(), i);
-                if (!level.getBlockState(rel).isAir())
+                Optional<ChannelBlockEntity> blockEntity = level.getBlockEntity(
+                    expectedSourcePos,
+                    TFCBlockEntities.CHANNEL.get());
+
+                if (blockEntity.isEmpty())
                 {
                     return true;
                 }
+
+                for (byte i = 1; i < flowSource.get().getRight(); i++)
+                {
+                    BlockPos rel = worldPosition.relative(flowSource.get().getLeft(), i);
+                    if (!level.getBlockState(rel).isAir())
+                    {
+                        return true;
+                    }
+                }
+
+                return blockEntity.get().isLinkBroken();
+            }
+            else // If expecting a crucible, then set broken only if crucible is not there
+            {
+                Optional<CrucibleBlockEntity> blockEntity = level.getBlockEntity(
+                    expectedSourcePos,
+                    TFCBlockEntities.CRUCIBLE.get());
+
+                return blockEntity.isEmpty();
             }
 
-            return blockEntity.get().isLinkBroken();
         }
-        else // If expecting a crucible, then set broken only if crucible is not there
+        finally
         {
-            Optional<CrucibleBlockEntity> blockEntity = level.getBlockEntity(
-                expectedSourcePos,
-                TFCBlockEntities.CRUCIBLE.get());
-
-            return blockEntity.isEmpty();
+            recursion_visiting = false;
         }
     }
 

--- a/src/main/java/net/dries007/tfc/common/blockentities/MoldTableBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/MoldTableBlockEntity.java
@@ -413,12 +413,11 @@ public class MoldTableBlockEntity extends TickableInventoryBlockEntity<MoldTable
     public void setAndUpdateSlots(int slot)
     {
         super.setAndUpdateSlots(slot);
-        markForSync();
+        requestModelDataUpdate();
         if (level != null && level.isClientSide)
         {
             // Need to make sure that this gets called at least on the client
-            // TODO figure out why requestModelDataUpdate() does not update the already rendered model
-            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_CLIENTS);
+            level.sendBlockUpdated(worldPosition, getBlockState(), getBlockState(), Block.UPDATE_CLIENTS | Block.UPDATE_IMMEDIATE);
         }
     }
 

--- a/src/main/java/net/dries007/tfc/common/blockentities/MoldTableBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/MoldTableBlockEntity.java
@@ -47,6 +47,7 @@ import net.dries007.tfc.common.component.mold.IMold;
 import net.dries007.tfc.common.recipes.CastingRecipe;
 import net.dries007.tfc.common.recipes.InstantBarrelRecipe;
 import net.dries007.tfc.common.recipes.TFCRecipeTypes;
+import net.dries007.tfc.util.ChannelFlow;
 import net.dries007.tfc.util.FluidAlloy;
 import net.dries007.tfc.util.Helpers;
 
@@ -78,7 +79,7 @@ public class MoldTableBlockEntity extends TickableInventoryBlockEntity<MoldTable
                     Optional<IFluidHandler> fluidHandler = getFluidHandlerIfAppropriate(crucible, mold.fluid);
 
                     // If the chain of channels was broken, finish the flow
-                    if (fluidHandler.isEmpty() || mold.isLinkBroken())
+                    if (fluidHandler.isEmpty() || !mold.isFlowing())
                     {
                         mold.finishFlow();
                         return;
@@ -235,7 +236,7 @@ public class MoldTableBlockEntity extends TickableInventoryBlockEntity<MoldTable
         this.flowSource = Optional.of(flowSource);
     }
 
-    public boolean isLinkBroken()
+    public boolean isFlowing()
     {
         assert level != null;
         Optional<ChannelBlockEntity> blockEntity = level.getBlockEntity(
@@ -243,18 +244,24 @@ public class MoldTableBlockEntity extends TickableInventoryBlockEntity<MoldTable
             TFCBlockEntities.CHANNEL.get());
 
         if (blockEntity.isEmpty())
-            return true;
+            return false;
 
         for (byte i = 1; i < flowSource.get().getRight(); i++)
         {
             BlockPos rel = worldPosition.relative(flowSource.get().getLeft(), i);
             if (!level.getBlockState(rel).isAir())
             {
-                return true;
+                return false;
             }
         }
 
-        return blockEntity.get().isLinkBroken();
+        if (blockEntity.get().isFlowing())
+        {
+            if (flowSource.get().getLeft() == Direction.UP && flowSource.get().getRight() > 1)
+                ChannelFlow.damageEntities(level, worldPosition, flowSource.get().getRight());
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/blocks/devices/MoldTableBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/devices/MoldTableBlock.java
@@ -150,7 +150,7 @@ public class MoldTableBlock extends ExtendedBlock implements EntityBlockExtensio
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving)
     {
-        if (newState.getBlock() != state.getBlock())
+        if (newState.getBlock() != state.getBlock() && !isMoving)
         {
             level.getBlockEntity(pos, TFCBlockEntities.MOLD_TABLE.get()).ifPresent(
                 mold -> {

--- a/src/main/java/net/dries007/tfc/util/ChannelFlow.java
+++ b/src/main/java/net/dries007/tfc/util/ChannelFlow.java
@@ -16,29 +16,28 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import org.apache.commons.lang3.tuple.Pair;
-import org.jetbrains.annotations.Nullable;
-
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import net.dries007.tfc.common.blockentities.MoldTableBlockEntity;
-import net.dries007.tfc.common.blockentities.TFCBlockEntities;
-import net.dries007.tfc.common.blocks.devices.ChannelBlock;
-import net.dries007.tfc.common.blocks.devices.MoldTableBlock;
-import net.dries007.tfc.common.blockentities.CrucibleBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.LevelAccessor;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.items.IItemHandlerModifiable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.Nullable;
+
+import net.dries007.tfc.common.blockentities.ChannelBlockEntity;
+import net.dries007.tfc.common.blockentities.CrucibleBlockEntity;
+import net.dries007.tfc.common.blockentities.MoldTableBlockEntity;
+import net.dries007.tfc.common.blockentities.TFCBlockEntities;
 
 public class ChannelFlow
 {
@@ -101,16 +100,16 @@ public class ChannelFlow
         // improves performance a bit and most importantly prevents
         // a flickering rendered flow.
         molds.removeIf(
-                pos -> {
-                    Optional<MoldTableBlockEntity> moldEnt = level.getBlockEntity(pos, TFCBlockEntities.MOLD_TABLE.get());
+            pos -> {
+                Optional<MoldTableBlockEntity> moldEnt = level.getBlockEntity(pos, TFCBlockEntities.MOLD_TABLE.get());
 
-                    if (moldEnt.isEmpty())
-                        return true;
-                    if (!moldEnt.get().getOutputStack().isEmpty())
-                        return true;
-                    final FluidStack outputDrop = iFldHandler.get().drain(1, IFluidHandler.FluidAction.SIMULATE);
-                    return !couldBeFilled(moldEnt.get().getInventory(), outputDrop, MoldTableBlockEntity.MOLD_SLOT);
-                });
+                if (moldEnt.isEmpty())
+                    return true;
+                if (!moldEnt.get().getOutputStack().isEmpty())
+                    return true;
+                final FluidStack outputDrop = iFldHandler.get().drain(1, IFluidHandler.FluidAction.SIMULATE);
+                return !couldBeFilled(moldEnt.get().getInventory(), outputDrop, MoldTableBlockEntity.MOLD_SLOT);
+            });
 
         // Early exit if no (valid) molds are connected
         if (molds.size() == 0)
@@ -166,11 +165,11 @@ public class ChannelFlow
         for (BlockPos mold : molds)
         {
             List<BlockPos> path = aStar(
-                    graph,
-                    heuristic,
-                    0,
-                    channelsAndMolds.inverse().get(mold)).stream()
-                    .map(channelsAndMolds::get).toList(); // index to BlockPos
+                graph,
+                heuristic,
+                0,
+                channelsAndMolds.inverse().get(mold)).stream()
+                .map(channelsAndMolds::get).toList(); // index to BlockPos
             // goal (mold) to start (first channel)
 
             for (int i = 0; i < path.size() - 1; i++)
@@ -180,9 +179,9 @@ public class ChannelFlow
                 BlockPos relative = channelSource.offset(currentChannel.multiply(-1));
                 int distance = Math.abs(relative.getX() + relative.getY() + relative.getZ());
                 BlockPos normal = new BlockPos(relative.getX() / distance, relative.getY() / distance,
-                        relative.getZ() / distance);
+                    relative.getZ() / distance);
                 flowSource.put(currentChannel,
-                        Pair.of(Direction.fromDelta(normal.getX(), normal.getY(), normal.getZ()), (byte) distance));
+                    Pair.of(Direction.fromDelta(normal.getX(), normal.getY(), normal.getZ()), (byte) distance));
                 numFlows.put(channelSource, numFlows.getOrDefault(channelSource, 0) + 1);
             }
         }
@@ -190,23 +189,23 @@ public class ChannelFlow
         for (BlockPos channelOrMold : flowSource.keySet())
         {
             level.getBlockEntity(channelOrMold, TFCBlockEntities.CHANNEL.get()).ifPresent(
-                    channel -> {
-                        channel.setLinkProperties(
-                                flowSource.get(channelOrMold),
-                                true,
-                                numFlows.get(channelOrMold),
-                                fluidKey);
-                    });
+                channel -> {
+                    channel.setLinkProperties(
+                        flowSource.get(channelOrMold),
+                        true,
+                        numFlows.get(channelOrMold),
+                        fluidKey);
+                });
             level.getBlockEntity(channelOrMold, TFCBlockEntities.MOLD_TABLE.get()).ifPresent(
-                    mold -> mold.setSource(
-                            source.getBlockPos(), fluid, flowSource.get(channelOrMold)));
+                mold -> mold.setSource(
+                    source.getBlockPos(), fluid, flowSource.get(channelOrMold)));
         }
         BlockPos pos = source.getBlockPos().offset(originChannel.multiply(-1));
         level.getBlockEntity(originChannel, TFCBlockEntities.CHANNEL.get()).get().setLinkProperties(
-                Pair.of(Direction.fromDelta(pos.getX(), pos.getY(), pos.getZ()), (byte) 1),
-                false,
-                numFlows.get(originChannel),
-                fluidKey);
+            Pair.of(Direction.fromDelta(pos.getX(), pos.getY(), pos.getZ()), (byte) 1),
+            false,
+            numFlows.get(originChannel),
+            fluidKey);
     }
 
     private static List<BlockPos> findAdjacent(LevelAccessor level, BlockPos current, boolean findMolds)
@@ -224,13 +223,14 @@ public class ChannelFlow
             {
                 BlockPos relative = current.relative(dir, i);
                 BlockState blockState = level.getBlockState(relative);
+                BlockEntity blockEntity = level.getBlockEntity(relative);
 
-                if (findMolds && blockState.getBlock() instanceof MoldTableBlock)
+                if (findMolds && blockEntity instanceof MoldTableBlockEntity mold && !mold.hasSource())
                 {
                     adjacent.add(relative);
                     break;
                 }
-                else if (!findMolds && blockState.getBlock() instanceof ChannelBlock)
+                else if (!findMolds && blockEntity instanceof ChannelBlockEntity channel && !channel.hasFlow())
                 {
                     adjacent.add(relative);
                     break;
@@ -246,7 +246,7 @@ public class ChannelFlow
 
     /**
      * Finds the shortest distance between two nodes using the A-star algorithm
-     * 
+     *
      * @param graph     an adjacency-matrix-representation of the graph where (x,y)
      *                  is the weight of the edge or 0 if there is no edge.
      * @param heuristic an estimation of distance from node x to y that is
@@ -255,9 +255,9 @@ public class ChannelFlow
      * @param start     the node to start from.
      * @param goal      the node we're searching for
      * @return The path from goal to start, both included
-     * 
-     *         Adapted from
-     *         https://github.com/ClaasM/Algorithms/blob/master/src/a_star/java/simple/AStar.java
+     *
+     * Adapted from
+     * https://github.com/ClaasM/Algorithms/blob/master/src/a_star/java/simple/AStar.java
      */
     private static List<Integer> aStar(int[][] graph, double[][] heuristic, int start, int goal)
     {
@@ -292,7 +292,8 @@ public class ChannelFlow
             for (int i = 0; i < priorities.length; i++)
             {
                 // ... by going through all nodes that haven't been visited yet
-                if (priorities[i] < lowestPriority && !visited[i]) {
+                if (priorities[i] < lowestPriority && !visited[i])
+                {
                     lowestPriority = priorities[i];
                     lowestPriorityIndex = i;
                 }

--- a/src/main/java/net/dries007/tfc/util/ChannelFlow.java
+++ b/src/main/java/net/dries007/tfc/util/ChannelFlow.java
@@ -22,11 +22,14 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.phys.AABB;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
@@ -353,5 +356,15 @@ public class ChannelFlow
             }
         }
         return false;
+    }
+
+    public static void damageEntities(LevelAccessor level, BlockPos pos, int n)
+    {
+        if (level.isClientSide()) return;
+        AABB moltenFall = new AABB(
+            pos.getX() + 6.0 / 16, pos.getY() + 4.0 / 16, pos.getZ() + 6.0 / 16,
+            pos.getX() + +10.0 / 16, pos.getY() + (n - 1), pos.getZ() + +10.0 / 16
+        );
+        level.getEntitiesOfClass(LivingEntity.class, moltenFall).forEach(Entity::lavaHurt);
     }
 }

--- a/src/main/java/net/dries007/tfc/util/InteractionManager.java
+++ b/src/main/java/net/dries007/tfc/util/InteractionManager.java
@@ -347,7 +347,7 @@ public final class InteractionManager
         registerBlock(Ingredient.of(TFCTags.Items.USABLE_IN_MOLD_TABLE), (stack, context) -> {
 
             final Player player = context.getPlayer();
-            if (player != null && player.mayBuild() && !player.isShiftKeyDown()) 
+            if (player != null && player.mayBuild())
             {
                 final Level level = context.getLevel();
                 final BlockPos posClicked = context.getClickedPos();


### PR DESCRIPTION
Fixes #3498 by not allowing to reuse a channel for the route of another crucible
Fix stack overflow if the channels block entities point each other as sources, provoking an infinite recursion
Removed theoretic duping of mold table content on block movement (if block entity is not removed first)
Fixes #3472
Fixed mold swaping being unreachable
Added damage to falling molten metal, fixes #3493