### PR TITLE
Make wild crop maturity months configurable

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blocks/crop/WildCropBlock.java
+++ b/src/main/java/net/dries007/tfc/common/blocks/crop/WildCropBlock.java
@@ -26,6 +26,7 @@ import net.dries007.tfc.common.blocks.ExtendedProperties;
 import net.dries007.tfc.common.blocks.ISpecialPile;
 import net.dries007.tfc.common.blocks.TFCBlockStateProperties;
 import net.dries007.tfc.common.blocks.plant.TFCBushBlock;
+import net.dries007.tfc.config.TFCConfig;
 import net.dries007.tfc.util.Helpers;
 import net.dries007.tfc.util.calendar.Calendars;
 import net.dries007.tfc.util.calendar.Month;
@@ -34,8 +35,15 @@ public class WildCropBlock extends TFCBushBlock implements ISpecialPile
 {
     public static boolean isMature(LevelAccessor level)
     {
-        final int month = Calendars.get(level).getCalendarMonthOfYear().ordinal();
-        return month >= Month.JUNE.ordinal() && month <= Month.OCTOBER.ordinal();
+        final Month month = Calendars.get(level).getCalendarMonthOfYear();
+        final Month startMonth = TFCConfig.SERVER.wildCropMaturityStartMonth.get();
+        final Month endMonth = TFCConfig.SERVER.wildCropMaturityEndMonth.get();
+
+        if (startMonth.ordinal() <= endMonth.ordinal())
+        {
+            return month.ordinal() >= startMonth.ordinal() && month.ordinal() <= endMonth.ordinal();
+        }
+        return month.ordinal() >= startMonth.ordinal() || month.ordinal() <= endMonth.ordinal();
     }
 
     public static final BooleanProperty MATURE = TFCBlockStateProperties.MATURE;

--- a/src/main/java/net/dries007/tfc/config/ServerConfig.java
+++ b/src/main/java/net/dries007/tfc/config/ServerConfig.java
@@ -16,6 +16,7 @@ import net.dries007.tfc.config.animals.MammalConfig;
 import net.dries007.tfc.config.animals.OviparousAnimalConfig;
 import net.dries007.tfc.config.animals.ProducingMammalConfig;
 import net.dries007.tfc.util.Alloy;
+import net.dries007.tfc.util.calendar.Month;
 
 /**
  * Server Config
@@ -154,6 +155,8 @@ public class ServerConfig
     // Blocks - Crops
     public final ForgeConfigSpec.DoubleValue cropGrowthModifier;
     public final ForgeConfigSpec.DoubleValue cropExpiryModifier;
+    public final ForgeConfigSpec.EnumValue<Month> wildCropMaturityStartMonth;
+    public final ForgeConfigSpec.EnumValue<Month> wildCropMaturityEndMonth;
     // Blocks - Dispenser
     public final ForgeConfigSpec.BooleanValue dispenserEnableLighting;
     // Blocks - Powder Bowl
@@ -502,6 +505,13 @@ public class ServerConfig
 
         cropGrowthModifier = builder.comment("Modifier applied to the growth time of every crop. The modifier multiplies the ticks it takes to grow, so larger values cause longer growth times. For example, a value of 2 doubles the growth time.").define("cropGrowthModifier", 1, 0.001, 1000);
         cropExpiryModifier = builder.comment("Modifier applied to the expiry time of every crop. The modifier multiplies the ticks it takes to grow, so larger values cause longer expiry times. For example, a value of 2 doubles the expiry time.").define("cropExpiryModifier", 1, 0.001, 1000);
+        wildCropMaturityStartMonth = builder.comment(
+            "The first month in which wild crops are mature, inclusive.",
+            "If this month is later than the end month, the maturity period wraps across the end of the year."
+        ).define("wildCropMaturityStartMonth", Month.JUNE);
+        wildCropMaturityEndMonth = builder.comment(
+            "The last month in which wild crops are mature, inclusive."
+        ).define("wildCropMaturityEndMonth", Month.OCTOBER);
 
         builder.swap("dispenser");
 


### PR DESCRIPTION
## What changed

- Adds `wildCropMaturityStartMonth` and `wildCropMaturityEndMonth` to the synced per-world server config.
- Uses those values when determining whether wild crops are mature.
- Keeps `JUNE` through `OCTOBER` as the defaults, preserving existing behavior.
- Supports maturity periods that wrap across the end of the year, such as October through March.

## Why

Wild crop maturity is currently fixed to June–October in `WildCropBlock`. Exposing the boundaries lets modpack authors and server operators tune seasonal food availability without patching TFC.

## Impact

Existing worlds and packs retain the current June–October behavior unless they opt into different values. The settings are stored in the per-world server config and synchronized to clients through the existing config system.

## Validation

- `./gradlew build` — passed
- `./gradlew updateLicenses` — passed
- `git diff --check` — passed
