### PR TITLE
Fix isEyeInWaterLikeFluid (1.20)

### DIFF
--- a/src/main/java/net/dries007/tfc/common/fluids/FluidHelpers.java
+++ b/src/main/java/net/dries007/tfc/common/fluids/FluidHelpers.java
@@ -79,7 +79,7 @@ public final class FluidHelpers
      */
     public static boolean isEyeInWaterLikeFluid(Entity entity)
     {
-        return entity.isEyeInFluidType(TFCFluids.SALT_WATER.type().get()) || entity.isEyeInFluidType(TFCFluids.SALT_WATER.type().get());
+        return entity.isEyeInFluidType(TFCFluids.SALT_WATER.type().get()) || entity.isEyeInFluidType(TFCFluids.SPRING_WATER.type().get());
     }
 
 


### PR DESCRIPTION
SALT_WATER is referenced twice. I assume one is supposed to be SPRING_WATER? This affects things like the underwater ambient sound effects