### PR TITLE
[1.20] change barrel recipe assert into check to avoid structure worldgen crash

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/BarrelBlockEntity.java
@@ -481,18 +481,19 @@ public class BarrelBlockEntity extends TickableInventoryBlockEntity<BarrelBlockE
 
     protected void updateRecipe()
     {
-        assert level != null;
-
-        final SealedBarrelRecipe oldRecipe = recipe;
-        if (inventory.excess.isEmpty())
+        if (level != null)
         {
-            // Will only work on a recipe as long as the 'excess' is empty
-            recipe = level.getRecipeManager().getRecipeFor(TFCRecipeTypes.BARREL_SEALED.get(), inventory, level).orElse(null);
-            if (recipe != null && oldRecipe != recipe && (oldRecipe == null || !oldRecipe.getId().equals(recipe.getId())))
+            final SealedBarrelRecipe oldRecipe = recipe;
+            if (inventory.excess.isEmpty())
             {
-                // The recipe has changed to a new one, so update the recipe ticks
-                recipeTick = Calendars.get(level).getTicks();
-                markForSync();
+                // Will only work on a recipe as long as the 'excess' is empty
+                recipe = level.getRecipeManager().getRecipeFor(TFCRecipeTypes.BARREL_SEALED.get(), inventory, level).orElse(null);
+                if (recipe != null && oldRecipe != recipe && (oldRecipe == null || !oldRecipe.getId().equals(recipe.getId())))
+                {
+                    // The recipe has changed to a new one, so update the recipe ticks
+                    recipeTick = Calendars.get(level).getTicks();
+                    markForSync();
+                }
             }
         }
     }


### PR DESCRIPTION
Similar to #3625, changes a `assert level != null;` into an `if` check, because this method can get called if you have a sealed barrel containing a fluid as part of a structure that generates during worldgen.

See:
https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4548
https://github.com/TerraFirmaGreg-Team/Modpack-Modern/issues/4541