### PR TITLE
Change nest box setAndUpdateSlots from an assert to a check (1.20)

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/NestBoxBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/NestBoxBlockEntity.java
@@ -125,15 +125,16 @@ public class NestBoxBlockEntity extends TickableInventoryBlockEntity<ItemStackHa
     @Override
     public void setAndUpdateSlots(int slot)
     {
-        assert level != null;
+        if (level != null) 
+        {
+            super.setAndUpdateSlots(slot);
+            markForSync();
 
-        super.setAndUpdateSlots(slot);
-        markForSync();
-
-        // update blockstate for birds to not pathfinds towards full nestboxes
-        BlockPos pos = this.getBlockPos();
-        BlockState newBlockState = level.getBlockState(pos).setValue(NestBoxBlock.FULL, isFull());
-        this.level.setBlockAndUpdate(pos, newBlockState);
+            // update blockstate for birds to not pathfinds towards full nestboxes
+            BlockPos pos = this.getBlockPos();
+            BlockState newBlockState = level.getBlockState(pos).setValue(NestBoxBlock.FULL, isFull());
+            this.level.setBlockAndUpdate(pos, newBlockState);
+        }
     }
 
     @Nullable


### PR DESCRIPTION
This was causing rare crashes when the nest box is used as part of a structure.
See https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4118

The nest box code is different in 1.21 so I don't know if this can be ported, or if it even needs to be.