### PR TITLE
Give datagen welding recipes a minimum tier

### DIFF
--- a/src/data/java/net/dries007/tfc/data/recipes/WeldingRecipes.java
+++ b/src/data/java/net/dries007/tfc/data/recipes/WeldingRecipes.java
@@ -50,7 +50,7 @@ public interface WeldingRecipes extends Recipes
         add(new WeldingRecipe(
             ingredientOf(ingot1, ItemType.INGOT),
             ingredientOf(ingot2, ItemType.INGOT),
-            ingotOut.tier() - 1,
+            Math.max(0, ingotOut.tier() - 1),
             ItemStackProvider.of(TFCItems.METAL_ITEMS.get(ingotOut).get(ItemType.INGOT)),
             IGNORE
         ));
@@ -61,7 +61,7 @@ public interface WeldingRecipes extends Recipes
         add(new WeldingRecipe(
             ingredientOf(metal, input1),
             ingredientOf(metal, input2),
-            metal.tier() - 1,
+            Math.max(0, metal.tier() - 1),
             ItemStackProvider.of(TFCItems.METAL_ITEMS.get(metal).get(output)),
             behavior
         ));

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/bismuth.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/bismuth.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/bismuth"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/brass.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/brass.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/brass"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/cast_iron.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/cast_iron.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/cast_iron"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/gold.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/gold.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/gold"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/nickel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/nickel.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/nickel"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/rose_gold.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/rose_gold.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/rose_gold"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/silver.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/silver.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/silver"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/sterling_silver.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/sterling_silver.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/sterling_silver"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/tin.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/tin.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/tin"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/zinc.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_ingot/zinc.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/zinc"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/bismuth.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/bismuth.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/bismuth"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/brass.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/brass.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/brass"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/cast_iron.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/cast_iron.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/cast_iron"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/gold.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/gold.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/gold"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/nickel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/nickel.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/nickel"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/rose_gold.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/rose_gold.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/rose_gold"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/silver.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/silver.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/silver"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/sterling_silver.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/sterling_silver.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/sterling_silver"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/tin.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/tin.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/tin"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/zinc.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/double_sheet/zinc.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:sheets/zinc"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/ingot/high_carbon_black_steel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/ingot/high_carbon_black_steel.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/pig_iron"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/ingot/high_carbon_blue_steel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/ingot/high_carbon_blue_steel.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/black_steel"
-  },
-  "tier": -1
+  }
 }

--- a/src/generated/resources/data/tfc/recipe/welding/metal/ingot/high_carbon_red_steel.json
+++ b/src/generated/resources/data/tfc/recipe/welding/metal/ingot/high_carbon_red_steel.json
@@ -9,6 +9,5 @@
   },
   "second_input": {
     "tag": "c:ingots/black_steel"
-  },
-  "tier": -1
+  }
 }

--- a/src/main/java/net/dries007/tfc/compat/emi/recipe/EmiAnvilRecipe.java
+++ b/src/main/java/net/dries007/tfc/compat/emi/recipe/EmiAnvilRecipe.java
@@ -39,7 +39,12 @@ public class EmiAnvilRecipe extends AutoLayoutRecipe<AnvilRecipe>
     @Override
     protected SlotWidget generateOutputSlot(EmiStack stack, int x, int y, int index)
     {
-        return super.generateOutputSlot(stack, x, y, index).appendTooltip(Component.translatable("tfc.tooltip.anvil_tier_required", Tooltips.tier(tier)));
+        if (tier <= 0)
+        {
+            return super.generateOutputSlot(stack, x, y, index);
+        }
+        else return super.generateOutputSlot(stack, x, y, index)
+            .appendTooltip(Component.translatable("tfc.tooltip.anvil_tier_required", Tooltips.tier(tier)));
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/compat/emi/recipe/EmiWeldingRecipe.java
+++ b/src/main/java/net/dries007/tfc/compat/emi/recipe/EmiWeldingRecipe.java
@@ -42,7 +42,11 @@ public class EmiWeldingRecipe extends AutoLayoutRecipe<WeldingRecipe>
     @Override
     protected SlotWidget generateOutputSlot(EmiStack stack, int x, int y, int index)
     {
-        return super.generateOutputSlot(stack, x, y, index)
+        if (tier <= 0)
+        {
+            return super.generateOutputSlot(stack, x, y, index);
+        }
+        else return super.generateOutputSlot(stack, x, y, index)
             .appendTooltip(Component.translatable("tfc.tooltip.anvil_tier_required", Tooltips.tier(tier)));
     }
 

--- a/src/main/java/net/dries007/tfc/compat/jei/category/AnvilRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/AnvilRecipeCategory.java
@@ -40,7 +40,12 @@ public class AnvilRecipeCategory extends BaseRecipeCategory<AnvilRecipe>
         inputSlot.setBackground(slot, -1, -1);
         outputSlot.addItemStack(recipe.getResultItem(registryAccess()));
         outputSlot.setBackground(slot, -1, -1);
-        outputSlot.addRichTooltipCallback((view, tooltip) -> tooltip.add(Component.translatable("tfc.tooltip.anvil_tier_required", Tooltips.tier(recipe.getMinTier()))));
+        outputSlot.addRichTooltipCallback((view, tooltip) -> {
+            if (recipe.getMinTier() > 0)
+            {
+                tooltip.add(Component.translatable("tfc.tooltip.anvil_tier_required", Tooltips.tier(recipe.getMinTier())));
+            }
+        });
     }
 
     @Override

--- a/src/main/java/net/dries007/tfc/compat/jei/category/WeldingRecipeCategory.java
+++ b/src/main/java/net/dries007/tfc/compat/jei/category/WeldingRecipeCategory.java
@@ -12,7 +12,9 @@ import mezz.jei.api.helpers.IGuiHelper;
 import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
+import net.dries007.tfc.util.tooltip.Tooltips;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeHolder;
@@ -46,7 +48,13 @@ public class WeldingRecipeCategory extends BaseRecipeCategory<WeldingRecipe>
 
         builder.addSlot(RecipeIngredientRole.OUTPUT, 96, 5)
             .addItemStack(recipe.getResultItem(registryAccess()))
-            .setBackground(slot, -1, -1);
+            .setBackground(slot, -1, -1)
+            .addRichTooltipCallback((view, tooltip) -> {
+                if (recipe.getTier() > 0)
+                {
+                    tooltip.add(Component.translatable("tfc.tooltip.anvil_tier_required", Tooltips.tier(recipe.getTier())));
+                }
+            });
     }
 
     @Override


### PR DESCRIPTION
Applies Math.max() to the tier of datagen'd welding recipes to prevent recipes with a tier of -1, which caused a broken tooltip:

BEFORE
<img width="1280" height="720" alt="2026-08-25_12 46 52" src="https://github.com/user-attachments/assets/0fa8cb5f-6dec-4d90-9c47-faaf2b67d2cc" />

AFTER
<img width="1280" height="720" alt="2026-08-25_12 49 29" src="https://github.com/user-attachments/assets/a01c1824-b594-4ea5-a944-41b43a60abb5" />
