### PR TITLE
Make prey animals avoid predators

### DIFF
--- a/src/main/java/net/dries007/tfc/common/TFCTags.java
+++ b/src/main/java/net/dries007/tfc/common/TFCTags.java
@@ -672,7 +672,6 @@ public class TFCTags
 
     public static class Entities
     {
-        public static final TagKey<EntityType<?>> HUNTS_LAND_PREY = tag("hunts_land_prey");
         public static final TagKey<EntityType<?>> HUNTED_BY_LAND_PREDATORS = tag("hunted_by_land_predators");
         public static final TagKey<EntityType<?>> OCEAN_PREDATORS = tag("ocean_predators");
         public static final TagKey<EntityType<?>> HUNTED_BY_OCEAN_PREDATORS = tag("hunted_by_ocean_predators");

--- a/src/main/java/net/dries007/tfc/common/entities/ai/prey/AvoidPredatorAndRammersBehavior.java
+++ b/src/main/java/net/dries007/tfc/common/entities/ai/prey/AvoidPredatorAndRammersBehavior.java
@@ -30,7 +30,7 @@ public class AvoidPredatorAndRammersBehavior
                 instance.absent(MemoryModuleType.AVOID_TARGET)
             ).apply(instance, (visible, avoiding) -> {
                 return (level, mob, time) -> instance.get(visible).findClosest(
-                    e -> extraConditions.test(e) && (Helpers.isEntity(e, TFCTags.Entities.HUNTS_LAND_PREY) || Helpers.isEntity(e, TFCTags.Entities.RAMMING_ANIMALS))
+                    e -> extraConditions.test(e) && (Helpers.isEntity(e, TFCTags.Entities.LAND_PREDATORS) || Helpers.isEntity(e, TFCTags.Entities.RAMMING_ANIMALS))
                 ).map(closest -> {
                     avoiding.set(closest);
                     return true;

--- a/src/main/java/net/dries007/tfc/common/entities/ai/prey/AvoidPredatorsBehavior.java
+++ b/src/main/java/net/dries007/tfc/common/entities/ai/prey/AvoidPredatorsBehavior.java
@@ -29,7 +29,7 @@ public class AvoidPredatorsBehavior
                 instance.absent(MemoryModuleType.AVOID_TARGET)
             ).apply(instance, (visible, avoiding) -> {
                 return (level, mob, time) -> instance.get(visible).findClosest(
-                    e -> extraConditions.test(e) && Helpers.isEntity(e, TFCTags.Entities.HUNTS_LAND_PREY)
+                    e -> extraConditions.test(e) && Helpers.isEntity(e, TFCTags.Entities.LAND_PREDATORS)
                 ).map(closest -> {
                     avoiding.set(closest);
                     return true;

--- a/src/main/java/net/dries007/tfc/common/entities/livestock/horse/TFCChestedHorse.java
+++ b/src/main/java/net/dries007/tfc/common/entities/livestock/horse/TFCChestedHorse.java
@@ -124,7 +124,7 @@ public abstract class TFCChestedHorse extends AbstractChestedHorse implements Ho
         super.registerGoals();
         EntityHelpers.removeGoalOfPriority(goalSelector, 3);
         goalSelector.addGoal(3, new TemptGoal(this, 1.25f, Ingredient.of(getFoodTag()), false));
-        goalSelector.addGoal(5, new TFCAvoidEntityGoal<>(this, PathfinderMob.class, 8f, 1.6f, 1.4f, TFCTags.Entities.HUNTS_LAND_PREY));
+        goalSelector.addGoal(5, new TFCAvoidEntityGoal<>(this, PathfinderMob.class, 8f, 1.6f, 1.4f, TFCTags.Entities.LAND_PREDATORS));
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/entities/livestock/horse/TFCHorse.java
+++ b/src/main/java/net/dries007/tfc/common/entities/livestock/horse/TFCHorse.java
@@ -164,7 +164,7 @@ public class TFCHorse extends Horse implements HorseProperties
         super.registerGoals();
         EntityHelpers.removeGoalOfPriority(goalSelector, 3);
         goalSelector.addGoal(3, new TemptGoal(this, 1.25f, Ingredient.of(getFoodTag()), false));
-        goalSelector.addGoal(5, new TFCAvoidEntityGoal<>(this, PathfinderMob.class, 8f, 1.6f, 1.4f, TFCTags.Entities.HUNTS_LAND_PREY));
+        goalSelector.addGoal(5, new TFCAvoidEntityGoal<>(this, PathfinderMob.class, 8f, 1.6f, 1.4f, TFCTags.Entities.LAND_PREDATORS));
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/common/entities/prey/TFCFox.java
+++ b/src/main/java/net/dries007/tfc/common/entities/prey/TFCFox.java
@@ -81,7 +81,7 @@ public class TFCFox extends Fox
         super.registerGoals();
         EntityHelpers.removeGoalOfPriority(goalSelector, 3); // breed goal
         EntityHelpers.removeGoalOfClass(goalSelector, FoxEatBerriesGoal.class);
-        goalSelector.addGoal(4, new TFCAvoidEntityGoal<>(this, PathfinderMob.class, 8f, 1.6f, 1.4f, TFCTags.Entities.HUNTS_LAND_PREY));
+        goalSelector.addGoal(4, new TFCAvoidEntityGoal<>(this, PathfinderMob.class, 8f, 1.6f, 1.4f, TFCTags.Entities.LAND_PREDATORS));
         goalSelector.addGoal(10, new TFCFoxEatBerriesGoal());
     }
 

--- a/src/main/java/net/dries007/tfc/common/entities/prey/TFCPanda.java
+++ b/src/main/java/net/dries007/tfc/common/entities/prey/TFCPanda.java
@@ -77,7 +77,7 @@ public class TFCPanda extends Panda
 
         public PandaAvoidGoal(Panda panda)
         {
-            super(panda, PathfinderMob.class, 8f, 2, 2, TFCTags.Entities.HUNTS_LAND_PREY);
+            super(panda, PathfinderMob.class, 8f, 2, 2, TFCTags.Entities.LAND_PREDATORS);
             this.panda = panda;
         }
 

--- a/src/main/java/net/dries007/tfc/common/entities/prey/TFCRabbit.java
+++ b/src/main/java/net/dries007/tfc/common/entities/prey/TFCRabbit.java
@@ -102,7 +102,7 @@ public class TFCRabbit extends Rabbit implements MammalProperties
         EntityHelpers.removeGoalOfPriority(goalSelector, 4); // avoid goals
         EntityHelpers.removeGoalOfPriority(goalSelector, 5); // vanilla raid garden
         goalSelector.addGoal(3, new TemptGoal(this, 1.25f, Ingredient.of(getFoodTag()), false));
-        goalSelector.addGoal(4, new TFCAvoidEntityGoal<>(this, PathfinderMob.class, 8.0F, 2.2D, 2.2D, TFCTags.Entities.HUNTS_LAND_PREY));
+        goalSelector.addGoal(4, new TFCAvoidEntityGoal<>(this, PathfinderMob.class, 8.0F, 2.2D, 2.2D, TFCTags.Entities.LAND_PREDATORS));
         goalSelector.addGoal(5, new RaidGardenGoal(this));
     }
 

--- a/src/main/java/net/dries007/tfc/util/loot/NotPredatedCondition.java
+++ b/src/main/java/net/dries007/tfc/util/loot/NotPredatedCondition.java
@@ -44,7 +44,7 @@ public enum NotPredatedCondition implements LootItemCondition
             return true;
         }
         final Entity killer = context.getParam(LootContextParams.ATTACKING_ENTITY);
-        return killer instanceof Player || (!Helpers.isEntity(killer, TFCTags.Entities.HUNTS_LAND_PREY) && !Helpers.isEntity(killer, TFCTags.Entities.OCEAN_PREDATORS));
+        return killer instanceof Player || (!Helpers.isEntity(killer, TFCTags.Entities.LAND_PREDATORS) && !Helpers.isEntity(killer, TFCTags.Entities.OCEAN_PREDATORS));
     }
 
     @Contract(pure = true)


### PR DESCRIPTION
The `hunts_land_prey` entity tag is not currently assigned to any entities, meaning that prey animals have no issue walking up to predators until they aggro and get attacked.

Changing these usages of HUNTS_LAND_PREY to LAND_PREDATORS makes prey animals avoid predators.