### PR TITLE
Fix occasional crash from item drops during async worldgen

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/GroundcoverBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/GroundcoverBlock.java
@@ -98,7 +98,8 @@ public class GroundcoverBlock extends ExtendedBlock implements IFluidLoggable
     {
         if (fluidStateIn.getType() instanceof FlowingFluid && !getFluidProperty().canContain(fluidStateIn.getType()))
         {
-            level.destroyBlock(pos, false);
+            final boolean dropsOnMainThread = level instanceof ServerLevel serverLevel && serverLevel.getServer().isSameThread();
+            level.destroyBlock(pos, dropsOnMainThread);
             level.setBlock(pos, fluidStateIn.createLegacyBlock(), 2);
             return true;
         }

--- a/src/main/java/net/dries007/tfc/common/blocks/GroundcoverBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/GroundcoverBlock.java
@@ -98,7 +98,7 @@ public class GroundcoverBlock extends ExtendedBlock implements IFluidLoggable
     {
         if (fluidStateIn.getType() instanceof FlowingFluid && !getFluidProperty().canContain(fluidStateIn.getType()))
         {
-            level.destroyBlock(pos, true);
+            level.destroyBlock(pos, false);
             level.setBlock(pos, fluidStateIn.createLegacyBlock(), 2);
             return true;
         }


### PR DESCRIPTION
This fixes an intermittent crash (java.lang.Exception: null at ServerLevel.handler$cfd000$OnaddEntity) caused by GroundcoverBlock.onBlockAdded calling level.destroyBlock(pos, true).

When destroyBlock(..., true) drops resources, it tries to spawn an item entity. During structure generation, worldgen runs on async threads (WorldGenRegion), where addFreshEntity/ServerLevel.m_7967_ is not permitted, so the attempt throws and crashes the server.

The crash is rare because it only triggers when structure generation coincides with a flowing fluid being placed against a groundcover block, which would otherwise be destroyed (with drops). Changing the call to destroyBlock(pos, false) suppresses the drop, avoiding the invalid entity add entirely while preserving the intended block replacement behavior.

Root cause of the stack trace:

GroundcoverBlock.m_7361_ (onBlockAdded) → destroyBlock(pos, true) → dropResources → addFreshEntity → ServerLevel.addEntity → throws on async worldgen.

Crash Log:
`
java.lang.Exception: null at net.minecraft.server.level.ServerLevel.handler$cfd000$OnaddEntity(ServerLevel.java:1657) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.server.level.ServerLevel.m_8872_(ServerLevel.java) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.server.level.ServerLevel.m_7967_(ServerLevel.java:815) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.world.level.block.Block.m_152440_(Block.java:325) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.world.level.block.Block.m_49840_(Block.java:299) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.world.level.block.Block.m_49941_(Block.java:287) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at it.unimi.dsi.fastutil.objects.ObjectArrayList.forEach(ObjectArrayList.java:748) ~[fastutil-8.5.9.jar%2390!/:?] at net.minecraft.world.level.block.Block.dropResources(Block.java:286) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.world.level.block.Block.m_49881_(Block.java:282) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.server.level.WorldGenRegion.m_7740_(WorldGenRegion.java:195) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.world.level.LevelWriter.m_46953_(LevelWriter.java:27) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.minecraft.world.level.LevelWriter.m_46961_(LevelWriter.java:22) ~[server-1.20.1-20230612.114412-srg.jar%23711!/:?] at net.dries007.tfc.common.blocks.GroundcoverBlock.m_7361_(GroundcoverBlock.java:101) ~[TerraFirmaCraft-Forge-1.20.1-3.2.23.jar%23639!/:3.2.23]
`