### PR TITLE
Addresses #3589

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/plant/TopPlantBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/plant/TopPlantBlock.java
@@ -66,6 +66,10 @@ public class TopPlantBlock extends GrowingPlantHeadBlock implements IForgeBlockE
     @Nullable
     public BlockState getStateForPlacement(BlockPlaceContext context)
     {
+        if (!context.canPlace())
+        {
+            return null;
+        }
         BlockState state = super.getStateForPlacement(context);
         return state == null ? null : state.setValue(AGE, Mth.nextInt(context.getLevel().getRandom(), 10, 18));
     }


### PR DESCRIPTION
Bailout from `getStateForPlacement` when context's canPlace is false.
Some mods like MoreRED call `getPlacementState` method without checking that block can be placed.
This situation can lead to a crash when a call to the `super.getStateForPlacement` method returns block/object without AGE filed.

This is more of the bandaid solution, but should work for now.
I've tested it in the creative world.