### PR TITLE
Discs Recipes

### DIFF
--- a/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/CraftingRecipes.java
@@ -796,6 +796,57 @@ public interface CraftingRecipes extends Recipes
             .input(TFCTags.Items.ROCK_KNAPPING)
             .input(TFCItems.BLANK_DISC)
             .shapeless(Items.MUSIC_DISC_11);
+        recipe()
+            .input(FluidContentIngredient.of(Fluids.LAVA, 1000))
+            .input(TFCItems.BLANK_DISC)
+            .input(TFCItems.ORE_POWDERS.get(Ore.NATIVE_GOLD))
+            .shapeless(Items.MUSIC_DISC_PIGSTEP);
+        recipe()
+            .input(TFCTags.Items.ROCK_KNAPPING)
+            .input(Items.MUSIC_DISC_11)
+            .shapeless(Items.DISC_FRAGMENT_5, 8);
+        replace("music_disc_5")
+            .input('D', TFCItems.BLANK_DISC)
+            .input('F', Items.DISC_FRAGMENT_5)
+            .pattern("FFF", "FDF", "FFF")
+            .shaped(Items.MUSIC_DISC_5);
+        recipe()
+            .input('D', TFCItems.BLANK_DISC)
+            .input('M', TFCItems.ORE_POWDERS.get(Ore.MALACHITE))
+            .pattern("MMM", "MDM", "MMM")
+            .shaped(Items.MUSIC_DISC_CREATOR);
+        recipe()
+            .input('D', TFCItems.BLANK_DISC)
+            .input('N', TFCItems.ORE_POWDERS.get(Ore.NATIVE_COPPER))
+            .pattern("NNN", "NDN", "NNN")
+            .shaped(Items.MUSIC_DISC_CREATOR_MUSIC_BOX);
+        recipe()
+            .input('D', TFCItems.BLANK_DISC)
+            .input('O', TFCItems.ORE_POWDERS.get(Ore.OPAL))
+            .pattern("OOO", "ODO", "OOO")
+            .shaped(Items.MUSIC_DISC_PRECIPICE);
+        recipe()
+            .input('D', TFCItems.BLANK_DISC)
+            .input('S', TFCItems.ORE_POWDERS.get(Ore.SAPPHIRE))
+            .pattern("SSS", "SDS", "SSS")
+            .shaped(Items.MUSIC_DISC_RELIC);
+        // For the future
+        //recipe()
+        //    .input('D', TFCItems.BLANK_DISC)
+        //    .input('L', TFCItems.ORE_POWDERS.get(Ore.LAPIS_LAZULI))
+        //    .pattern("LLL", "LDL", "LLL")
+        //    .shaped(Items.MUSIC_DISC_TEARS);
+        //recipe()
+        //    .input(FluidContentIngredient.of(Fluids.LAVA, 1000))
+        //    .input(TFCItems.BLANK_DISC)
+        //    .input(TFCItems.FOOD.get(Food.CHICKEN))
+        //    .shapeless(Items.MUSIC_DISC_LAVA_CHICKEN);
+        // Longer Future
+        //recipe()
+        //    .input('D', TFCItems.BLANK_DISC)
+        //    .input('G', TFCItems.GLUE)
+        //    .pattern("GGG", "GDG", "GGG")
+        //    .shaped(Items.MUSIC_DISC_BOUNCE);
         replace("fire_charge")
             .input(Items.GUNPOWDER)
             .input(ItemTags.COALS)

--- a/src/generated/resources/data/minecraft/recipe/music_disc_5.json
+++ b/src/generated/resources/data/minecraft/recipe/music_disc_5.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "D": {
+      "item": "tfc:blank_disc"
+    },
+    "F": {
+      "item": "minecraft:disc_fragment_5"
+    }
+  },
+  "pattern": [
+    "FFF",
+    "FDF",
+    "FFF"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:music_disc_5"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/disc_fragment_5.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/disc_fragment_5.json
@@ -1,0 +1,16 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "tag": "tfc:rock_knapping"
+    },
+    {
+      "item": "minecraft:music_disc_11"
+    }
+  ],
+  "result": {
+    "count": 8,
+    "id": "minecraft:disc_fragment_5"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/music_disc_creator.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/music_disc_creator.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "D": {
+      "item": "tfc:blank_disc"
+    },
+    "M": {
+      "item": "tfc:powder/malachite"
+    }
+  },
+  "pattern": [
+    "MMM",
+    "MDM",
+    "MMM"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:music_disc_creator"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/music_disc_creator_music_box.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/music_disc_creator_music_box.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "D": {
+      "item": "tfc:blank_disc"
+    },
+    "N": {
+      "item": "tfc:powder/native_copper"
+    }
+  },
+  "pattern": [
+    "NNN",
+    "NDN",
+    "NNN"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:music_disc_creator_music_box"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/music_disc_pigstep.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/music_disc_pigstep.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    {
+      "type": "tfc:fluid_content",
+      "fluid": {
+        "amount": 1000,
+        "fluid": "minecraft:lava"
+      }
+    },
+    {
+      "item": "tfc:blank_disc"
+    },
+    {
+      "item": "tfc:powder/native_gold"
+    }
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:music_disc_pigstep"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/music_disc_precipice.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/music_disc_precipice.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "D": {
+      "item": "tfc:blank_disc"
+    },
+    "O": {
+      "item": "tfc:powder/opal"
+    }
+  },
+  "pattern": [
+    "OOO",
+    "ODO",
+    "OOO"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:music_disc_precipice"
+  }
+}

--- a/src/generated/resources/data/tfc/recipe/crafting/music_disc_relic.json
+++ b/src/generated/resources/data/tfc/recipe/crafting/music_disc_relic.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "key": {
+    "D": {
+      "item": "tfc:blank_disc"
+    },
+    "S": {
+      "item": "tfc:powder/sapphire"
+    }
+  },
+  "pattern": [
+    "SSS",
+    "SDS",
+    "SSS"
+  ],
+  "result": {
+    "count": 1,
+    "id": "minecraft:music_disc_relic"
+  }
+}


### PR DESCRIPTION
Added recipes for missing discs, fixes #3526

All from crafting with empty discs:

Pigstep: 1000 mb lava (good memories) and 1 native gold powder
5 : break 11 again and craft it back
Creator: 8 malaquite powder
Creator M.B:  8 native copper powder
Precipice : 8 opal powder
Relic: 8 sapphire powder