### PR TITLE
Tweak lake type selection

### DIFF
--- a/src/main/java/net/dries007/tfc/world/biome/TFCBiomes.java
+++ b/src/main/java/net/dries007/tfc/world/biome/TFCBiomes.java
@@ -158,7 +158,7 @@ public final class TFCBiomes
     public static final BiomeExtension TOWER_KARST_HIGHLANDS = register("tower_karst_highlands", builder().heightmap(seed -> BiomeNoise.mogotes(seed, 6, 110)).surface(NormalSurfaceBuilder.ROCKY).spawnable().type(RiverBlendType.CAVE).noSandyRiverShores());
 
     // Tower karsts in shallow water
-    public static final BiomeExtension TOWER_KARST_LAKE = register("tower_karst_lake", builder().heightmap(seed -> BiomeNoise.fenglinPlains(seed, -8, 98)).surface(NormalSurfaceBuilder.ROCKY).aquiferHeightOffset(-16).spawnable().type(RiverBlendType.TALL_CANYON).noSandyRiverShores()); // Shallow fresh water, fenglin karsts
+    public static final BiomeExtension TOWER_KARST_LAKE = register("tower_karst_lake", builder().heightmap(seed -> BiomeNoise.fenglinPlains(seed, -8, 98)).surface(NormalSurfaceBuilder.ROCKY).aquiferHeightOffset(-16).spawnable().type(RiverBlendType.TALL_CANYON).type(BiomeBlendType.LAKE).noSandyRiverShores()); // Shallow fresh water, fenglin karsts
     public static final BiomeExtension TOWER_KARST_BAY = register("tower_karst_bay", builder().heightmap(seed -> BiomeNoise.fenglinPlains(seed, -12, 102)).surface(NormalSurfaceBuilder.ROCKY).aquiferHeightOffset(-16).spawnable().salty().type(RiverBlendType.TALL_CANYON).noSandyRiverShores()); // Salt water, fenglin karsts
 
     // Karren Karsts

--- a/src/main/java/net/dries007/tfc/world/layer/TFCLayers.java
+++ b/src/main/java/net/dries007/tfc/world/layer/TFCLayers.java
@@ -354,7 +354,7 @@ public class TFCLayers
             && value != ICE_SHEET_MOUNTAINS_EDGE && value != ICE_SHEET_OCEANIC_MOUNTAINS && value != ICE_SHEET_OCEANIC_MOUNTAINS_EDGE
             && value != ICE_SHEET_SHIELD_VOLCANO && value != ICE_SHEET_SHORE && value != GLACIATED_SHIELD_VOLCANO
             && value != GLACIATED_MOUNTAINS && value != GLACIATED_OCEANIC_MOUNTAINS && value != GLACIALLY_CARVED_MOUNTAINS
-            && value != GLACIALLY_CARVED_OCEANIC_MOUNTAINS && value != SALT_FLATS);
+            && value != GLACIALLY_CARVED_OCEANIC_MOUNTAINS && value != SALT_FLATS && value != MUD_FLATS);
     }
 
     public static int lakeFor(int value)

--- a/src/main/java/net/dries007/tfc/world/layer/TFCLayers.java
+++ b/src/main/java/net/dries007/tfc/world/layer/TFCLayers.java
@@ -354,7 +354,7 @@ public class TFCLayers
             && value != ICE_SHEET_MOUNTAINS_EDGE && value != ICE_SHEET_OCEANIC_MOUNTAINS && value != ICE_SHEET_OCEANIC_MOUNTAINS_EDGE
             && value != ICE_SHEET_SHIELD_VOLCANO && value != ICE_SHEET_SHORE && value != GLACIATED_SHIELD_VOLCANO
             && value != GLACIATED_MOUNTAINS && value != GLACIATED_OCEANIC_MOUNTAINS && value != GLACIALLY_CARVED_MOUNTAINS
-            && value != GLACIALLY_CARVED_OCEANIC_MOUNTAINS);
+            && value != GLACIALLY_CARVED_OCEANIC_MOUNTAINS && value != SALT_FLATS);
     }
 
     public static int lakeFor(int value)
@@ -367,7 +367,7 @@ public class TFCLayers
         {
             return VOLCANIC_MOUNTAIN_LAKE;
         }
-        if (value == OLD_MOUNTAINS)
+        if (value == OLD_MOUNTAINS || value == EXTREME_DOLINE_MOUNTAINS)
         {
             return OLD_MOUNTAIN_LAKE;
         }
@@ -379,7 +379,7 @@ public class TFCLayers
         {
             return VOLCANIC_OCEANIC_MOUNTAIN_LAKE;
         }
-        if (value == PLATEAU)
+        if (value == PLATEAU || value == PLATEAU_WIDE || value == ROCKY_PLATEAU || value == BURREN_PLATEAU || value == SHILIN_PLATEAU || value == DOLINE_PLATEAU || value == CENOTE_PLATEAU || value == EXTREME_DOLINE_PLATEAU)
         {
             return PLATEAU_LAKE;
         }
@@ -390,6 +390,9 @@ public class TFCLayers
         if (value == ICE_SHEET_EDGE)
         {
             return MELTWATER_LAKE;
+        }
+        if (value == TOWER_KARST_CANYONS || value == TOWER_KARST_HIGHLANDS || value == TOWER_KARST_HILLS || value == TOWER_KARST_PLAINS) {
+            return TOWER_KARST_LAKE;
         }
         return LAKE;
     }


### PR DESCRIPTION
Some adjustments to lake type selection, for consistency:

- Use plateau lake for all plateau variants.
- Use tower karst lake for tower karst biomes.
- Avoid lakes in salt flats.
