### PR TITLE
Bowl Placing Parity

### DIFF
--- a/src/main/java/net/dries007/tfc/ForgeEventHandler.java
+++ b/src/main/java/net/dries007/tfc/ForgeEventHandler.java
@@ -634,7 +634,7 @@ public final class ForgeEventHandler
             level.setBlock(pos, Blocks.AIR.defaultBlockState(), 11);
             event.setCanceled(true);
         }
-        else if (block == TFCBlocks.CERAMIC_BOWL.get())
+        else if (block == TFCBlocks.CERAMIC_BOWL.get() || block == TFCBlocks.WOODEN_BOWL.get())
         {
             if (level.getBlockEntity(pos) instanceof BowlBlockEntity bowl)
             {

--- a/src/main/java/net/dries007/tfc/util/InteractionManager.java
+++ b/src/main/java/net/dries007/tfc/util/InteractionManager.java
@@ -113,6 +113,10 @@ public final class InteractionManager
     /**
      * Registers TFC's interactions.
      */
+
+    // Can't register 2 interactions per item, so this one needs to be called by the salad one
+    final static BlockItemPlacement WOODEN_BOWL = new BlockItemPlacement(Items.BOWL, TFCBlocks.WOODEN_BOWL);
+
     public static void registerDefaultInteractions()
     {
         registerBlock(Ingredient.of(TFCTags.Items.THATCH_BED_HIDES), (stack, context) -> {
@@ -307,8 +311,6 @@ public final class InteractionManager
             }
         }
 
-        registerBlock(new BlockItemPlacement(Items.BOWL, TFCBlocks.WOODEN_BOWL));
-
         // Knapping
         final KeyedIngredient knapping = KeyedIngredient.of(
             stack -> KnappingType.get(stack) != null,
@@ -365,13 +367,24 @@ public final class InteractionManager
             // Only open salads when shift key is down
             // Normally when consuming bowl food (like salads), you'll be holding right click down causing the salad gui to immediately open
             // That feels bad to use, so we require shift to open salads - better in the common case
-            if (context.getPlayer() != null && context.getPlayer().isShiftKeyDown())
+            if (context.getPlayer() != null)
             {
-                if (context.getPlayer() instanceof ServerPlayer player)
+                if (context.getPlayer().isShiftKeyDown())
                 {
-                    player.openMenu(TFCContainerProviders.SALAD);
+                    if (context.getPlayer() instanceof ServerPlayer player)
+                    {
+                        player.openMenu(TFCContainerProviders.SALAD);
+                    }
+                    return InteractionResult.sidedSuccess(context.getLevel().isClientSide);
                 }
-                return InteractionResult.sidedSuccess(context.getLevel().isClientSide);
+                else
+                {
+                    ItemStack itemStack = context.getItemInHand();
+                    if (itemStack.is(WOODEN_BOWL.getItem()))
+                    {
+                        return WOODEN_BOWL.onItemUse(itemStack, context);
+                    }
+                }
             }
             return InteractionResult.PASS;
         });


### PR DESCRIPTION
InteractionManager seems not to be prepared to have  a single item with 2 interactions, so wood bowl salad interaction with a block was being shadowed. Not sure if it's the right approach. Bonus wooden bowls with gunpowder didn't blow up