### PR TITLE
Prevent baby animals from being sheared

### DIFF
--- a/src/main/java/net/dries007/tfc/common/entities/livestock/WoolyAnimal.java
+++ b/src/main/java/net/dries007/tfc/common/entities/livestock/WoolyAnimal.java
@@ -41,6 +41,12 @@ public abstract class WoolyAnimal extends ProducingMammal implements IShearable
     }
 
     @Override
+    public boolean isReadyForAnimalProduct()
+    {
+        return super.isReadyForAnimalProduct() && getAgeType() == Age.ADULT;
+    }
+
+    @Override
     public List<ItemStack> onSheared(@Nullable Player player, ItemStack item, Level level, BlockPos pos)
     {
         setProductsCooldown();
@@ -57,7 +63,7 @@ public abstract class WoolyAnimal extends ProducingMammal implements IShearable
     @Override
     public boolean hasProduct()
     {
-        return getProducedTick() <= 0 || getProductsCooldown() <= 0 && getAgeType() == Age.ADULT;
+        return getProducedTick() <= 0 || getProductsCooldown() <= 0;
     }
 
     public ItemStack getWoolItem()


### PR DESCRIPTION
Baby shearable animals are currently able to be sheared once after they are born, but they will not regrow their wool.

Moving the age check from hasProduct() into isReadyForAnimalProduct() fully prevents them from being sheared while they are babies. This same issue does not occur with Dairy Animals due to the differing order of conditions for hasProduct().

### Alternative Implementations
An alternative means to solve this issue involves changing hasProduct() to:
```java
return getAgeType() == Age.ADULT && (getProducedTick() <= 0 || getProductsCooldown() <= 0)
```
This matches the pattern used in the DairyAnimal class, but in the case of Wooly Animals, it makes them bald until they reach adulthood unless an age check is also added to their models when checking wool visibility.
___
Adding the age check to IsShearable is another possibility, but this makes the tooltip claim babies are ready to be sheared, as it checks isReadyForAnimalProduct(), which, before this change, only checks familiarity and hasProduct.

Adding the age check to isReadyForAnimalProduct itself, as is done here, solves this tooltip problem and prevents shearing of babies.