### PR TITLE
fix: prevent rotten eggs from starting incubation

### DIFF
--- a/src/main/java/net/dries007/tfc/common/blockentities/NestBoxBlockEntity.java
+++ b/src/main/java/net/dries007/tfc/common/blockentities/NestBoxBlockEntity.java
@@ -8,6 +8,8 @@ package net.dries007.tfc.common.blockentities;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Inventory;
@@ -22,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import net.dries007.tfc.common.capabilities.PartialItemHandler;
 import net.dries007.tfc.common.component.EggComponent;
 import net.dries007.tfc.common.component.TFCComponents;
+import net.dries007.tfc.common.component.food.FoodCapability;
 import net.dries007.tfc.common.container.NestBoxContainer;
 import net.dries007.tfc.common.entities.livestock.OviparousAnimal;
 import net.dries007.tfc.common.entities.misc.Seat;
@@ -31,6 +34,9 @@ import net.dries007.tfc.util.Helpers;
 public class NestBoxBlockEntity extends TickableInventoryBlockEntity<ItemStackHandler>
 {
     public static final int SLOTS = 4;
+    private static final String INCUBATING_EGGS = "incubatingEggs";
+
+    private int incubatingEggs;
 
     public static void serverTick(Level level, BlockPos pos, BlockState state, NestBoxBlockEntity nest)
     {
@@ -76,7 +82,7 @@ public class NestBoxBlockEntity extends TickableInventoryBlockEntity<ItemStackHa
             {
                 final ItemStack stack = nest.inventory.getStackInSlot(slot);
                 final @Nullable EggComponent egg = stack.get(TFCComponents.EGG);
-                if (egg != null && egg.canHatch())
+                if (nest.isIncubating(slot) && egg != null && egg.canHatch())
                 {
                     egg.hatch(level).ifPresent(entity -> {
                         entity.moveTo(pos, 0f, 0f);
@@ -113,8 +119,54 @@ public class NestBoxBlockEntity extends TickableInventoryBlockEntity<ItemStackHa
     @Override
     public void setAndUpdateSlots(int slot)
     {
+        final ItemStack stack = inventory.getStackInSlot(slot);
+        final @Nullable EggComponent egg = stack.get(TFCComponents.EGG);
+        setIncubating(slot, egg != null && egg.fertilized() && !FoodCapability.isRotten(stack));
         super.setAndUpdateSlots(slot);
         markForSync();
+    }
+
+    @Override
+    public void loadAdditional(CompoundTag nbt, HolderLookup.Provider provider)
+    {
+        super.loadAdditional(nbt, provider);
+        if (nbt.contains(INCUBATING_EGGS, CompoundTag.TAG_ANY_NUMERIC))
+        {
+            incubatingEggs = nbt.getInt(INCUBATING_EGGS);
+        }
+        else
+        {
+            incubatingEggs = 0;
+            for (int slot = 0; slot < inventory.getSlots(); slot++)
+            {
+                final @Nullable EggComponent egg = inventory.getStackInSlot(slot).get(TFCComponents.EGG);
+                setIncubating(slot, egg != null && egg.fertilized());
+            }
+        }
+    }
+
+    @Override
+    public void saveAdditional(CompoundTag nbt, HolderLookup.Provider provider)
+    {
+        super.saveAdditional(nbt, provider);
+        nbt.putInt(INCUBATING_EGGS, incubatingEggs);
+    }
+
+    private boolean isIncubating(int slot)
+    {
+        return (incubatingEggs & 1 << slot) != 0;
+    }
+
+    private void setIncubating(int slot, boolean incubating)
+    {
+        if (incubating)
+        {
+            incubatingEggs |= 1 << slot;
+        }
+        else
+        {
+            incubatingEggs &= ~(1 << slot);
+        }
     }
 
     @Nullable

--- a/src/test/java/net/dries007/tfc/test/blockentity/NestBoxBlockEntityTest.java
+++ b/src/test/java/net/dries007/tfc/test/blockentity/NestBoxBlockEntityTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the EUPL, Version 1.2.
+ * You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
+
+package net.dries007.tfc.test.blockentity;
+
+import java.util.Optional;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.junit.jupiter.api.Test;
+
+import net.dries007.tfc.common.blockentities.NestBoxBlockEntity;
+import net.dries007.tfc.common.blocks.TFCBlocks;
+import net.dries007.tfc.common.component.EggComponent;
+import net.dries007.tfc.common.component.TFCComponents;
+import net.dries007.tfc.common.component.food.FoodCapability;
+import net.dries007.tfc.test.TestSetup;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NestBoxBlockEntityTest implements TestSetup
+{
+    private static final String INCUBATING_EGGS = "incubatingEggs";
+    private static final HolderLookup.Provider REGISTRIES = RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY);
+
+    @Test
+    public void testFreshEggRemainsEligibleAfterReloadAndRotting()
+    {
+        final NestBoxBlockEntity nest = createNest();
+        nest.getInventory().setStackInSlot(0, egg(true));
+
+        final CompoundTag saved = nest.saveCustomOnly(REGISTRIES);
+        assertTrue(isEligible(saved, 0));
+
+        final NestBoxBlockEntity loaded = createNest();
+        loaded.loadWithComponents(saved, REGISTRIES);
+        FoodCapability.setRotten(loaded.getInventory().getStackInSlot(0));
+
+        assertTrue(FoodCapability.isRotten(loaded.getInventory().getStackInSlot(0)));
+        assertTrue(loaded.getInventory().getStackInSlot(0).getOrDefault(TFCComponents.EGG, EggComponent.DEFAULT).canHatch());
+        assertTrue(isEligible(loaded.saveCustomOnly(REGISTRIES), 0));
+    }
+
+    @Test
+    public void testRottenEggIsIneligibleOnInsertion()
+    {
+        final NestBoxBlockEntity nest = createNest();
+        final ItemStack egg = egg(true);
+        FoodCapability.setRotten(egg);
+
+        assertTrue(FoodCapability.isRotten(egg));
+        nest.getInventory().setStackInSlot(0, egg);
+
+        assertTrue(egg.getOrDefault(TFCComponents.EGG, EggComponent.DEFAULT).canHatch());
+        assertFalse(isEligible(nest.saveCustomOnly(REGISTRIES), 0));
+        assertFalse(nest.getInventory().getStackInSlot(0).isEmpty());
+    }
+
+    @Test
+    public void testRemovalClearsEligibilityBeforeRottenEggIsReinserted()
+    {
+        final NestBoxBlockEntity nest = createNest();
+        nest.getInventory().setStackInSlot(0, egg(true));
+        final ItemStack removed = nest.getInventory().extractItem(0, 1, false);
+
+        assertFalse(isEligible(nest.saveCustomOnly(REGISTRIES), 0));
+
+        FoodCapability.setRotten(removed);
+        nest.getInventory().setStackInSlot(0, removed);
+
+        assertFalse(isEligible(nest.saveCustomOnly(REGISTRIES), 0));
+    }
+
+    @Test
+    public void testReplacementRecomputesEligibility()
+    {
+        final NestBoxBlockEntity nest = createNest();
+        nest.getInventory().setStackInSlot(0, egg(true));
+        nest.getInventory().setStackInSlot(0, egg(false));
+
+        assertFalse(isEligible(nest.saveCustomOnly(REGISTRIES), 0));
+    }
+
+    @Test
+    public void testLegacyEggIsMigratedButLaterChangesUseFreshnessGate()
+    {
+        final NestBoxBlockEntity original = createNest();
+        original.getInventory().setStackInSlot(0, egg(true));
+        final CompoundTag legacy = original.saveCustomOnly(REGISTRIES);
+        legacy.remove(INCUBATING_EGGS);
+
+        final NestBoxBlockEntity loaded = createNest();
+        loaded.loadWithComponents(legacy, REGISTRIES);
+        assertTrue(isEligible(loaded.saveCustomOnly(REGISTRIES), 0));
+
+        final ItemStack rotten = egg(true);
+        FoodCapability.setRotten(rotten);
+        loaded.getInventory().setStackInSlot(0, rotten);
+
+        assertFalse(isEligible(loaded.saveCustomOnly(REGISTRIES), 0));
+    }
+
+    private static NestBoxBlockEntity createNest()
+    {
+        return new NestBoxBlockEntity(BlockPos.ZERO, TFCBlocks.NEST_BOX.get().defaultBlockState());
+    }
+
+    private static ItemStack egg(boolean fertilized)
+    {
+        final ItemStack stack = new ItemStack(Items.EGG);
+        final CompoundTag entity = new CompoundTag();
+        entity.putString("id", "minecraft:chicken");
+        stack.set(TFCComponents.EGG, new EggComponent(fertilized, 0, Optional.of(entity)));
+        return stack;
+    }
+
+    private static boolean isEligible(CompoundTag tag, int slot)
+    {
+        return (tag.getInt(INCUBATING_EGGS) & 1 << slot) != 0;
+    }
+}


### PR DESCRIPTION
Add per-slot incubation eligibility state to `NestBoxBlockEntity`, setting a slot eligible when a fertilized, non-rotten egg first enters it and clearing or recomputing that state whenever the slot is removed or replaced. A fertilized egg can age in an ordinary chest until its food component is rotten, then be moved into a nest box and still hatch because `NestBoxBlockEntity.serverTick` checks only `EggComponent.canHatch()`.

Insert a fresh fertilized egg into an empty nest slot, serialize and reload the nest, advance beyond its hatch and rotten dates, and verify the slot remains eligible for the existing catch-up hatch path; Mark a fertilized egg rotten before inserting it and verify the slot is ineligible and the hatch path does not consume the egg or spawn its saved entity after the hatch day.

Fixes #3699
